### PR TITLE
v1/api: support adding content template to a blueprint

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -514,6 +514,9 @@ type Customizations struct {
 	Services            *Services                       `json:"services,omitempty"`
 	Subscription        *Subscription                   `json:"subscription,omitempty"`
 
+	// Template ID of template.
+	Template *string `json:"template,omitempty"`
+
 	// Timezone Timezone configuration
 	Timezone *Timezone `json:"timezone,omitempty"`
 

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1597,6 +1597,9 @@ components:
           items:
             $ref: '#/components/schemas/CustomRepository'
           description: List of custom repositories.
+        template:
+          type: string
+          description: ID of template.
         openscap:
           $ref: '#/components/schemas/OpenSCAP'
         filesystem:

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -214,6 +214,14 @@ func (h *Handlers) CreateBlueprint(ctx echo.Context) error {
 		}
 	}
 
+	if blueprintRequest.Customizations.Template != nil {
+		template, err := h.server.csClient.GetTemplateByID(ctx.Request().Context(), *blueprintRequest.Customizations.Template)
+		if err != nil {
+			return err
+		}
+		blueprintRequest.ImageRequests[0].SnapshotDate = template.Date
+	}
+
 	blueprint, err := BlueprintFromAPI(blueprintRequest)
 	if err != nil {
 		return err

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -71,6 +71,7 @@ func TestHandlers_CreateBlueprint(t *testing.T) {
 				{"name": "user", "password": "test"},
 				{"name": "user2", "ssh_key": "ssh-rsa AAAAB3NzaC1"},
 			},
+			"template": mocks.TemplateID,
 		},
 		"distribution": "centos-9",
 		"image_requests": []map[string]interface{}{
@@ -115,6 +116,12 @@ func TestHandlers_CreateBlueprint(t *testing.T) {
 	err = json.Unmarshal([]byte(resp), &jsonResp)
 	require.NoError(t, err)
 	require.Equal(t, "Invalid user", jsonResp.Errors[0].Title)
+
+	// Test the template ID and date from the template were saved to the blueprint
+	blueprintResp, err := v1.BlueprintFromEntry(be)
+	require.NoError(t, err)
+	require.Equal(t, *blueprintResp.Customizations.Template, mocks.TemplateID)
+	require.Equal(t, *blueprintResp.ImageRequests[0].SnapshotDate, "2000-01-30T00:00:00Z")
 }
 
 func TestUser_MergeForUpdate(t *testing.T) {

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -2797,6 +2797,124 @@ func TestComposeCustomizations(t *testing.T) {
 				},
 			},
 		},
+		// content template with 1 custom repository
+		{
+			imageBuilderRequest: v1.ComposeRequest{
+				Customizations: &v1.Customizations{
+					Template: &mocks.TemplateID,
+				},
+				Distribution: "rhel-8",
+				ImageRequests: []v1.ImageRequest{
+					{
+						Architecture: "x86_64",
+						ImageType:    v1.ImageTypesGuestImage,
+						UploadRequest: v1.UploadRequest{
+							Type:    v1.UploadTypesAwsS3,
+							Options: uo,
+						},
+						SnapshotDate: common.ToPtr("2000-01-30T00:00:00Z"),
+					},
+				},
+			},
+			composerRequest: composer.ComposeRequest{
+				Customizations: &composer.Customizations{
+					CustomRepositories: &[]composer.CustomRepository{
+						{
+							Baseurl:  &[]string{"http://snappy-url/template/snapshot1"},
+							Name:     common.ToPtr("payload"),
+							CheckGpg: common.ToPtr(true),
+							Enabled:  common.ToPtr(false),
+							Gpgkey:   &[]string{"some-gpg-key"},
+							Id:       mocks.RepoPLID,
+						},
+					},
+				},
+				Distribution: "rhel-8.10",
+				ImageRequest: &composer.ImageRequest{
+					Architecture: "x86_64",
+					ImageType:    composer.ImageTypesGuestImage,
+					UploadOptions: makeUploadOptions(t, composer.AWSS3UploadOptions{
+						Region: "",
+					}),
+					Repositories: []composer.Repository{
+						{
+							Baseurl:  common.ToPtr("https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os"),
+							Rhsm:     common.ToPtr(true),
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+						},
+						{
+							Baseurl:  common.ToPtr("https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os"),
+							Rhsm:     common.ToPtr(true),
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+						},
+					},
+				},
+			},
+		},
+		// content template with 2 custom repositories
+		{
+			imageBuilderRequest: v1.ComposeRequest{
+				Customizations: &v1.Customizations{
+					Template: &mocks.TemplateID2,
+				},
+				Distribution: "rhel-8",
+				ImageRequests: []v1.ImageRequest{
+					{
+						Architecture: "x86_64",
+						ImageType:    v1.ImageTypesGuestImage,
+						UploadRequest: v1.UploadRequest{
+							Type:    v1.UploadTypesAwsS3,
+							Options: uo,
+						},
+						SnapshotDate: common.ToPtr("2000-01-30T00:00:00Z"),
+					},
+				},
+			},
+			composerRequest: composer.ComposeRequest{
+				Customizations: &composer.Customizations{
+					CustomRepositories: &[]composer.CustomRepository{
+						{
+							Baseurl:  &[]string{"http://snappy-url/template/snapshot1"},
+							Name:     common.ToPtr("payload"),
+							CheckGpg: common.ToPtr(true),
+							Enabled:  common.ToPtr(false),
+							Gpgkey:   &[]string{"some-gpg-key"},
+							Id:       mocks.RepoPLID,
+						},
+						{
+							Baseurl: &[]string{"http://snappy-url/template/snapshot2"},
+							Name:    common.ToPtr("payload2"),
+							Enabled: common.ToPtr(false),
+							Id:      mocks.RepoPLID2,
+						},
+					},
+				},
+				Distribution: "rhel-8.10",
+				ImageRequest: &composer.ImageRequest{
+					Architecture: "x86_64",
+					ImageType:    composer.ImageTypesGuestImage,
+					UploadOptions: makeUploadOptions(t, composer.AWSS3UploadOptions{
+						Region: "",
+					}),
+					Repositories: []composer.Repository{
+						{
+							Baseurl:  common.ToPtr("https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os"),
+							Rhsm:     common.ToPtr(true),
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+						},
+						{
+							Baseurl:  common.ToPtr("https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os"),
+							Rhsm:     common.ToPtr(true),
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for idx, payload := range payloads {

--- a/internal/v1/mocks/content_sources.go
+++ b/internal/v1/mocks/content_sources.go
@@ -23,6 +23,10 @@ var (
 	RepoPLID     = "a7ec8864-0e3c-4af2-8c06-567891280af5"
 	RepoPLID2    = "c01c2d9c-4624-4558-9ca9-8abcc5eb4437"
 	RepoPLID3    = "d064585d-5d25-4e10-88d0-9ab4d192b21d"
+	TemplateID   = "267232b1-d5af-467f-b6c0-2b502fa02d3d"
+	TemplateID2  = "f3203472-e8ed-4d52-8a98-0e9905e91953"
+	SnapshotID   = "6161fd44-ade8-4300-882b-ede6d65ee56e"
+	SnapshotID2  = "470f9dfa-10dd-4d70-aacb-96ba9a3d9f06"
 )
 
 func rhRepos(ids []string, urls []string) (res []content_sources.ApiRepositoryResponse) {
@@ -184,6 +188,47 @@ func exports(uuids []string) (res []content_sources.ApiRepositoryExportResponse)
 	return res
 }
 
+func templateByID(uuid string) (res content_sources.ApiTemplateResponse) {
+	if uuid == TemplateID {
+		res = content_sources.ApiTemplateResponse{
+			Uuid:            common.ToPtr(uuid),
+			Name:            common.ToPtr("template1"),
+			RepositoryUuids: common.ToPtr([]string{RepoBaseID, RepoAppstrID, RepoPLID}),
+			Date:            common.ToPtr("2000-01-30T00:00:00Z"),
+			Snapshots: &[]content_sources.ApiSnapshotResponse{
+				{
+					Uuid:           common.ToPtr(SnapshotID),
+					RepositoryUuid: common.ToPtr(RepoPLID),
+					RepositoryPath: common.ToPtr("/template/snapshot1"),
+					Url:            common.ToPtr("http://snappy-url/template/snapshot1"),
+				},
+			},
+		}
+	} else if uuid == TemplateID2 {
+		res = content_sources.ApiTemplateResponse{
+			Uuid:            common.ToPtr(uuid),
+			Name:            common.ToPtr("template2"),
+			RepositoryUuids: common.ToPtr([]string{RepoBaseID, RepoAppstrID, RepoPLID, RepoPLID2}),
+			Date:            common.ToPtr("2000-01-30T00:00:00Z"),
+			Snapshots: &[]content_sources.ApiSnapshotResponse{
+				{
+					Uuid:           common.ToPtr(SnapshotID),
+					RepositoryUuid: common.ToPtr(RepoPLID),
+					RepositoryPath: common.ToPtr("/template/snapshot1"),
+					Url:            common.ToPtr("http://snappy-url/template/snapshot1"),
+				},
+				{
+					Uuid:           common.ToPtr(SnapshotID2),
+					RepositoryUuid: common.ToPtr(RepoPLID2),
+					RepositoryPath: common.ToPtr("/template/snapshot2"),
+					Url:            common.ToPtr("http://snappy-url/template/snapshot2"),
+				},
+			},
+		}
+	}
+	return res
+}
+
 func ContentSources(w http.ResponseWriter, r *http.Request) {
 	if tutils.AuthString0 != r.Header.Get("x-rh-identity") {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -241,6 +286,18 @@ func ContentSources(w http.ResponseWriter, r *http.Request) {
 		err = json.NewEncoder(w).Encode(exports(body.RepositoryUuids))
 		if err != nil {
 			w.WriteHeader(http.StatusInsufficientStorage)
+			return
+		}
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/templates/") {
+		pathParts := strings.Split(strings.TrimPrefix(r.URL.Path, "/templates/"), "/")
+		if len(pathParts) == 1 {
+			uuid := pathParts[0]
+			err := json.NewEncoder(w).Encode(templateByID(uuid))
+			if err != nil {
+				w.WriteHeader(http.StatusInsufficientStorage)
+			}
 			return
 		}
 	}


### PR DESCRIPTION
To add support for adding a content template to a blueprint, this PR does a few things:

- Adds a new field (`template`) to the blueprint customizations, which holds the template UUID
- Saves the template UUID and snapshot date from the template to the blueprint on creation
- Resolves custom repositories in the template at compose time
- Adds another content sources mock for the unit tests

Ticket here: https://issues.redhat.com/browse/HMS-5319

Open question(s):

- How should Red Hat repositories in the template be handled? Currently I've filtered out and added only the custom repos, I'm not sure if this is what we want though :) 

