### PR TITLE
v1/api: Add on prem boolean to blueprints metadata

### DIFF
--- a/internal/common/testdata/exported_blueprint.json
+++ b/internal/common/testdata/exported_blueprint.json
@@ -32,7 +32,8 @@
   "distribution": "centos-9",
   "metadata": {
     "exported_at": "2013-06-13 00:00:00 +0000 UTC",
-    "parent_id": "f43a4ec2-5447-4a25-8a62-e258ff11a2d9"
+    "parent_id": "f43a4ec2-5447-4a25-8a62-e258ff11a2d9",
+    "is_on_prem": false
   },
   "name": "blueprint"
 }

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -255,6 +255,7 @@ type BlueprintItem struct {
 // BlueprintMetadata defines model for BlueprintMetadata.
 type BlueprintMetadata struct {
 	ExportedAt string              `json:"exported_at"`
+	IsOnPrem   bool                `json:"is_on_prem"`
 	ParentId   *openapi_types.UUID `json:"parent_id"`
 }
 

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1081,6 +1081,7 @@ components:
       required:
         - parent_id
         - exported_at
+        - is_on_prem
       properties:
         parent_id:
           type: string
@@ -1088,6 +1089,9 @@ components:
           nullable: true
         exported_at:
           type: string
+        is_on_prem:
+          type: boolean
+          default: false
     Distributions:
       type: string
       description: |

--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -211,6 +211,7 @@ objects:
           v.blueprint_id::text as blueprint_id, v.version, b.deleted,
           b.metadata->>'exported_at' as exported_at,
           b.metadata->>'parent_id' as parent_id
+          b.metadata->>'is_on_prem' as is_on_prem
         from
           blueprint_versions v
           left outer join blueprints b ON v.blueprint_id = b.id


### PR DESCRIPTION
This way we might be able to track how much are people using the on prem blueprints using.

[HMS-4980](https://issues.redhat.com/browse/HMS-4980)