### PR TITLE
build: ensure Go version in prep script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up bootstrap Go 1.22
         uses: actions/setup-go@v5.3.0
         with:
-          go-version: '1.22'
+          go-version: '1.22.9' # also update tools/prepare-source.sh
           cache: false
         id: go
 
@@ -40,6 +40,7 @@ jobs:
 
       - name: Check that source has been prepared
         run: |
+          go env
           ./tools/prepare-source.sh
           if [ -n "$(git status --porcelain)" ]; then
             echo

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -2,7 +2,7 @@
 set -eu
 
 GO_MAJOR_VER=1.22
-GO_VERSION=1.22.9
+GO_VERSION=1.22.9 # also update .github/workflows/tests.yml
 OAPI_VERSION=2.4.1
 TOOLS_PATH="$(realpath "$(dirname "$0")/bin")"
 
@@ -13,8 +13,11 @@ if test "$LATEST" != "$GO_VERSION"; then
 fi
 
 set -x
+export GOTOOLCHAIN=go$GO_VERSION
+export GOSUMDB='sum.golang.org' # this is turned off for Go from Fedora / RHEL
+go version
 
-# Pin Go and toolbox versions at a reasonable version
+# Pin Go and toolchain versions at a reasonable version
 go get go@$GO_VERSION toolchain@$GO_VERSION
 
 # Update go.mod and go.sum:


### PR DESCRIPTION
There is something different on the CICD, I am unable to reproduce this failure locally:

https://github.com/osbuild/image-builder-crc/pull/1490

This is an attempt to fix that. Versions do vary, this puts them in sync.