### PR TITLE
templates/image-builder: fix floorist query

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -200,9 +200,13 @@ objects:
           c.request->'customizations'->'payload_repositories' as payload_repositories,
           c.request->'customizations'->'openscap' as openscap,
           c.request->'customizations'->'files' as files,
-          c.request->'customizations'->'services' as services,
-          c.request->'customizations'->'locale' as locale,
-          c.request->'customizations'->'timezone' as timezone,
+          -- parquet doesn't deal well with empty objects
+          case when c.request->'customizations'->'services'='{}' then 'null'
+               else c.request->'customizations'->'services' end as services,
+          case when c.request->'customizations'->'locale'='{}' then 'null'
+               else c.request->'customizations'->'locale' end as locale,
+          case when c.request->'customizations'->'timezone'='{}' then 'null'
+               else c.request->'customizations'->'timezone' end as timezone,
           jsonb_array_length(c.request->'customizations'->'users') as num_users
         from
           composes c


### PR DESCRIPTION
Parquet doesn't deal well with empty objects:
```
Cannot write struct type 'timezone' with no child field to
Parquet. Consider adding a dummy child field.
```

Work around it by returning 'null' if all the fields in the objects are marked as optional.