### PR TITLE
renovate.json: fix syntax error

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "github>konflux-ci/mintmaker//config/renovate/renovate.json",
     "group:allNonMajor",
-    "schedule:earlyMondays",
+    "schedule:earlyMondays"
   ],
   "prConcurrentLimit": 3
 }


### PR DESCRIPTION
Fixes: https://github.com/osbuild/image-builder-crc/issues/1559