### PR TITLE
 v1: add hasPassword field to user

### DIFF
--- a/internal/common/testdata/exported_blueprint.json
+++ b/internal/common/testdata/exported_blueprint.json
@@ -25,7 +25,8 @@
     ],
     "users": [
       {
-        "name": "user"
+        "name": "user",
+        "hasPassword": true
       }
     ]
   },

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -1028,7 +1028,10 @@ type User struct {
 	// Groups List of groups to add the user to. The 'wheel' group should be added explicitly, as the
 	// default value is empty.
 	Groups *[]string `json:"groups,omitempty"`
-	Name   string    `json:"name"`
+
+	// HasPassword Indicates whether the user has a password set.
+	HasPassword *bool  `json:"hasPassword,omitempty"`
+	Name        string `json:"name"`
 
 	// Password Plaintext passwords are also supported, they will be hashed and stored using the SHA-512 algorithm.
 	// The password is never returned in the response.

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -2017,6 +2017,10 @@ components:
             Plaintext passwords are also supported, they will be hashed and stored using the SHA-512 algorithm.
             The password is never returned in the response.
             Empty string can be used to remove the password during update but only with ssh_key set.
+        hasPassword:
+          type: boolean
+          description: |
+            Indicates whether the user has a password set.
     Filesystem:
       type: object
       required:

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -54,6 +54,11 @@ func (u *User) CryptPassword() error {
 
 // Set password to nil if it is not nil
 func (u *User) RedactPassword() {
+	if u.Password != nil {
+		u.HasPassword = common.ToPtr(true)
+	} else {
+		u.HasPassword = common.ToPtr(false)
+	}
 	u.Password = nil
 }
 

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -723,6 +723,7 @@ func TestHandlers_BlueprintFromEntryWithRedactedPasswords(t *testing.T) {
 		result, err := v1.BlueprintFromEntryWithRedactedPasswords(be)
 		require.NoError(t, err)
 		require.NotEqual(t, common.ToPtr("foo"), (*result.Customizations.Users)[0].Password)
+		require.True(t, *(*result.Customizations.Users)[0].HasPassword)
 	})
 	t.Run("already hashed password", func(t *testing.T) {
 		body := []byte(`{"name": "Blueprint", "description": "desc", "customizations": {"users": [{"name": "user", "password": "$6$foo"}]}, "distribution": "centos-9"}`)
@@ -733,6 +734,7 @@ func TestHandlers_BlueprintFromEntryWithRedactedPasswords(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Nil(t, (*result.Customizations.Users)[0].Password)
+		require.True(t, *(*result.Customizations.Users)[0].HasPassword)
 	})
 }
 


### PR DESCRIPTION
The front-end needs to know whether or not a user has a password so that
it can correctly render the password input field in edit mode. If there
is no password, the field should be empty. If there is a password, a
placeholder similar to '********' will be displayed.