### PR TITLE
renovate.json: revert to weekly updates and edit grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,22 @@
 {
   "extends": [
     "github>konflux-ci/mintmaker//config/renovate/renovate.json",
-    "group:allNonMajor",
-    "schedule:daily",
-    ":gomod"
+    "schedule:earlyMondays"
   ],
   "prConcurrentLimit": 3,
-  "constraints": {
-    "go": "1.22"
-  }
+  "packageRules": [
+    {
+      "groupName": "go dependencies patch updates",
+      "groupSlug": "go-deps-patch",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Konflux only runs the go updater once per week on Sundays, so our schedule directive gets ignored anyway.

Only group patch updates because renovate will just update the go directive in go.mod whenever it sees fit, and we really need to ignore any updates to the go directive. This assumes that go or toolchain upgrades don't happen with patch upgrades.

---

Examples:
- https://github.com/croissanne/image-builder-crc/tree/konflux/mintmaker/main/gomod-patch grouping of patch updates
- minor upgrades: https://github.com/croissanne/image-builder-crc/tree/konflux/mintmaker/main/aws-sdk-go-v2-monorepo