### PR TITLE
v1/api: Add export endpoint for blueprints (HMS-4451)

### DIFF
--- a/cmd/image-builder-db-test/main_test.go
+++ b/cmd/image-builder-db-test/main_test.go
@@ -110,7 +110,7 @@ func testInsertCompose(t *testing.T) {
 
 	migrateTern(t)
 
-	err = d.InsertBlueprint(ctx, blueprintId, versionId, ORGID1, ANR1, "blueprint", "blueprint desc", []byte("{}"))
+	err = d.InsertBlueprint(ctx, blueprintId, versionId, ORGID1, ANR1, "blueprint", "blueprint desc", []byte("{}"), []byte("{}"))
 	require.NoError(t, err)
 
 	// test
@@ -392,7 +392,7 @@ func testBlueprints(t *testing.T) {
 
 	id := uuid.New()
 	versionId := uuid.New()
-	err = d.InsertBlueprint(ctx, id, versionId, ORGID1, ANR1, name1, description1, bodyJson1)
+	err = d.InsertBlueprint(ctx, id, versionId, ORGID1, ANR1, name1, description1, bodyJson1, []byte("{}"))
 	require.NoError(t, err)
 
 	entry, err := d.GetBlueprint(ctx, id, ORGID1)
@@ -460,11 +460,11 @@ func testBlueprints(t *testing.T) {
 	newestBlueprintName := "new name"
 
 	// Fail to insert blueprint with the same name
-	err = d.InsertBlueprint(ctx, newestBlueprintId, newestBlueprintVersionId, ORGID1, ANR1, newestBlueprintName, "desc", bodyJson1)
+	err = d.InsertBlueprint(ctx, newestBlueprintId, newestBlueprintVersionId, ORGID1, ANR1, newestBlueprintName, "desc", bodyJson1, []byte("{}"))
 	require.Error(t, err)
 
 	newestBlueprintName = "New name 2"
-	err = d.InsertBlueprint(ctx, newestBlueprintId, newestBlueprintVersionId, ORGID1, ANR1, newestBlueprintName, "desc", bodyJson1)
+	err = d.InsertBlueprint(ctx, newestBlueprintId, newestBlueprintVersionId, ORGID1, ANR1, newestBlueprintName, "desc", bodyJson1, []byte("{}"))
 	require.NoError(t, err)
 	entries, bpCount, err := d.GetBlueprints(ctx, ORGID1, 100, 0)
 	require.NoError(t, err)
@@ -472,7 +472,7 @@ func testBlueprints(t *testing.T) {
 	require.Equal(t, entries[0].Name, newestBlueprintName)
 	require.Equal(t, entries[1].Version, 2)
 
-	err = d.InsertBlueprint(ctx, uuid.New(), uuid.New(), ORGID1, ANR1, "unique name", "unique desc", bodyJson1)
+	err = d.InsertBlueprint(ctx, uuid.New(), uuid.New(), ORGID1, ANR1, "unique name", "unique desc", bodyJson1, []byte("{}"))
 	entries, count, err := d.FindBlueprints(ctx, ORGID1, "", 100, 0)
 	require.NoError(t, err)
 	require.Equal(t, 3, count)
@@ -514,7 +514,7 @@ func testGetBlueprintComposes(t *testing.T) {
 
 	id := uuid.New()
 	versionId := uuid.New()
-	err = d.InsertBlueprint(ctx, id, versionId, ORGID1, ANR1, "name", "desc", []byte("{}"))
+	err = d.InsertBlueprint(ctx, id, versionId, ORGID1, ANR1, "name", "desc", []byte("{}"), []byte("{}"))
 	require.NoError(t, err)
 
 	// get latest version

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -49,6 +49,7 @@ type BlueprintEntry struct {
 	Body        json.RawMessage
 	Name        string
 	Description string
+	Metadata    json.RawMessage
 }
 
 type BlueprintWithNoBody struct {
@@ -74,7 +75,7 @@ type DB interface {
 	GetClonesForCompose(ctx context.Context, composeId uuid.UUID, orgId string, limit, offset int) ([]CloneEntry, int, error)
 	GetClone(ctx context.Context, id uuid.UUID, orgId string) (*CloneEntry, error)
 
-	InsertBlueprint(ctx context.Context, id uuid.UUID, versionId uuid.UUID, orgID, accountNumber, name, description string, body json.RawMessage) error
+	InsertBlueprint(ctx context.Context, id uuid.UUID, versionId uuid.UUID, orgID, accountNumber, name, description string, body json.RawMessage, metadata json.RawMessage) error
 	GetBlueprint(ctx context.Context, id uuid.UUID, orgID string) (*BlueprintEntry, error)
 	UpdateBlueprint(ctx context.Context, id uuid.UUID, blueprintId uuid.UUID, orgId string, name string, description string, body json.RawMessage) error
 	GetBlueprints(ctx context.Context, orgID string, limit, offset int) ([]BlueprintWithNoBody, int, error)

--- a/internal/db/db_blueprints.go
+++ b/internal/db/db_blueprints.go
@@ -19,8 +19,8 @@ type BlueprintCompose struct {
 
 const (
 	sqlInsertBlueprint = `
-		INSERT INTO blueprints(id, org_id, account_number, name, description)
-		VALUES($1, $2, $3, $4, $5)`
+		INSERT INTO blueprints(id, org_id, account_number, name, description, metadata)
+		VALUES($1, $2, $3, $4, $5, $6)`
 
 	sqlInsertVersion = `
 		INSERT INTO blueprint_versions(id, blueprint_id, version, body)
@@ -211,7 +211,7 @@ func (db *dB) GetBlueprintComposes(ctx context.Context, orgId string, blueprintI
 	return composes, nil
 }
 
-func (db *dB) InsertBlueprint(ctx context.Context, id uuid.UUID, versionId uuid.UUID, orgID, accountNumber, name, description string, body json.RawMessage) error {
+func (db *dB) InsertBlueprint(ctx context.Context, id uuid.UUID, versionId uuid.UUID, orgID, accountNumber, name, description string, body json.RawMessage, metadata json.RawMessage) error {
 	conn, err := db.Pool.Acquire(ctx)
 	if err != nil {
 		return err
@@ -219,7 +219,7 @@ func (db *dB) InsertBlueprint(ctx context.Context, id uuid.UUID, versionId uuid.
 	defer conn.Release()
 
 	err = db.withTransaction(ctx, func(tx pgx.Tx) error {
-		tag, txErr := tx.Exec(ctx, sqlInsertBlueprint, id, orgID, accountNumber, name, description)
+		tag, txErr := tx.Exec(ctx, sqlInsertBlueprint, id, orgID, accountNumber, name, description, metadata)
 		if txErr != nil {
 			return txErr
 		}

--- a/internal/db/migrations-tern/013_add_blueprints_metadata.sql
+++ b/internal/db/migrations-tern/013_add_blueprints_metadata.sql
@@ -1,0 +1,1 @@
+ALTER TABLE blueprints ADD metadata jsonb;

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -242,6 +242,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPErrorList'
+  /blueprints/{id}/export:
+    parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        example: '123e4567-e89b-12d3-a456-426655440000'
+        required: true
+        description: UUID of a blueprint
+    get:
+      summary: export a blueprint
+      description: "export a blueprint"
+      operationId: exportBlueprint
+      tags:
+        - blueprint
+      responses:
+        '200':
+          description: detail of a blueprint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlueprintExportResponse'
+        '404':
+          description: blueprint was not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
   /blueprints/{id}/compose:
     post:
       parameters:
@@ -1194,6 +1223,8 @@ components:
             Array of image requests. Having more image requests in a single blueprint is currently not supported.
         customizations:
           $ref: '#/components/schemas/Customizations'
+        metadata:
+          $ref: '#/components/schemas/BlueprintMetadata'
     CreateBlueprintResponse:
       required:
         - id
@@ -1262,6 +1293,35 @@ components:
             Array of image requests. Having more image requests in a single blueprint is currently not supported.
         customizations:
           $ref: '#/components/schemas/Customizations'
+    BlueprintExportResponse:
+      required:
+        - name
+        - description
+        - distribution
+        - customizations
+        - metadata
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        distribution:
+          $ref: '#/components/schemas/Distributions'
+        customizations:
+          $ref: '#/components/schemas/Customizations'
+        metadata:
+          $ref: '#/components/schemas/BlueprintMetadata'
+    BlueprintMetadata:
+      required:
+        - parent_id
+        - exported_at
+      properties:
+        parent_id:
+          type: string
+          format: uuid
+          nullable: true
+        exported_at:
+          type: string
     Distributions:
       type: string
       description: |

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -195,7 +195,7 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 	var message []byte
 	message, err = json.Marshal(blueprint)
 	require.NoError(t, err)
-	err = dbase.InsertBlueprint(ctx, id, versionId, "000000", "000000", name, description, message)
+	err = dbase.InsertBlueprint(ctx, id, versionId, "000000", "000000", name, description, message, json.RawMessage(`{}`))
 	require.NoError(t, err)
 
 	tests := map[string]struct {
@@ -245,7 +245,7 @@ func TestHandlers_GetBlueprintComposes(t *testing.T) {
 
 	var result ComposesResponse
 
-	err = dbase.InsertBlueprint(ctx, blueprintId, versionId, "000000", "500000", "blueprint", "blueprint desc", json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`))
+	err = dbase.InsertBlueprint(ctx, blueprintId, versionId, "000000", "500000", "blueprint", "blueprint desc", json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`), json.RawMessage(`{}`))
 	require.NoError(t, err)
 	id1 := uuid.New()
 	err = dbase.InsertCompose(ctx, id1, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-installer"}]}`), &clientId, &versionId)
@@ -307,7 +307,7 @@ func TestHandlers_GetBlueprintComposes(t *testing.T) {
 	// get composes for a blueprint that does not have any composes
 	id5 := uuid.New()
 	versionId2 := uuid.New()
-	err = dbase.InsertBlueprint(ctx, id5, versionId2, "000000", "500000", "newBlueprint", "blueprint desc", json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`))
+	err = dbase.InsertBlueprint(ctx, id5, versionId2, "000000", "500000", "newBlueprint", "blueprint desc", json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`), json.RawMessage(`{}`))
 	require.NoError(t, err)
 	respStatusCode, body = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/composes?blueprint_version=1", id5), &tutils.AuthString0)
 	require.Equal(t, 200, respStatusCode)
@@ -370,7 +370,7 @@ func TestHandlers_GetBlueprint(t *testing.T) {
 	var message []byte
 	message, err = json.Marshal(blueprint)
 	require.NoError(t, err)
-	err = dbase.InsertBlueprint(ctx, id, versionId, "000000", "000000", name, description, message)
+	err = dbase.InsertBlueprint(ctx, id, versionId, "000000", "000000", name, description, message, json.RawMessage(`{}`))
 	require.NoError(t, err)
 
 	respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/blueprints/%s", id.String()), &tutils.AuthString0)
@@ -391,6 +391,92 @@ func TestHandlers_GetBlueprint(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, respStatusCodeNotFound)
 }
 
+func TestHandlers_ExportBlueprint(t *testing.T) {
+	ctx := context.Background()
+	dbase, err := dbc.NewDB()
+	require.NoError(t, err)
+
+	db_srv, tokenSrv := startServer(t, &testServerClientsConf{}, &ServerConfig{
+		DBase:            dbase,
+		DistributionsDir: "../../distributions",
+	})
+	defer func() {
+		err := db_srv.Shutdown(ctx)
+		require.NoError(t, err)
+	}()
+	defer tokenSrv.Close()
+
+	id := uuid.New()
+	versionId := uuid.New()
+
+	uploadOptions := UploadRequest_Options{}
+	err = uploadOptions.FromAWSUploadRequestOptions(AWSUploadRequestOptions{
+		ShareWithAccounts: common.ToPtr([]string{"test-account"}),
+	})
+	require.NoError(t, err)
+	name := "blueprint"
+	description := "desc"
+	blueprint := BlueprintBody{
+		Customizations: Customizations{
+			Packages: common.ToPtr([]string{"nginx"}),
+			Subscription: &Subscription{
+				ActivationKey: "aaa",
+			},
+		},
+		Distribution: "centos-9",
+		ImageRequests: []ImageRequest{
+			{
+				Architecture: ImageRequestArchitectureX8664,
+				ImageType:    ImageTypesAws,
+				UploadRequest: UploadRequest{
+					Type:    UploadTypesAws,
+					Options: uploadOptions,
+				},
+			},
+			{
+				Architecture: ImageRequestArchitectureAarch64,
+				ImageType:    ImageTypesAws,
+				UploadRequest: UploadRequest{
+					Type:    UploadTypesAws,
+					Options: uploadOptions,
+				},
+			},
+		},
+	}
+
+	var message []byte
+	message, err = json.Marshal(blueprint)
+	require.NoError(t, err)
+
+	parentId := uuid.New()
+	exportedAt := time.RFC3339
+	metadata := BlueprintMetadata{
+		ParentId:   &parentId,
+		ExportedAt: exportedAt,
+	}
+	var metadataMessage []byte
+	metadataMessage, err = json.Marshal(metadata)
+	require.NoError(t, err)
+
+	err = dbase.InsertBlueprint(ctx, id, versionId, "000000", "000000", name, description, message, metadataMessage)
+	require.NoError(t, err)
+
+	respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/blueprints/%s/export", id.String()), &tutils.AuthString0)
+	require.Equal(t, http.StatusOK, respStatusCode)
+
+	var result BlueprintExportResponse
+	require.Equal(t, 200, respStatusCode)
+	err = json.Unmarshal([]byte(body), &result)
+	require.NoError(t, err)
+	require.Equal(t, description, result.Description)
+	require.Equal(t, name, result.Name)
+	require.Equal(t, blueprint.Distribution, result.Distribution)
+	require.Equal(t, blueprint.Customizations.Packages, result.Customizations.Packages)
+	require.Equal(t, &Subscription{}, result.Customizations.Subscription)
+	require.Equal(t, &id, result.Metadata.ParentId)
+	require.NotEqual(t, metadata.ExportedAt, result.Metadata.ExportedAt)
+}
+
 func TestHandlers_GetBlueprints(t *testing.T) {
 	ctx := context.Background()
 	dbase, err := dbc.NewDB()
@@ -408,11 +494,11 @@ func TestHandlers_GetBlueprints(t *testing.T) {
 
 	blueprintId := uuid.New()
 	versionId := uuid.New()
-	err = dbase.InsertBlueprint(ctx, blueprintId, versionId, "000000", "000000", "blueprint", "blueprint desc", json.RawMessage(`{}`))
+	err = dbase.InsertBlueprint(ctx, blueprintId, versionId, "000000", "000000", "blueprint", "blueprint desc", json.RawMessage(`{}`), json.RawMessage(`{}`))
 	require.NoError(t, err)
 	blueprintId2 := uuid.New()
 	versionId2 := uuid.New()
-	err = dbase.InsertBlueprint(ctx, blueprintId2, versionId2, "000000", "000000", "Blueprint2", "blueprint desc", json.RawMessage(`{}`))
+	err = dbase.InsertBlueprint(ctx, blueprintId2, versionId2, "000000", "000000", "Blueprint2", "blueprint desc", json.RawMessage(`{}`), json.RawMessage(`{}`))
 	require.NoError(t, err)
 
 	var result BlueprintsResponse
@@ -452,7 +538,7 @@ func TestHandlers_DeleteBlueprint(t *testing.T) {
 	defer tokenSrv.Close()
 
 	blueprintName := "blueprint"
-	err = dbase.InsertBlueprint(ctx, blueprintId, versionId, "000000", "000000", blueprintName, "blueprint desc", json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`))
+	err = dbase.InsertBlueprint(ctx, blueprintId, versionId, "000000", "000000", blueprintName, "blueprint desc", json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`), json.RawMessage(`{}`))
 	require.NoError(t, err)
 	id1 := uuid.New()
 	err = dbase.InsertCompose(ctx, id1, "000000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-installer"}]}`), &clientId, &versionId)
@@ -505,7 +591,7 @@ func TestHandlers_DeleteBlueprint(t *testing.T) {
 	// We should be able to create a Blueprint with same name
 	blueprintId2 := uuid.New()
 	versionId2 := uuid.New()
-	err = dbase.InsertBlueprint(ctx, blueprintId2, versionId2, "000000", "000000", blueprintName, "blueprint desc", json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`))
+	err = dbase.InsertBlueprint(ctx, blueprintId2, versionId2, "000000", "000000", blueprintName, "blueprint desc", json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`), json.RawMessage(`{}`))
 	require.NoError(t, err)
 
 	bpComposes, err := dbase.GetBlueprintComposes(ctx, "000000", blueprintId2, nil, (time.Hour * 24 * 14), 10, 0, nil)

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -287,7 +287,7 @@ func TestGetComposes(t *testing.T) {
 
 	bpId := uuid.New()
 	versionId := uuid.New()
-	err = dbase.InsertBlueprint(ctx, bpId, versionId, "000000", "500000", "bpName", "desc", json.RawMessage("{}"))
+	err = dbase.InsertBlueprint(ctx, bpId, versionId, "000000", "500000", "bpName", "desc", json.RawMessage("{}"), json.RawMessage("{}"))
 	require.NoError(t, err)
 
 	err = dbase.InsertCompose(ctx, id4, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-installer"}]}`), &clientId, &versionId)

--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -197,7 +197,7 @@ objects:
         from
           composes c
           left outer join blueprint_versions v on c.blueprint_version_id = v.id
-          left outer join blueprint b ON v.blueprint_id = b.id
+          left outer join blueprints b ON v.blueprint_id = b.id
           cross join lateral jsonb_array_elements(c.request->'image_requests') as req;
 
 - apiVersion: v1


### PR DESCRIPTION
The idea behind this is to have an endpoint for export. We would use this in the frontend for exporting blueprints.
Using a header "Content-Type" or "Accept" with "application/json;export=true" adds the metadata for the blueprint, omits ImageRequests (targets) and omits Activation Key. Maybe it makes sense to set the Subscription to nil overall. What do you think?
Users will not be able to create a blueprint with this exported JSON, as the "ImageRequests" field is mandatory. This feels a bit wrong in the API, but this is what we wanted users to specify in the Wizard.

We can also discuss other ways to add this to the API, such as parameter/different path for export, such as GET xxx/blueprints/{id}/export. I am open to this discussion.