### PR TITLE
v1: use internally accessible baseurl for RH repo snapshot from template

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -568,7 +568,7 @@ func (h *Handlers) buildTemplateRepositories(ctx echo.Context, templateID string
 				return payloadRepositories, customRepositories, rhRepositories, fmt.Errorf("Returned snapshot %v unexpected repository id %v", *snap.Uuid, *snap.RepositoryUuid)
 			}
 			rhRepo := composer.Repository{
-				Baseurl:  snap.Url,
+				Baseurl:  common.ToPtr(h.server.csReposURL.JoinPath(h.server.csReposPrefix, *snap.RepositoryPath).String()),
 				Rhsm:     common.ToPtr(true),
 				Gpgkey:   repo.GpgKey,
 				CheckGpg: common.ToPtr(true),

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -2766,13 +2766,13 @@ func TestComposeCustomizations(t *testing.T) {
 					}),
 					Repositories: []composer.Repository{
 						{
-							Baseurl:  common.ToPtr("http://snappy-url/snappy/baseos"),
+							Baseurl:  common.ToPtr("https://content-sources.org/api/neat/template/snapshot1/base"),
 							Rhsm:     common.ToPtr(true),
 							Gpgkey:   common.ToPtr(mocks.RhelGPG),
 							CheckGpg: common.ToPtr(true),
 						},
 						{
-							Baseurl:  common.ToPtr("http://snappy-url/snappy/appstream"),
+							Baseurl:  common.ToPtr("https://content-sources.org/api/neat/template/snapshot1/appstream"),
 							Rhsm:     common.ToPtr(true),
 							Gpgkey:   common.ToPtr(mocks.RhelGPG),
 							CheckGpg: common.ToPtr(true),
@@ -2837,13 +2837,13 @@ func TestComposeCustomizations(t *testing.T) {
 					}),
 					Repositories: []composer.Repository{
 						{
-							Baseurl:  common.ToPtr("http://snappy-url/snappy/baseos"),
+							Baseurl:  common.ToPtr("https://content-sources.org/api/neat/template/snapshot2/base"),
 							Rhsm:     common.ToPtr(true),
 							Gpgkey:   common.ToPtr(mocks.RhelGPG),
 							CheckGpg: common.ToPtr(true),
 						},
 						{
-							Baseurl:  common.ToPtr("http://snappy-url/snappy/appstream"),
+							Baseurl:  common.ToPtr("https://content-sources.org/api/neat/template/snapshot2/appstream"),
 							Rhsm:     common.ToPtr(true),
 							Gpgkey:   common.ToPtr(mocks.RhelGPG),
 							CheckGpg: common.ToPtr(true),


### PR DESCRIPTION
We need to use the internal pulp URL for RH repo snapshots coming from a content template so composer can access it, otherwise we'll see errors reading the repository on image build