### PR TITLE
.github: Add secret env to coverity workflow

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,9 +1,6 @@
 name: Coverity
 
 on:
-  pull_request:
-    branches:
-      - "*"
   push:
     branches:
       - main


### PR DESCRIPTION
This will map the correct secrets to the workflow. I defined them as repo secrets first instead of env ones, and PRs from forks don't have access to repo secrets.