### PR TITLE
v1: set rhsm to false for repo snapshots from template

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -569,7 +569,7 @@ func (h *Handlers) buildTemplateRepositories(ctx echo.Context, templateID string
 			}
 			rhRepo := composer.Repository{
 				Baseurl:  common.ToPtr(h.server.csReposURL.JoinPath(h.server.csReposPrefix, *snap.RepositoryPath).String()),
-				Rhsm:     common.ToPtr(true),
+				Rhsm:     common.ToPtr(false),
 				Gpgkey:   repo.GpgKey,
 				CheckGpg: common.ToPtr(true),
 			}

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -2767,13 +2767,13 @@ func TestComposeCustomizations(t *testing.T) {
 					Repositories: []composer.Repository{
 						{
 							Baseurl:  common.ToPtr("https://content-sources.org/api/neat/template/snapshot1/base"),
-							Rhsm:     common.ToPtr(true),
+							Rhsm:     common.ToPtr(false),
 							Gpgkey:   common.ToPtr(mocks.RhelGPG),
 							CheckGpg: common.ToPtr(true),
 						},
 						{
 							Baseurl:  common.ToPtr("https://content-sources.org/api/neat/template/snapshot1/appstream"),
-							Rhsm:     common.ToPtr(true),
+							Rhsm:     common.ToPtr(false),
 							Gpgkey:   common.ToPtr(mocks.RhelGPG),
 							CheckGpg: common.ToPtr(true),
 						},
@@ -2838,13 +2838,13 @@ func TestComposeCustomizations(t *testing.T) {
 					Repositories: []composer.Repository{
 						{
 							Baseurl:  common.ToPtr("https://content-sources.org/api/neat/template/snapshot2/base"),
-							Rhsm:     common.ToPtr(true),
+							Rhsm:     common.ToPtr(false),
 							Gpgkey:   common.ToPtr(mocks.RhelGPG),
 							CheckGpg: common.ToPtr(true),
 						},
 						{
 							Baseurl:  common.ToPtr("https://content-sources.org/api/neat/template/snapshot2/appstream"),
-							Rhsm:     common.ToPtr(true),
+							Rhsm:     common.ToPtr(false),
 							Gpgkey:   common.ToPtr(mocks.RhelGPG),
 							CheckGpg: common.ToPtr(true),
 						},


### PR DESCRIPTION
Sets RHSM to false for repository snapshots coming from a template. When set to true, the RHSM certs would be used instead of the service account certs which may have resulted in repository read errors when building an image with a template.