### PR TITLE
refactor: make use of generated clients for composer

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -124,7 +124,7 @@ func main() {
 			ClientSecret: conf.RecommendSecret,
 		},
 	}
-	compClient, err := composer.NewClient(composerConf)
+	compClient, err := composer.NewClientFromConfig(composerConf)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/clients/composer/client.cfg.yaml
+++ b/internal/clients/composer/client.cfg.yaml
@@ -2,3 +2,16 @@ package: composer
 output: openapi.v2.gen.go
 generate:
   models: true
+  client: true
+output-options:
+  include-operation-ids:
+    - getComposeStatus
+    - getComposeMetadata
+    - postCompose
+    - postComposeStatus
+    - getCloneStatus
+    - cloneComposeBody
+    - awsEc2ComposeBody
+    - postCloneCompose
+    - getCompose
+    - getOpenapi

--- a/internal/clients/composer/client.go
+++ b/internal/clients/composer/client.go
@@ -1,54 +1,41 @@
 package composer
 
 import (
-	"bytes"
-	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/osbuild/image-builder-crc/internal/oauth2"
-	"github.com/osbuild/logging/pkg/strc"
 )
-
-type ComposerClient struct {
-	composerURL string
-	tokener     oauth2.Tokener
-	client      *http.Client
-}
 
 type ComposerClientConfig struct {
 	URL     string
 	CA      string
-	Tokener oauth2.Tokener
+	Tokener oauth2.TokenerDoer
 }
 
-var contentHeaders = map[string]string{"Content-Type": "application/json"}
-
-func NewClient(conf ComposerClientConfig) (*ComposerClient, error) {
+func NewClientFromConfig(conf ComposerClientConfig) (*Client, error) {
 	if conf.URL == "" {
 		slog.Warn("composer URL not set, client will fail")
 	}
-	client, err := createClient(conf.URL, conf.CA)
+	httpClient, err := createClient(conf.URL, conf.CA)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating compose http client")
 	}
+	conf.Tokener.SetClient(httpClient)
 
-	cc := ComposerClient{
-		composerURL: fmt.Sprintf("%s/api/image-builder-composer/v2", conf.URL),
-		tokener:     conf.Tokener,
-		client:      client,
+	client, err := NewClient(fmt.Sprintf("%s/api/image-builder-composer/v2", conf.URL))
+	if err != nil {
+		return nil, fmt.Errorf("Error creating compose http client")
 	}
+	client.Client = conf.Tokener
 
-	return &cc, nil
+	return client, nil
 }
 
 func createClient(composerURL string, ca string) (*http.Client, error) {
@@ -72,79 +59,4 @@ func createClient(composerURL string, ca string) (*http.Client, error) {
 
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
 	return &http.Client{Transport: transport}, nil
-}
-
-func (cc *ComposerClient) request(ctx context.Context, method, url string, headers map[string]string, body io.ReadSeeker) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, method, url, body)
-	if err != nil {
-		return nil, err
-	}
-
-	for k, v := range headers {
-		req.Header.Add(k, v)
-	}
-
-	token, err := cc.tokener.Token(req.Context())
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-
-	resp, err := strc.NewTracingDoer(cc.client).Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
-		token, err = cc.tokener.ForceRefresh(req.Context())
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-		if body != nil {
-			_, err = body.Seek(0, io.SeekStart)
-			if err != nil {
-				return nil, err
-			}
-		}
-		resp, err = strc.NewTracingDoer(cc.client).Do(req)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return resp, err
-}
-
-func (cc *ComposerClient) ComposeStatus(ctx context.Context, id uuid.UUID) (*http.Response, error) {
-	return cc.request(ctx, "GET", fmt.Sprintf("%s/composes/%s", cc.composerURL, id), nil, nil)
-}
-
-func (cc *ComposerClient) ComposeMetadata(ctx context.Context, id uuid.UUID) (*http.Response, error) {
-	return cc.request(ctx, "GET", fmt.Sprintf("%s/composes/%s/metadata", cc.composerURL, id), nil, nil)
-}
-
-func (cc *ComposerClient) Compose(ctx context.Context, compose ComposeRequest) (*http.Response, error) {
-	buf, err := json.Marshal(compose)
-	if err != nil {
-		return nil, err
-	}
-
-	return cc.request(ctx, "POST", fmt.Sprintf("%s/compose", cc.composerURL), contentHeaders, bytes.NewReader(buf))
-}
-
-func (cc *ComposerClient) OpenAPI(ctx context.Context) (*http.Response, error) {
-	return cc.request(ctx, "GET", fmt.Sprintf("%s/openapi", cc.composerURL), nil, nil)
-}
-
-func (cc *ComposerClient) CloneCompose(ctx context.Context, id uuid.UUID, clone CloneComposeBody) (*http.Response, error) {
-	buf, err := json.Marshal(clone)
-	if err != nil {
-		return nil, err
-	}
-	return cc.request(ctx, "POST", fmt.Sprintf("%s/composes/%s/clone", cc.composerURL, id), contentHeaders, bytes.NewReader(buf))
-}
-
-func (cc *ComposerClient) CloneStatus(ctx context.Context, id uuid.UUID) (*http.Response, error) {
-	return cc.request(ctx, "GET", fmt.Sprintf("%s/clones/%s", cc.composerURL, id), nil, nil)
 }

--- a/internal/oauth2/doer.go
+++ b/internal/oauth2/doer.go
@@ -1,0 +1,61 @@
+package oauth2
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/osbuild/logging/pkg/strc"
+)
+
+func do(client *http.Client, tokener Tokener, req *http.Request) (*http.Response, error) {
+	if client == nil {
+		panic("client must be set before calling Do()")
+	}
+
+	var bodyBytes []byte
+	var err error
+	if req.Body != nil {
+		bodyBytes, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		err = req.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	}
+
+	token, err := tokener.Token(req.Context())
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	resp, err := strc.NewTracingDoer(client).Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+		token, err = tokener.ForceRefresh(req.Context())
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+		if req.Body != nil {
+			req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		}
+		resp, err = strc.NewTracingDoer(client).Do(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return resp, err
+}

--- a/internal/oauth2/dummy_token.go
+++ b/internal/oauth2/dummy_token.go
@@ -1,9 +1,16 @@
 package oauth2
 
-import "context"
+import (
+	"context"
+	"net/http"
+	"sync"
+)
 
 // DummyToken is a dummy implementation of the Tokener interface.
-type DummyToken struct{}
+type DummyToken struct {
+	c *http.Client
+	m sync.Mutex
+}
 
 // Token returns a static "testtoken" string.
 func (dt *DummyToken) Token(ctx context.Context) (string, error) {
@@ -13,4 +20,22 @@ func (dt *DummyToken) Token(ctx context.Context) (string, error) {
 
 func (dt *DummyToken) ForceRefresh(ctx context.Context) (string, error) {
 	return "", nil
+}
+
+func (dt *DummyToken) SetClient(c *http.Client) {
+	dt.m.Lock()
+	defer dt.m.Unlock()
+
+	dt.c = c
+}
+
+func (dt *DummyToken) Do(req *http.Request) (*http.Response, error) {
+	dt.m.Lock()
+	defer dt.m.Unlock()
+
+	if dt.c == nil {
+		dt.c = http.DefaultClient
+	}
+
+	return do(dt.c, dt, req)
 }

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -57,7 +57,7 @@ func (h *Handlers) GetVersion(ctx echo.Context) error {
 }
 
 func (h *Handlers) GetReadiness(ctx echo.Context) error {
-	resp, err := h.server.cClient.OpenAPI(ctx.Request().Context())
+	resp, err := h.server.cClient.GetOpenapi(ctx.Request().Context())
 	if err != nil {
 		return err
 	}
@@ -249,7 +249,7 @@ func (h *Handlers) GetComposeStatus(ctx echo.Context, composeId uuid.UUID) error
 		}
 	}
 
-	resp, err := h.server.cClient.ComposeStatus(ctx.Request().Context(), composeId)
+	resp, err := h.server.cClient.GetComposeStatus(ctx.Request().Context(), composeId)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get compose status from client").SetInternal(err)
 	}
@@ -453,7 +453,7 @@ func (h *Handlers) GetComposeMetadata(ctx echo.Context, composeId uuid.UUID) err
 		return err
 	}
 
-	resp, err := h.server.cClient.ComposeMetadata(ctx.Request().Context(), composeId)
+	resp, err := h.server.cClient.GetComposeMetadata(ctx.Request().Context(), composeId)
 	if err != nil {
 		return err
 	}
@@ -667,7 +667,7 @@ func (h *Handlers) CloneCompose(ctx echo.Context, composeId uuid.UUID) error {
 			return err
 		}
 
-		resp, err = h.server.cClient.CloneCompose(ctx.Request().Context(), composeId, ccb)
+		resp, err = h.server.cClient.PostCloneCompose(ctx.Request().Context(), composeId, ccb)
 		if err != nil {
 			return err
 		}
@@ -727,7 +727,7 @@ func (h *Handlers) GetCloneStatus(ctx echo.Context, id uuid.UUID) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Requested clone cannot be found")
 	}
 
-	resp, err := h.server.cClient.CloneStatus(ctx.Request().Context(), id)
+	resp, err := h.server.cClient.GetCloneStatus(ctx.Request().Context(), id)
 	if err != nil {
 		ctx.Logger().Errorf("Error requesting clone status for clone %v: %v", id, err)
 		return err

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -152,7 +152,7 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 		},
 	}
 
-	resp, err := h.server.cClient.Compose(ctx.Request().Context(), cloudCR)
+	resp, err := h.server.cClient.PostCompose(ctx.Request().Context(), cloudCR)
 	if err != nil {
 		return ComposeResponse{}, err
 	}

--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -31,7 +31,7 @@ import (
 
 type Server struct {
 	echo                *echo.Echo
-	cClient             *composer.ComposerClient
+	cClient             *composer.Client
 	pClient             *provisioning.ProvisioningClient
 	csClient            *content_sources.ContentSourcesClient
 	csReposURL          *url.URL
@@ -53,7 +53,7 @@ type Server struct {
 
 type ServerConfig struct {
 	EchoServer          *echo.Echo
-	CompClient          *composer.ComposerClient
+	CompClient          *composer.Client
 	ProvClient          *provisioning.ProvisioningClient
 	CSClient            *content_sources.ContentSourcesClient
 	CSReposURL          string

--- a/internal/v1/server_test.go
+++ b/internal/v1/server_test.go
@@ -134,7 +134,7 @@ func startServer(t *testing.T, tscc *testServerClientsConf, conf *v1.ServerConfi
 	}))
 
 	dummyTokener := &oauth2.DummyToken{}
-	compClient, err := composer.NewClient(composer.ComposerClientConfig{
+	compClient, err := composer.NewClientFromConfig(composer.ComposerClientConfig{
 		URL:     tscc.ComposerURL,
 		Tokener: dummyTokener,
 	})


### PR DESCRIPTION
I have always wondered why client code is not generated, this fixes it. It should be pretty stragithforward change for all other OAS3 clients (not onese which are OpenAPI 3.1). Review with care, things can go wild here.