### PR TITLE
v1: avoid returning null in blueprint lint section

### DIFF
--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -293,7 +293,7 @@ func (h *Handlers) GetBlueprint(ctx echo.Context, id openapi_types.UUID, params 
 }
 
 func (h *Handlers) lintBlueprint(ctx echo.Context, blueprint *BlueprintBody, fixup bool) ([]BlueprintLintItem, error) {
-	var lintErrors []BlueprintLintItem
+	lintErrors := []BlueprintLintItem{}
 	if blueprint.Customizations.Openscap != nil {
 		errs, err := h.lintOpenscap(ctx, blueprint, fixup)
 		if err != nil {


### PR DESCRIPTION
Uninitialized slices marshal into `null` instead of an empty array.