### PR TITLE
v1: allow users without pass/key (HMS-5993)

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -1029,7 +1029,7 @@ type User struct {
 	// default value is empty.
 	Groups *[]string `json:"groups,omitempty"`
 
-	// HasPassword Indicates whether the user has a password set.
+	// HasPassword Indicates whether the user has a password set. This flag is read-only.
 	HasPassword *bool  `json:"hasPassword,omitempty"`
 	Name        string `json:"name"`
 

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -2048,7 +2048,7 @@ components:
         hasPassword:
           type: boolean
           description: |
-            Indicates whether the user has a password set.
+            Indicates whether the user has a password set. This flag is read-only.
     Filesystem:
       type: object
       required:

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -91,13 +91,12 @@ func (u *User) MergeExisting(other User) {
 	}
 }
 
+var ErrMissingUserName = errors.New("missing user name")
+
 // User must have name and non-empty password or ssh key
 func (u *User) Valid() error {
-	validName := customizationUserNameRegex.MatchString(u.Name)
-	validPassword := u.Password != nil && len(*u.Password) > 0
-	validSshKey := u.SshKey != nil && len(*u.SshKey) > 0
-	if !validName || !(validPassword || validSshKey) {
-		return fmt.Errorf("user ('%s') must have a name and either a password or an SSH key set", u.Name)
+	if !customizationUserNameRegex.MatchString(u.Name) {
+		return ErrMissingUserName
 	}
 	return nil
 }


### PR DESCRIPTION
We want to allow creation of system users with `/sbin/nologin` shell.

Not sure how to link jiras so trying both what I have seen so far:

https://issues.redhat.com/browse/HMS-4181

/jira-epic HMS-4181

JIRA: [HMS-5993](https://issues.redhat.com/browse/HMS-5993)