### PR TITLE
Docs: Reword README and Makefile-comment to avoid "image-builder"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PACKAGE_NAME = image-builder
 help:
 	@echo "make [TARGETS...]"
 	@echo
-	@echo "This is the maintenance makefile of image-builder. The following"
+	@echo "This is the maintenance makefile of image-builder-crc. The following"
 	@echo "targets are available:"
 	@echo
 	@echo "    help:               Print this usage information."

--- a/README.md
+++ b/README.md
@@ -1,28 +1,26 @@
-Image Builder
-=============
+# Image Builder console.redhat.com Middleware
 
-Image Builder serves as an HTTP API on top of [Osbuild
-Composer](https://github.com/osbuild/osbuild-composer), and serves as the
-backend for [Image Builder
-Frontend](https://github.com/osbuild/image-builder-frontend/).
+"Image Builder **C**onsole.**R**edhat.**C**om" serves as
+an HTTP API on top of [Osbuild Composer](https://github.com/osbuild/osbuild-composer),
+and serves as the backend for [Image Builder Frontend](https://github.com/osbuild/image-builder-frontend/).
 
-Image Builder is intended to be run within the
+Image Builder Middleware is intended to be run within the
 [console.redhat.com](https://console.redhat.com) platform.
 
 ### Project
 
  * **Website**: <https://www.osbuild.org>
- * **Bug Tracker**: <https://github.com/osbuild/image-builder/issues>
+ * **Bug Tracker**: <https://github.com/osbuild/image-builder-crc/issues>
  * **Discussions**: https://github.com/orgs/osbuild/discussions
  * **Matrix**: [#image-builder on fedoraproject.org](https://matrix.to/#/#image-builder:fedoraproject.org)
- * **Changelog**: <https://github.com/osbuild/image-builder/releases>
+ * **Changelog**: <https://github.com/osbuild/image-builder-crc/releases>
 
 ### OpenAPI spec
 
 The latest OpenAPI specification:
 
-* [raw YAML](https://github.com/osbuild/image-builder/blob/main/internal/v1/api.yaml)
-* [on-line version](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/osbuild/image-builder/main/internal/v1/api.yaml)
+* [raw YAML](https://github.com/osbuild/image-builder-crc/blob/main/internal/v1/api.yaml)
+* [on-line version](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/osbuild/image-builder-crc/main/internal/v1/api.yaml)
 
 ### Contributing
 
@@ -54,9 +52,9 @@ To run the project use `make run` target
 
 ## Repository
 
- - **web**:   <https://github.com/osbuild/image-builder>
- - **https**: `https://github.com/osbuild/image-builder.git`
- - **ssh**:   `git@github.com:osbuild/image-builder.git`
+ - **web**:   <https://github.com/osbuild/image-builder-crc>
+ - **https**: `https://github.com/osbuild/image-builder-crc.git`
+ - **ssh**:   `git@github.com:osbuild/image-builder-crc.git`
 
 ## License
 


### PR DESCRIPTION
We'll avoid the name "image-builder" here, as this repository is now renamed to `image-builder-crc` and the command line interface tool and RPM is called `image-builder` which would cause confusions at least in the overarching documentation in osbuild.org.
See: https://github.com/osbuild/image-builder-cli

There are more places which might cause confusions like the binary is also called `image-builder`
https://github.com/osbuild/image-builder-crc/blob/4ecc6263f1f07d8617a52777fe45c03ed5b43987/Makefile#L24
…but that's up to followup PRs