### PR TITLE
internal/v1: add BlueprintV1 nested body

### DIFF
--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -53,10 +53,9 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 		ShareWithAccounts: common.ToPtr([]string{"test-account"}),
 	})
 	require.NoError(t, err)
-	blueprintBody := BlueprintV1{
-		Version:     1,
-		Name:        "blueprint",
-		Description: "desc",
+	name := "blueprint"
+	description := "desc"
+	blueprint := BlueprintBody{
 		Customizations: Customizations{
 			Packages: common.ToPtr([]string{"nginx"}),
 		},
@@ -82,9 +81,9 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 	}
 
 	var message []byte
-	message, err = json.Marshal(blueprintBody)
+	message, err = json.Marshal(blueprint)
 	require.NoError(t, err)
-	err = dbase.InsertBlueprint(id, versionId, "000000", "000000", "blueprint", "desc", message)
+	err = dbase.InsertBlueprint(id, versionId, "000000", "000000", name, description, message)
 	require.NoError(t, err)
 
 	respStatusCode, body := tutils.PostResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprint/%s/compose", id.String()), map[string]string{})


### PR DESCRIPTION
This PR adds a wrapper around the body parameters. In this way, we would not have to marshal/unmarshal the name, version and description parameters from/to json.
I came to the conclusion, that the nested struct should be anonymous, it felt cumbersome to have something like BlueprintBodyV1, BlueprintBodyV2 etc. This feels like the best solution.