### PR TITLE
templates: Single podAntiAffinity rule based on hostname

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -43,13 +43,7 @@ objects:
                 labelSelector:
                   matchLabels:
                     name: image-builder
-                topologyKey: node
-            - weight: 50
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    name: image-builder
-                topologyKey: zone
+                topologyKey: kubernetes.io/hostname
         containers:
         - image: "${IMAGE_NAME}:${IMAGE_TAG}"
           name: image-builder


### PR DESCRIPTION
Linter output:
Specify anti-affinity in your pod specification to ensure that the
orchestrator attempts to schedule replicas on different nodes. Using
podAntiAffinity, specify a labelSelector that matches pods for the
deployment, and set the topologyKey to kubernetes.io/hostname.