### PR TITLE
clients/content_sources: fix baseurl for upload repositories

### DIFF
--- a/internal/clients/content_sources/util.go
+++ b/internal/clients/content_sources/util.go
@@ -2,15 +2,24 @@ package content_sources
 
 import (
 	"fmt"
+	"net/url"
 )
 
-func GetBaseURL(repo ApiRepositoryResponse) (string, error) {
+func GetBaseURL(repo ApiRepositoryResponse, csReposURL *url.URL) (string, error) {
 	if repo.Origin == nil {
 		return "", fmt.Errorf("unable to read origin from repository %s", *repo.Uuid)
 	}
 	switch *repo.Origin {
 	case "upload":
-		return *repo.LatestSnapshotUrl, nil
+		if csReposURL == nil {
+			return "", fmt.Errorf("upload repositories require a content sources URL")
+		}
+		// Snapshot URLs need to be replaced with the internal mtls URL
+		repoURL, err := url.Parse(*repo.LatestSnapshotUrl)
+		if err != nil {
+			return "", err
+		}
+		return csReposURL.JoinPath(repoURL.Path).String(), nil
 	case "external", "red_hat":
 		return *repo.Url, nil
 	}

--- a/internal/clients/content_sources/util_test.go
+++ b/internal/clients/content_sources/util_test.go
@@ -1,6 +1,7 @@
 package content_sources_test
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,30 +11,32 @@ import (
 )
 
 func TestGetBaseURL(t *testing.T) {
-	url, err := content_sources.GetBaseURL(content_sources.ApiRepositoryResponse{
+	baseURL, err := content_sources.GetBaseURL(content_sources.ApiRepositoryResponse{
 		Url:    common.ToPtr("someurl"),
 		Origin: common.ToPtr("external"),
-	})
+	}, nil)
 	require.NoError(t, err)
-	require.Equal(t, "someurl", url)
+	require.Equal(t, "someurl", baseURL)
 
-	url, err = content_sources.GetBaseURL(content_sources.ApiRepositoryResponse{
+	baseURL, err = content_sources.GetBaseURL(content_sources.ApiRepositoryResponse{
 		Url:    common.ToPtr("someurl"),
 		Origin: common.ToPtr("red_hat"),
-	})
+	}, nil)
 	require.NoError(t, err)
-	require.Equal(t, "someurl", url)
+	require.Equal(t, "someurl", baseURL)
 
-	url, err = content_sources.GetBaseURL(content_sources.ApiRepositoryResponse{
+	csURL, err := url.Parse("https://realurl.com")
+	require.NoError(t, err)
+	baseURL, err = content_sources.GetBaseURL(content_sources.ApiRepositoryResponse{
 		Url:               common.ToPtr("someurl"),
 		LatestSnapshotUrl: common.ToPtr("realurl"),
 		Origin:            common.ToPtr("upload"),
-	})
+	}, csURL)
 	require.NoError(t, err)
-	require.Equal(t, "realurl", url)
+	require.Equal(t, "https://realurl.com/realurl", baseURL)
 
 	_, err = content_sources.GetBaseURL(content_sources.ApiRepositoryResponse{
 		Uuid: common.ToPtr("d15a0c50-1549-4d04-bcb8-b3553576acd4"),
-	})
+	}, nil)
 	require.Error(t, err)
 }

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -342,7 +342,7 @@ func (h *Handlers) buildPayloadRepositories(ctx echo.Context, payloadRepos []Rep
 			res[i].Baseurl = pyrepo.Baseurl
 		} else if repo.Uuid != nil {
 			// If the repo was found in content sources, its uuid will be set
-			baseurl, err := content_sources.GetBaseURL(repo)
+			baseurl, err := content_sources.GetBaseURL(repo, h.server.csReposURL)
 			if err != nil {
 				return nil, err
 			}
@@ -415,7 +415,7 @@ func (h *Handlers) buildCustomRepositories(ctx echo.Context, custRepos []CustomR
 			res[i].Baseurl = curepo.Baseurl
 		} else if repo.Uuid != nil {
 			// If the repo was found in content sources, its uuid will be set
-			baseurl, err := content_sources.GetBaseURL(repo)
+			baseurl, err := content_sources.GetBaseURL(repo, h.server.csReposURL)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -1818,7 +1818,7 @@ func TestComposeCustomizations(t *testing.T) {
 							Rhsm:         common.ToPtr(false),
 						},
 						{
-							Baseurl:      common.ToPtr("https://upload-latest-snapshot-url.org"),
+							Baseurl:      common.ToPtr("https://content-sources.org"),
 							Gpgkey:       common.ToPtr("some-gpg-key"),
 							CheckGpg:     common.ToPtr(true),
 							CheckRepoGpg: common.ToPtr(false),
@@ -1847,7 +1847,7 @@ func TestComposeCustomizations(t *testing.T) {
 						{
 							Id:       mocks.RepoUplID,
 							Name:     common.ToPtr("upload"),
-							Baseurl:  &[]string{"https://upload-latest-snapshot-url.org"},
+							Baseurl:  &[]string{"https://content-sources.org"},
 							Gpgkey:   &[]string{"some-gpg-key"},
 							CheckGpg: common.ToPtr(true),
 						},


### PR DESCRIPTION
Whenever snapshot URLs are used, they need to be used with the internal URL, as it's content hosted by content sources.