### PR TITLE
renovate.json: pin go version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,11 @@
   "extends": [
     "github>konflux-ci/mintmaker//config/renovate/renovate.json",
     "group:allNonMajor",
-    "schedule:earlyMondays"
+    "schedule:earlyMondays",
+    ":gomod"
   ],
-  "prConcurrentLimit": 3
+  "prConcurrentLimit": 3,
+  "constraints": {
+    "go": "1.22"
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "github>konflux-ci/mintmaker//config/renovate/renovate.json",
     "group:allNonMajor",
-    "schedule:earlyMondays",
+    "schedule:daily",
     ":gomod"
   ],
   "prConcurrentLimit": 3,


### PR DESCRIPTION
Currently the bot is trying to update the go version of the whole project (see #1562), but the max go version at any given time should be the one shipped in the ubi9 go-toolset container.