### PR TITLE
v1: upload request default values

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -783,8 +783,8 @@ type ImageRequest struct {
 	// be used. If no snapshots made before the specified date can be found, the snapshot
 	// closest to, but after the specified date will be used. If no snapshots can be found at
 	// all, the request will fail. The format must be YYYY-MM-DD (ISO 8601 extended).
-	SnapshotDate  *string       `json:"snapshot_date,omitempty"`
-	UploadRequest UploadRequest `json:"upload_request"`
+	SnapshotDate  *string        `json:"snapshot_date,omitempty"`
+	UploadRequest *UploadRequest `json:"upload_request,omitempty"`
 }
 
 // ImageRequestArchitecture CPU architecture of the image, x86_64 and aarch64 are currently supported.

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1215,18 +1215,22 @@ components:
       required:
         - architecture
         - image_type
-        - upload_request
       properties:
         architecture:
           type: string
           enum:
             - x86_64
             - aarch64
+          default: x86_64
           description: |
             CPU architecture of the image, x86_64 and aarch64 are currently supported.
         image_type:
           $ref: '#/components/schemas/ImageTypes'
         upload_request:
+          description: |
+            Upload request is optional. If not specified, the image will be
+            uploaded to the image builder S3 bucket and kept for several days for download.
+          nullable: true
           $ref: '#/components/schemas/UploadRequest'
         ostree:
           $ref: '#/components/schemas/OSTree'

--- a/internal/v1/defaults.go
+++ b/internal/v1/defaults.go
@@ -1,0 +1,35 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+var ErrMultipleUploadRequests = errors.New("multiple upload requests are not allowed")
+
+func imageRequestsDefaults(obj *[]ImageRequest) {
+	for i := range *obj {
+		if (*obj)[i].Architecture == "" {
+			(*obj)[i].Architecture = "x86_64"
+		}
+
+		if (*obj)[i].UploadRequest == nil {
+			(*obj)[i].UploadRequest = &UploadRequest{
+				Type: UploadTypesAwsS3,
+				Options: UploadRequest_Options{
+					union: json.RawMessage(`{"type": "aws.s3", "options": {}}`),
+				},
+			}
+		}
+	}
+}
+
+// BuildDefaults sets default values for the given field and checks for basic constraints.
+func (obj *ComposeRequest) BuildDefaults() {
+	imageRequestsDefaults(&obj.ImageRequests)
+}
+
+// BuildDefaults sets default values for the given field and checks for basic constraints.
+func (obj *CreateBlueprintRequest) BuildDefaults() {
+	imageRequestsDefaults(&obj.ImageRequests)
+}

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -178,6 +178,8 @@ func (h *Handlers) CreateBlueprint(ctx echo.Context) error {
 		return err
 	}
 
+	blueprintRequest.BuildDefaults()
+
 	var metadata []byte
 	if blueprintRequest.Metadata != nil {
 		metadata, err = json.Marshal(blueprintRequest.Metadata)
@@ -401,6 +403,8 @@ func (h *Handlers) UpdateBlueprint(ctx echo.Context, blueprintId uuid.UUID) erro
 	if err != nil {
 		return err
 	}
+
+	blueprintRequest.BuildDefaults()
 
 	if !blueprintNameRegex.MatchString(blueprintRequest.Name) {
 		return ctx.JSON(http.StatusUnprocessableEntity, HTTPErrorList{

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -75,9 +75,7 @@ func TestHandlers_CreateBlueprint(t *testing.T) {
 		"distribution": "centos-9",
 		"image_requests": []map[string]interface{}{
 			{
-				"architecture":     "x86_64",
 				"image_type":       "aws",
-				"upload_request":   map[string]interface{}{"type": "aws", "options": map[string]interface{}{"share_with_accounts": []string{"test-account"}}},
 				"content_template": mocks.TemplateID,
 			},
 		},
@@ -121,6 +119,10 @@ func TestHandlers_CreateBlueprint(t *testing.T) {
 	blueprintResp, err := v1.BlueprintFromEntry(be)
 	require.NoError(t, err)
 	require.Equal(t, *blueprintResp.ImageRequests[0].ContentTemplate, mocks.TemplateID)
+
+	// Test the default values
+	require.Equal(t, v1.ImageRequestArchitectureX8664, blueprintResp.ImageRequests[0].Architecture)
+	require.Equal(t, v1.UploadTypesAwsS3, blueprintResp.ImageRequests[0].UploadRequest.Type)
 }
 
 func TestUser_MergeForUpdate(t *testing.T) {
@@ -572,7 +574,7 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 			{
 				Architecture: v1.ImageRequestArchitectureX8664,
 				ImageType:    v1.ImageTypesAws,
-				UploadRequest: v1.UploadRequest{
+				UploadRequest: &v1.UploadRequest{
 					Type:    v1.UploadTypesAws,
 					Options: uploadOptions,
 				},
@@ -580,7 +582,7 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 			{
 				Architecture: v1.ImageRequestArchitectureAarch64,
 				ImageType:    v1.ImageTypesAws,
-				UploadRequest: v1.UploadRequest{
+				UploadRequest: &v1.UploadRequest{
 					Type:    v1.UploadTypesAws,
 					Options: uploadOptions,
 				},
@@ -588,7 +590,7 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 			{
 				Architecture: v1.ImageRequestArchitectureAarch64,
 				ImageType:    v1.ImageTypesGuestImage,
-				UploadRequest: v1.UploadRequest{
+				UploadRequest: &v1.UploadRequest{
 					Type:    v1.UploadTypesAwsS3,
 					Options: uploadOptions,
 				},
@@ -768,7 +770,7 @@ func TestHandlers_GetBlueprint(t *testing.T) {
 			{
 				Architecture: v1.ImageRequestArchitectureX8664,
 				ImageType:    v1.ImageTypesAws,
-				UploadRequest: v1.UploadRequest{
+				UploadRequest: &v1.UploadRequest{
 					Type:    v1.UploadTypesAws,
 					Options: uploadOptions,
 				},
@@ -776,7 +778,7 @@ func TestHandlers_GetBlueprint(t *testing.T) {
 			{
 				Architecture: v1.ImageRequestArchitectureAarch64,
 				ImageType:    v1.ImageTypesAws,
-				UploadRequest: v1.UploadRequest{
+				UploadRequest: &v1.UploadRequest{
 					Type:    v1.UploadTypesAws,
 					Options: uploadOptions,
 				},
@@ -955,7 +957,7 @@ func TestHandlers_ExportBlueprint(t *testing.T) {
 			{
 				Architecture: v1.ImageRequestArchitectureX8664,
 				ImageType:    v1.ImageTypesAws,
-				UploadRequest: v1.UploadRequest{
+				UploadRequest: &v1.UploadRequest{
 					Type:    v1.UploadTypesAws,
 					Options: uploadOptions,
 				},
@@ -964,7 +966,7 @@ func TestHandlers_ExportBlueprint(t *testing.T) {
 			{
 				Architecture: v1.ImageRequestArchitectureAarch64,
 				ImageType:    v1.ImageTypesAws,
-				UploadRequest: v1.UploadRequest{
+				UploadRequest: &v1.UploadRequest{
 					Type:    v1.UploadTypesAws,
 					Options: uploadOptions,
 				},

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -57,6 +57,8 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 		return ComposeResponse{}, echo.NewHTTPError(http.StatusBadRequest, "Exactly one upload request should be included")
 	}
 
+	composeRequest.BuildDefaults()
+
 	if composeRequest.ImageRequests[0].SnapshotDate != nil && composeRequest.ImageRequests[0].ContentTemplate != nil {
 		return ComposeResponse{}, echo.NewHTTPError(http.StatusBadRequest, "Either a snapshot date or content template can be specified, but not both")
 	}
@@ -580,7 +582,7 @@ func (h *Handlers) buildTemplateRepositories(ctx echo.Context, templateID string
 	return payloadRepositories, customRepositories, rhRepositories, nil
 }
 
-func (h *Handlers) buildUploadOptions(ctx echo.Context, ur UploadRequest, it ImageTypes) (composer.UploadOptions, composer.ImageTypes, error) {
+func (h *Handlers) buildUploadOptions(ctx echo.Context, ur *UploadRequest, it ImageTypes) (composer.UploadOptions, composer.ImageTypes, error) {
 	var uploadOptions composer.UploadOptions
 	switch ur.Type {
 	case UploadTypesAws:

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -49,7 +49,7 @@ func TestValidateComposeRequest(t *testing.T) {
 				{
 					Architecture: "x86_64",
 					ImageType:    v1.ImageTypesAws,
-					UploadRequest: v1.UploadRequest{
+					UploadRequest: &v1.UploadRequest{
 						Type:    v1.UploadTypesAws,
 						Options: uo,
 					},
@@ -57,7 +57,7 @@ func TestValidateComposeRequest(t *testing.T) {
 				{
 					Architecture: "x86_64",
 					ImageType:    v1.ImageTypesAmi,
-					UploadRequest: v1.UploadRequest{
+					UploadRequest: &v1.UploadRequest{
 						Type:    v1.UploadTypesAws,
 						Options: uo,
 					},
@@ -80,7 +80,7 @@ func TestValidateComposeRequest(t *testing.T) {
 				{
 					Architecture: "x86_64",
 					ImageType:    v1.ImageTypesAws,
-					UploadRequest: v1.UploadRequest{
+					UploadRequest: &v1.UploadRequest{
 						Type:    v1.UploadTypesAws,
 						Options: uo,
 					},
@@ -115,7 +115,7 @@ func TestValidateComposeRequest(t *testing.T) {
 		azureRequest := v1.ImageRequest{
 			Architecture: "x86_64",
 			ImageType:    v1.ImageTypesAzure,
-			UploadRequest: v1.UploadRequest{
+			UploadRequest: &v1.UploadRequest{
 				Type:    v1.UploadTypesAzure,
 				Options: auo,
 			},
@@ -157,7 +157,7 @@ func TestValidateComposeRequest(t *testing.T) {
 				{
 					Architecture:  "x86_64",
 					ImageType:     v1.ImageTypesAzure,
-					UploadRequest: v1.UploadRequest{},
+					UploadRequest: &v1.UploadRequest{},
 				},
 			},
 		}
@@ -182,7 +182,7 @@ func TestValidateComposeRequest(t *testing.T) {
 				{
 					Architecture: "unsupported-arch",
 					ImageType:    v1.ImageTypesAws,
-					UploadRequest: v1.UploadRequest{
+					UploadRequest: &v1.UploadRequest{
 						Type:    v1.UploadTypesAws,
 						Options: uo,
 					},
@@ -207,7 +207,7 @@ func TestValidateComposeRequest(t *testing.T) {
 				{
 					Architecture: "x86_64",
 					ImageType:    v1.ImageTypesAzure,
-					UploadRequest: v1.UploadRequest{
+					UploadRequest: &v1.UploadRequest{
 						Type:    "unknown",
 						Options: uo,
 					},
@@ -239,7 +239,7 @@ func TestValidateComposeRequest(t *testing.T) {
 				{
 					Architecture:  "x86_64",
 					ImageType:     v1.ImageTypesAmi,
-					UploadRequest: v1.UploadRequest{},
+					UploadRequest: &v1.UploadRequest{},
 				},
 			},
 		}
@@ -266,7 +266,7 @@ func TestValidateComposeRequest(t *testing.T) {
 		}
 		for _, it := range []v1.ImageTypes{v1.ImageTypesAmi, v1.ImageTypesAws} {
 			payload.ImageRequests[0].ImageType = it
-			payload.ImageRequests[0].UploadRequest = awsUr
+			payload.ImageRequests[0].UploadRequest = &awsUr
 			respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 			require.Equal(t, http.StatusBadRequest, respStatusCode)
 			require.Contains(t, body, fmt.Sprintf("Total AWS image size cannot exceed %d bytes", v1.FSMaxSize))
@@ -274,7 +274,7 @@ func TestValidateComposeRequest(t *testing.T) {
 
 		for _, it := range []v1.ImageTypes{v1.ImageTypesAzure, v1.ImageTypesVhd} {
 			payload.ImageRequests[0].ImageType = it
-			payload.ImageRequests[0].UploadRequest = azureUr
+			payload.ImageRequests[0].UploadRequest = &azureUr
 			respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 			require.Equal(t, http.StatusBadRequest, respStatusCode)
 			require.Contains(t, body, fmt.Sprintf("Total Azure image size cannot exceed %d bytes", v1.FSMaxSize))
@@ -290,7 +290,7 @@ func TestValidateComposeRequest(t *testing.T) {
 						Architecture:  "x86_64",
 						ImageType:     imgType,
 						Size:          imgSize,
-						UploadRequest: v1.UploadRequest{},
+						UploadRequest: &v1.UploadRequest{},
 					},
 				},
 			}
@@ -446,7 +446,7 @@ func TestComposeImageErrorsWhenStatusCodeIsNotStatusCreated(t *testing.T) {
 			{
 				Architecture: "x86_64",
 				ImageType:    v1.ImageTypesAws,
-				UploadRequest: v1.UploadRequest{
+				UploadRequest: &v1.UploadRequest{
 					Type:    v1.UploadTypesAws,
 					Options: uo,
 				},
@@ -496,7 +496,7 @@ func TestComposeImageErrorResolvingOSTree(t *testing.T) {
 				Ostree: &v1.OSTree{
 					Ref: common.ToPtr("edge/ref"),
 				},
-				UploadRequest: v1.UploadRequest{
+				UploadRequest: &v1.UploadRequest{
 					Type:    v1.UploadTypesAwsS3,
 					Options: uo,
 				},
@@ -537,7 +537,7 @@ func TestComposeImageErrorsWhenCannotParseResponse(t *testing.T) {
 			{
 				Architecture: "x86_64",
 				ImageType:    v1.ImageTypesAws,
-				UploadRequest: v1.UploadRequest{
+				UploadRequest: &v1.UploadRequest{
 					Type:    v1.UploadTypesAws,
 					Options: uo,
 				},
@@ -566,7 +566,7 @@ func TestComposeImageErrorsWhenDistributionNotExists(t *testing.T) {
 			{
 				Architecture: "x86_64",
 				ImageType:    v1.ImageTypesAws,
-				UploadRequest: v1.UploadRequest{
+				UploadRequest: &v1.UploadRequest{
 					Type:    v1.UploadTypesAws,
 					Options: uo,
 				},
@@ -609,7 +609,7 @@ func TestComposeImageReturnsIdWhenNoErrors(t *testing.T) {
 			{
 				Architecture: "x86_64",
 				ImageType:    v1.ImageTypesAws,
-				UploadRequest: v1.UploadRequest{
+				UploadRequest: &v1.UploadRequest{
 					Type:    v1.UploadTypesAws,
 					Options: uo,
 				},
@@ -659,7 +659,7 @@ func TestComposeImageAllowList(t *testing.T) {
 				{
 					Architecture: "x86_64",
 					ImageType:    v1.ImageTypesAws,
-					UploadRequest: v1.UploadRequest{
+					UploadRequest: &v1.UploadRequest{
 						Type:    v1.UploadTypesAws,
 						Options: uo,
 					},
@@ -747,7 +747,7 @@ func TestCompliancePolicyErrors(t *testing.T) {
 			{
 				Architecture: "x86_64",
 				ImageType:    v1.ImageTypesGuestImage,
-				UploadRequest: v1.UploadRequest{
+				UploadRequest: &v1.UploadRequest{
 					Type:    v1.UploadTypesAwsS3,
 					Options: uo,
 				},
@@ -823,7 +823,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
 						SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -872,7 +872,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
 						SnapshotDate: common.ToPtr("1999-01-30"),
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -921,7 +921,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
 						SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -1020,7 +1020,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
 						SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -1116,7 +1116,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
 						SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -1213,7 +1213,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGcp,
 						SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesGcp,
 							Options: uoGCP,
 						},
@@ -1323,7 +1323,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
 						SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -1605,7 +1605,7 @@ func TestComposeCustomizations(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesRhelEdgeInstaller,
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -1768,7 +1768,7 @@ func TestComposeCustomizations(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -1889,7 +1889,7 @@ func TestComposeCustomizations(t *testing.T) {
 							Parent:     common.ToPtr("test/edge/ref2"),
 							Rhsm:       common.ToPtr(true),
 						},
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -1971,7 +1971,7 @@ func TestComposeCustomizations(t *testing.T) {
 							Url:    common.ToPtr("https://ostree.srv/"),
 							Parent: common.ToPtr("test/edge/ref2"),
 						},
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAzure,
 							Options: auo,
 						},
@@ -2035,7 +2035,7 @@ func TestComposeCustomizations(t *testing.T) {
 							Url:    common.ToPtr("https://ostree.srv/"),
 							Parent: common.ToPtr("test/edge/ref2"),
 						},
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAzure,
 							Options: auo2,
 						},
@@ -2093,7 +2093,7 @@ func TestComposeCustomizations(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesAws,
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAws,
 							Options: ec2uo,
 						},
@@ -2144,7 +2144,7 @@ func TestComposeCustomizations(t *testing.T) {
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesAws,
 						Size:         common.ToPtr(uint64(13958643712)),
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAws,
 							Options: ec2uo,
 						},
@@ -2203,7 +2203,7 @@ func TestComposeCustomizations(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -2259,7 +2259,7 @@ func TestComposeCustomizations(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesOci,
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesOciObjectstorage,
 							Options: uo,
 						},
@@ -2314,7 +2314,7 @@ func TestComposeCustomizations(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -2388,7 +2388,7 @@ func TestComposeCustomizations(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -2474,7 +2474,7 @@ func TestComposeCustomizations(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -2545,7 +2545,7 @@ func TestComposeCustomizations(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -2608,7 +2608,7 @@ func TestComposeCustomizations(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -2667,7 +2667,7 @@ func TestComposeCustomizations(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -2728,7 +2728,7 @@ func TestComposeCustomizations(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},
@@ -2789,7 +2789,7 @@ func TestComposeCustomizations(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
-						UploadRequest: v1.UploadRequest{
+						UploadRequest: &v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
 						},


### PR DESCRIPTION
I noticed that the upload request must be always present and that API user must figure out that the cryptic `aws.s3` is what they want when building non-cloud images like `guest-image`.

This patch makes `x86_64` a default value upload request architecture and `aws.s3` for UR type. I am trying to set a standard for how to set default values by creating methods called `BuildDefaults` in a separate file to do that.

Whether to include the architecture is an open question, I just wanted to have two examples when working on this. Also the default value is somewhat weird, we might be able to use the default value of the image itself (and convert it to the proper CR architecture constant).

This is all for discussion, I do not feel strongly about all of this but I would love to start taking advantage of the OpenAPI default value feature so the API is more convenient to work with.