### PR TITLE
fix: remove trace disallow flag

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -179,7 +179,6 @@ func main() {
 			strc.IgnorePathPrefix("/status"),
 			strc.IgnorePathPrefix("/ready"),
 		},
-		NoTraceContext: true,
 	})))
 	if conf.GlitchTipDSN != "" {
 		echoServer.Use(sentryecho.New(sentryecho.Options{}))

--- a/internal/oauth2/lazy_token.go
+++ b/internal/oauth2/lazy_token.go
@@ -54,8 +54,6 @@ func (lt *LazyToken) acquireNewToken(ctx context.Context, forceRefresh bool) (st
 		lt.Expiration = time.Now().Add(time.Duration(tokenRes.ExpiresIn) * time.Second)
 
 		slog.DebugContext(ctx, "acquired new token", "expiration", lt.Expiration)
-	} else {
-		slog.DebugContext(ctx, "reusing token", "expiration", lt.Expiration)
 	}
 
 	return lt.AccessToken, nil


### PR DESCRIPTION
Tracing was explicitly disabled, this flag lift up tracing being added to context, it can be now distributed through the app and correlation will start. Remember, you can use `trace_id` field to trace ALL messages from now on, the tracing random string is also returned via HTTP header and passed in called services (e.g. composer) via HTTP header too.

The patch also drops a very noisy debug line "reusing token" which appears way to often to my taste and carries low informative value.

