### PR TITLE
v1: Add InsightsClientProxy to compose request (HMS-5992)

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -208,11 +208,12 @@ func main() {
 			Region: conf.OsbuildGCPRegion,
 			Bucket: conf.OsbuildGCPBucket,
 		},
-		QuotaFile:        conf.QuotaFile,
-		AllowFile:        conf.AllowFile,
-		AllDistros:       adr,
-		DistributionsDir: conf.DistributionsDir,
-		FedoraAuth:       conf.FedoraAuth,
+		QuotaFile:           conf.QuotaFile,
+		AllowFile:           conf.AllowFile,
+		AllDistros:          adr,
+		DistributionsDir:    conf.DistributionsDir,
+		FedoraAuth:          conf.FedoraAuth,
+		InsightsClientProxy: conf.InsightsClientProxy,
 	}
 
 	_, err = v1.Attach(serverConfig)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ type ImageBuilderConfig struct {
 	DeploymentChannel        string `env:"CHANNEL"`
 	UnleashURL               string `env:"UNLEASH_URL"`
 	UnleashToken             string `env:"UNLEASH_TOKEN"`
+	InsightsClientProxy      string `env:"INSIGHTS_CLIENT_PROXY"`
 }
 
 func (ibc *ImageBuilderConfig) IsDebug() bool {

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -976,7 +976,10 @@ type Subscription struct {
 	ActivationKey string `json:"activation-key"`
 	BaseUrl       string `json:"base-url"`
 	Insights      bool   `json:"insights"`
-	Organization  int    `json:"organization"`
+
+	// InsightsClientProxy Optional value to set proxy option when registering the system to Insights.
+	InsightsClientProxy *string `json:"insights_client_proxy,omitempty"`
+	Organization        int     `json:"organization"`
 
 	// Rhc Optional flag to use rhc to register the system, which also always enables Insights.
 	Rhc       *bool  `json:"rhc,omitempty"`

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -2097,6 +2097,11 @@ components:
           example: true
           description: |
             Optional flag to use rhc to register the system, which also always enables Insights.
+        insights_client_proxy:
+          type: string
+          format: uri
+          description: |
+            Optional value to set proxy option when registering the system to Insights.
     OpenSCAP:
       oneOf:
         - $ref: '#/components/schemas/OpenSCAPProfile'

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -828,12 +828,13 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 
 	if cust.Subscription != nil {
 		res.Subscription = &composer.Subscription{
-			ActivationKey: cust.Subscription.ActivationKey,
-			BaseUrl:       cust.Subscription.BaseUrl,
-			Insights:      cust.Subscription.Insights,
-			Rhc:           cust.Subscription.Rhc,
-			Organization:  fmt.Sprintf("%d", cust.Subscription.Organization),
-			ServerUrl:     cust.Subscription.ServerUrl,
+			ActivationKey:       cust.Subscription.ActivationKey,
+			BaseUrl:             cust.Subscription.BaseUrl,
+			Insights:            cust.Subscription.Insights,
+			Rhc:                 cust.Subscription.Rhc,
+			Organization:        fmt.Sprintf("%d", cust.Subscription.Organization),
+			ServerUrl:           cust.Subscription.ServerUrl,
+			InsightsClientProxy: &h.server.insightsClientProxy,
 		}
 	}
 

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -1866,7 +1866,8 @@ func TestComposeCustomizations(t *testing.T) {
 				Customizations: &v1.Customizations{
 					Packages: &[]string{"pkg"},
 					Subscription: &v1.Subscription{
-						Organization: 000,
+						Organization:        000,
+						InsightsClientProxy: common.ToPtr(""),
 					},
 					Fdo: &v1.FDO{
 						DiunPubKeyHash: common.ToPtr("hash"),
@@ -1903,12 +1904,13 @@ func TestComposeCustomizations(t *testing.T) {
 						"pkg",
 					},
 					Subscription: &composer.Subscription{
-						ActivationKey: "",
-						BaseUrl:       "",
-						Insights:      false,
-						Rhc:           common.ToPtr(false),
-						Organization:  "0",
-						ServerUrl:     "",
+						ActivationKey:       "",
+						BaseUrl:             "",
+						Insights:            false,
+						Rhc:                 common.ToPtr(false),
+						Organization:        "0",
+						ServerUrl:           "",
+						InsightsClientProxy: common.ToPtr(""),
 					},
 					Fdo: &composer.FDO{
 						DiunPubKeyHash: common.ToPtr("hash"),
@@ -2532,7 +2534,8 @@ func TestComposeCustomizations(t *testing.T) {
 			imageBuilderRequest: v1.ComposeRequest{
 				Customizations: &v1.Customizations{
 					Subscription: &v1.Subscription{
-						Insights: true,
+						Insights:            true,
+						InsightsClientProxy: common.ToPtr(""),
 					},
 					Openscap: &openscap,
 					Services: &v1.Services{
@@ -2556,12 +2559,13 @@ func TestComposeCustomizations(t *testing.T) {
 				Distribution: "rhel-8.10",
 				Customizations: &composer.Customizations{
 					Subscription: &composer.Subscription{
-						ActivationKey: "",
-						BaseUrl:       "",
-						Insights:      true,
-						Rhc:           common.ToPtr(false),
-						Organization:  "0",
-						ServerUrl:     "",
+						ActivationKey:       "",
+						BaseUrl:             "",
+						Insights:            true,
+						Rhc:                 common.ToPtr(false),
+						Organization:        "0",
+						ServerUrl:           "",
+						InsightsClientProxy: common.ToPtr(""),
 					},
 					Openscap: &composer.OpenSCAP{
 						ProfileId: "test-profile",
@@ -2619,12 +2623,13 @@ func TestComposeCustomizations(t *testing.T) {
 				Distribution: "rhel-8.10",
 				Customizations: &composer.Customizations{
 					Subscription: &composer.Subscription{
-						ActivationKey: "",
-						BaseUrl:       "",
-						Insights:      true,
-						Rhc:           common.ToPtr(false),
-						Organization:  "0",
-						ServerUrl:     "",
+						ActivationKey:       "",
+						BaseUrl:             "",
+						Insights:            true,
+						Rhc:                 common.ToPtr(false),
+						Organization:        "0",
+						ServerUrl:           "",
+						InsightsClientProxy: common.ToPtr(""),
 					},
 					Openscap: &composer.OpenSCAP{
 						ProfileId: "test-profile",

--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -30,43 +30,45 @@ import (
 )
 
 type Server struct {
-	echo             *echo.Echo
-	cClient          *composer.ComposerClient
-	pClient          *provisioning.ProvisioningClient
-	csClient         *content_sources.ContentSourcesClient
-	csReposURL       *url.URL
-	csReposPrefix    string
-	rClient          *recommendations.RecommendationsClient
-	complianceClient *compliance.ComplianceClient
-	spec             *openapi3.T
-	router           routers.Router
-	db               db.DB
-	aws              AWSConfig
-	gcp              GCPConfig
-	quotaFile        string
-	allowList        common.AllowList
-	allDistros       *distribution.AllDistroRegistry
-	distributionsDir string
-	fedoraAuth       bool
+	echo                *echo.Echo
+	cClient             *composer.ComposerClient
+	pClient             *provisioning.ProvisioningClient
+	csClient            *content_sources.ContentSourcesClient
+	csReposURL          *url.URL
+	csReposPrefix       string
+	rClient             *recommendations.RecommendationsClient
+	complianceClient    *compliance.ComplianceClient
+	spec                *openapi3.T
+	router              routers.Router
+	db                  db.DB
+	aws                 AWSConfig
+	gcp                 GCPConfig
+	quotaFile           string
+	allowList           common.AllowList
+	allDistros          *distribution.AllDistroRegistry
+	distributionsDir    string
+	fedoraAuth          bool
+	insightsClientProxy string
 }
 
 type ServerConfig struct {
-	EchoServer       *echo.Echo
-	CompClient       *composer.ComposerClient
-	ProvClient       *provisioning.ProvisioningClient
-	CSClient         *content_sources.ContentSourcesClient
-	CSReposURL       string
-	CSReposPrefix    string
-	RecommendClient  *recommendations.RecommendationsClient
-	ComplianceClient *compliance.ComplianceClient
-	DBase            db.DB
-	AwsConfig        AWSConfig
-	GcpConfig        GCPConfig
-	QuotaFile        string
-	AllowFile        string
-	AllDistros       *distribution.AllDistroRegistry
-	DistributionsDir string
-	FedoraAuth       bool
+	EchoServer          *echo.Echo
+	CompClient          *composer.ComposerClient
+	ProvClient          *provisioning.ProvisioningClient
+	CSClient            *content_sources.ContentSourcesClient
+	CSReposURL          string
+	CSReposPrefix       string
+	RecommendClient     *recommendations.RecommendationsClient
+	ComplianceClient    *compliance.ComplianceClient
+	DBase               db.DB
+	AwsConfig           AWSConfig
+	GcpConfig           GCPConfig
+	QuotaFile           string
+	AllowFile           string
+	AllDistros          *distribution.AllDistroRegistry
+	DistributionsDir    string
+	FedoraAuth          bool
+	InsightsClientProxy string
 }
 
 type AWSConfig struct {
@@ -124,6 +126,7 @@ func Attach(conf *ServerConfig) (*Server, error) {
 		conf.AllDistros,
 		conf.DistributionsDir,
 		conf.FedoraAuth,
+		conf.InsightsClientProxy,
 	}
 	var h Handlers
 	h.server = &s

--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -134,6 +134,8 @@ objects:
                 optional: true
           - name: CHANNEL
             value: ${CHANNEL}
+          - name: INSIGHTS_CLIENT_PROXY
+            value: ${INSIGHTS_CLIENT_PROXY}
         volumeMounts:
           - name: config-volume
             mountPath: /app/config
@@ -340,4 +342,6 @@ parameters:
       Channel where this pod is deployed.
       This is appended to the logs. Usually something like
       "local", "staging" or "production".
+  - name: INSIGHTS_CLIENT_PROXY
+    value: ""
 


### PR DESCRIPTION
Value of the environment variable INSIGHTS_CLIENT_PROXY is passed along to composer. Depends on this work: https://github.com/osbuild/osbuild-composer/pull/4672

Feedback welcome and appreciated :)



JIRA: [HMS-5992](https://issues.redhat.com/browse/HMS-5992)