### PR TITLE
templates: Include image name in FloorPlan

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -143,7 +143,7 @@ objects:
     - prefix: ${FLOORIST_QUERY_PREFIX}/builds
       query: >-
         select
-          job_id,created_at,org_id,account_number,email,request->>'distribution' as distribution,
+          job_id,created_at,org_id,account_number,email,image_name,request->>'distribution' as distribution,
           req->>'architecture' as architecture,req->>'image_type' as image_type,req->'upload_request'->>'type' as upload_request_type,req->'ostree'->>'url' as ostree_url,
           request->'customizations'->'packages' as packages,
           request->'customizations'->'filesystem' as filesystem,


### PR DESCRIPTION
Hello,
I am working on statistics of image builder vs launch.
if I understand from your database files correctly, this should match our [image_id](https://github.com/RHEnVision/provisioning-backend/blob/259c6f32122d1623d1e1591d1429fa5fb421c479/deploy/clowdapp.yaml#L461) column. :)
I hope this is what we are going for. :)