### PR TITLE
internal/v1: export snapshot date

### DIFF
--- a/internal/common/testdata/exported_blueprint.json
+++ b/internal/common/testdata/exported_blueprint.json
@@ -6,6 +6,7 @@
       "url": "http://snappy-url/snappy/baseos"
     }
   ],
+  "snapshot_date": "2012-12-20",
   "customizations": {
     "custom_repositories": [
       {

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -256,6 +256,10 @@ type BlueprintExportResponse struct {
 	Distribution Distributions     `json:"distribution"`
 	Metadata     BlueprintMetadata `json:"metadata"`
 	Name         string            `json:"name"`
+
+	// SnapshotDate Importing the snapshot date will not yet be supported. It is exported for informative reasons.
+	// The format is YYYY-MM-DD.
+	SnapshotDate *string `json:"snapshot_date,omitempty"`
 }
 
 // BlueprintItem defines model for BlueprintItem.

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1077,6 +1077,11 @@ components:
           description: |
             List of custom repositories including all the repository details needed in order
             to recreate the repositories.
+        snapshot_date:
+          type: string
+          description: |
+            Importing the snapshot date will not yet be supported. It is exported for informative reasons.
+            The format is YYYY-MM-DD.
     BlueprintMetadata:
       required:
         - parent_id

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -316,6 +316,10 @@ func (h *Handlers) ExportBlueprint(ctx echo.Context, id openapi_types.UUID) erro
 		},
 	}
 
+	if len(blueprint.ImageRequests) != 0 {
+		blueprintExportResponse.SnapshotDate = blueprint.ImageRequests[0].SnapshotDate
+	}
+
 	repoUUIDs := []string{}
 	if blueprint.Customizations.CustomRepositories != nil {
 		for _, repo := range *blueprint.Customizations.CustomRepositories {

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -31,6 +31,7 @@ type BlueprintExportResponseUnmarshal struct {
 	Distribution   Distributions                                 `json:"distribution"`
 	Metadata       BlueprintMetadata                             `json:"metadata"`
 	Name           string                                        `json:"name"`
+	SnapshotDate   *string                                       `json:"snapshot_date,omitempty"`
 }
 
 func makeTestServer(t *testing.T, apiSrv *string, csSrv *string) (dbase db.DB, srvURL string, shutdown func()) {
@@ -1011,6 +1012,7 @@ func TestHandlers_ExportBlueprint(t *testing.T) {
 					Type:    UploadTypesAws,
 					Options: uploadOptions,
 				},
+				SnapshotDate: common.ToPtr("2012-12-20"),
 			},
 			{
 				Architecture: ImageRequestArchitectureAarch64,
@@ -1019,6 +1021,7 @@ func TestHandlers_ExportBlueprint(t *testing.T) {
 					Type:    UploadTypesAws,
 					Options: uploadOptions,
 				},
+				SnapshotDate: common.ToPtr("2012-12-21"),
 			},
 		},
 	}
@@ -1056,6 +1059,7 @@ func TestHandlers_ExportBlueprint(t *testing.T) {
 	require.Equal(t, "payload", *result.ContentSources[0].Name)
 	require.Equal(t, "http://snappy-url/snappy/baseos", *result.ContentSources[0].Url)
 	require.Equal(t, "some-gpg-key", *result.ContentSources[0].GpgKey)
+	require.Equal(t, "2012-12-20", *result.SnapshotDate)
 	require.Len(t, result.ContentSources, 1)
 	// Check that the password returned is redacted
 	for _, u := range *result.Customizations.Users {


### PR DESCRIPTION
I started a conversation about importing and exporting snapshot dates. Our team thought that it would be convenient to export the snapshot date. We might have a follow-up discussion about importing it as well, but there are some issues that we need to handle. 
In the wizard, we currently do not limit how much in the history the user can pick the snapshot date, so maybe we can just import it as is on the front end. @croissanne ? But then, users also import custom repositories, and they would most likely not have that snapshot from the history.
The discussion's outcome was to keep the feature without importing the snapshot date, but we will keep that option for the future. What do we think? We can mention somewhere that this value is not being imported.
