### PR TITLE
v1/api: Add exported custom repositories

### DIFF
--- a/internal/clients/content_sources/client.go
+++ b/internal/clients/content_sources/client.go
@@ -70,6 +70,24 @@ func (csc *ContentSourcesClient) GetRepositories(ctx context.Context, repoURLs [
 	}, nil)
 }
 
+// returns []ApiRepositoryExportResponse
+func (csc *ContentSourcesClient) BulkExportRepositories(ctx context.Context, body ApiRepositoryExportRequest) (*http.Response, error) {
+	id, ok := identity.GetIdentityHeader(ctx)
+	if !ok {
+		return nil, fmt.Errorf("Unable to get identity from context")
+	}
+
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return csc.request("POST", csc.url.JoinPath("repositories", "bulk_export/").String(), map[string]string{
+		"x-rh-identity": id,
+		"content-type":  "application/json",
+	}, bytes.NewReader(buf))
+}
+
 // returns ApiListSnapshotByDateResponse
 func (csc *ContentSourcesClient) GetSnapshotsForDate(ctx context.Context, body ApiListSnapshotByDateRequest) (*http.Response, error) {
 	id, ok := identity.GetIdentityHeader(ctx)

--- a/internal/common/testdata/exported_blueprint.json
+++ b/internal/common/testdata/exported_blueprint.json
@@ -1,0 +1,38 @@
+{
+  "content_sources": [
+    {
+      "gpg_key": "some-gpg-key",
+      "name": "payload",
+      "url": "http://snappy-url/snappy/baseos"
+    }
+  ],
+  "customizations": {
+    "custom_repositories": [
+      {
+        "baseurl": [
+          "http://snappy-url/snappy/baseos"
+        ],
+        "gpgkey": [
+          "some-gpg-key"
+        ],
+        "id": "2531793b-c607-4e1c-80b2-fbbaf9d12790",
+        "name": "payload"
+      }
+    ],
+    "packages": [
+      "nginx"
+    ],
+    "users": [
+      {
+        "name": "user"
+      }
+    ]
+  },
+  "description": "desc",
+  "distribution": "centos-9",
+  "metadata": {
+    "exported_at": "2013-06-13 00:00:00 +0000 UTC",
+    "parent_id": "f43a4ec2-5447-4a25-8a62-e258ff11a2d9"
+  },
+  "name": "blueprint"
+}

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -227,8 +227,11 @@ type AzureUploadStatus struct {
 
 // BlueprintExportResponse defines model for BlueprintExportResponse.
 type BlueprintExportResponse struct {
-	Customizations Customizations `json:"customizations"`
-	Description    string         `json:"description"`
+	// ContentSources List of custom repositories including all the repository details needed in order
+	// to recreate the repositories.
+	ContentSources *[]map[string]interface{} `json:"content_sources,omitempty"`
+	Customizations Customizations            `json:"customizations"`
+	Description    string                    `json:"description"`
 
 	// Distribution List of all distributions that image builder supports. A user might not have access to
 	// restricted distributions.
@@ -443,7 +446,9 @@ type CustomRepository struct {
 
 // Customizations defines model for Customizations.
 type Customizations struct {
-	Containers         *[]Container        `json:"containers,omitempty"`
+	Containers *[]Container `json:"containers,omitempty"`
+
+	// CustomRepositories List of custom repositories.
 	CustomRepositories *[]CustomRepository `json:"custom_repositories,omitempty"`
 	Directories        *[]Directory        `json:"directories,omitempty"`
 

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1069,6 +1069,14 @@ components:
           $ref: '#/components/schemas/Customizations'
         metadata:
           $ref: '#/components/schemas/BlueprintMetadata'
+        content_sources:
+          type: array
+          items:
+            type: object
+          additionalProperties: true
+          description: |
+            List of custom repositories including all the repository details needed in order
+            to recreate the repositories.
     BlueprintMetadata:
       required:
         - parent_id
@@ -1568,6 +1576,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CustomRepository'
+          description: List of custom repositories.
         openscap:
           $ref: '#/components/schemas/OpenSCAP'
         filesystem:

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -4,11 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
 	"time"
+
+	"github.com/osbuild/image-builder/internal/clients/content_sources"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -312,6 +315,50 @@ func (h *Handlers) ExportBlueprint(ctx echo.Context, id openapi_types.UUID) erro
 			ParentId:   &id,
 		},
 	}
+
+	repoUUIDs := []string{}
+	if blueprint.Customizations.CustomRepositories != nil {
+		for _, repo := range *blueprint.Customizations.CustomRepositories {
+			repoUUIDs = append(repoUUIDs, repo.Id)
+		}
+	}
+
+	exportedRepositoriesResp, err := h.server.csClient.BulkExportRepositories(ctx.Request().Context(), content_sources.ApiRepositoryExportRequest{
+		RepositoryUuids: common.ToPtr(repoUUIDs),
+	})
+	if err != nil {
+		return err
+	}
+	defer closeBody(ctx, exportedRepositoriesResp.Body)
+
+	if exportedRepositoriesResp.StatusCode != http.StatusOK {
+		if exportedRepositoriesResp.StatusCode != http.StatusUnauthorized {
+			body, err := io.ReadAll(exportedRepositoriesResp.Body)
+			if err != nil {
+				return err
+			}
+			ctx.Logger().Warnf("Unable to export custom repositories: %s", body)
+		}
+		return fmt.Errorf("Unable to fetch custom repositories, got %v response", exportedRepositoriesResp.StatusCode)
+	}
+
+	if exportedRepositoriesResp.Body != nil {
+		bodyBytes, err := io.ReadAll(exportedRepositoriesResp.Body)
+		if err != nil {
+			return fmt.Errorf("Unable to export custom repositories: %w", err)
+		}
+
+		if len(bodyBytes) != 0 {
+			// Saving the custom repositories in the object format
+			var result []map[string]interface{}
+			err = json.Unmarshal(bodyBytes, &result)
+			if err != nil {
+				return fmt.Errorf("Unable to export custom repositories: %w, %s", err, string(bodyBytes))
+			}
+			blueprintExportResponse.ContentSources = &result
+		}
+	}
+
 	return ctx.JSON(http.StatusOK, blueprintExportResponse)
 }
 


### PR DESCRIPTION
Currently, the custom_repositories field only stores ids. When exporting a blueprint and sharing with someone from different org, we can not reuse ids, because from different org, users would not be able to see it. For that reason, we need to export more details about the repositories on export.

[https://issues.redhat.com/browse/HMS-4811](https://issues.redhat.com/browse/HMS-4811)

Edit: There is a very long discussion, the summary is in this comment (https://github.com/osbuild/image-builder/pull/1381#issuecomment-2451696913)