### PR TITLE
v1: omit empty payload repos from compose request

### DIFF
--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -2720,7 +2720,7 @@ func TestComposeCustomizations(t *testing.T) {
 				},
 			},
 		},
-		// content template with 1 custom repository
+		// content template with 1 custom repository and 2 Red Hat repositories
 		{
 			imageBuilderRequest: v1.ComposeRequest{
 				Distribution: "rhel-95",
@@ -2772,7 +2772,7 @@ func TestComposeCustomizations(t *testing.T) {
 				},
 			},
 		},
-		// content template with 2 custom repositories
+		// content template with 2 custom repositories and 2 Red Hat repositories
 		{
 			imageBuilderRequest: v1.ComposeRequest{
 				Distribution: "rhel-95",
@@ -2804,6 +2804,47 @@ func TestComposeCustomizations(t *testing.T) {
 						},
 					},
 				},
+				Distribution: "rhel-9.5",
+				ImageRequest: &composer.ImageRequest{
+					Architecture: "x86_64",
+					ImageType:    composer.ImageTypesGuestImage,
+					UploadOptions: makeUploadOptions(t, composer.AWSS3UploadOptions{
+						Region: "",
+					}),
+					Repositories: []composer.Repository{
+						{
+							Baseurl:  common.ToPtr("https://content-sources.org/api/neat/template/snapshot2/base"),
+							Rhsm:     common.ToPtr(false),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+							CheckGpg: common.ToPtr(true),
+						},
+						{
+							Baseurl:  common.ToPtr("https://content-sources.org/api/neat/template/snapshot2/appstream"),
+							Rhsm:     common.ToPtr(false),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+							CheckGpg: common.ToPtr(true),
+						},
+					},
+				},
+			},
+		},
+		// content template with 0 custom repositories, only Red Hat repos
+		{
+			imageBuilderRequest: v1.ComposeRequest{
+				Distribution: "rhel-95",
+				ImageRequests: []v1.ImageRequest{
+					{
+						Architecture: "x86_64",
+						ImageType:    v1.ImageTypesGuestImage,
+						UploadRequest: v1.UploadRequest{
+							Type:    v1.UploadTypesAwsS3,
+							Options: uo,
+						},
+						ContentTemplate: common.ToPtr(mocks.TemplateID3),
+					},
+				},
+			},
+			composerRequest: composer.ComposeRequest{
 				Distribution: "rhel-9.5",
 				ImageRequest: &composer.ImageRequest{
 					Architecture: "x86_64",

--- a/internal/v1/mocks/content_sources.go
+++ b/internal/v1/mocks/content_sources.go
@@ -26,6 +26,7 @@ const (
 	RepoUplID        = "7fa07d5a-3df4-4c83-bfe3-79633a0ad27d"
 	TemplateID       = "267232b1-d5af-467f-b6c0-2b502fa02d3d"
 	TemplateID2      = "f3203472-e8ed-4d52-8a98-0e9905e91953"
+	TemplateID3      = "71c14af2-2970-4c0d-a60c-a2ab1247cec6"
 	SnapshotID       = "6161fd44-ade8-4300-882b-ede6d65ee56e"
 	SnapshotID2      = "470f9dfa-10dd-4d70-aacb-96ba9a3d9f06"
 	SnapshotBaseID   = "fb1551cc-706d-4fb5-bd14-4a29e7aeef3a"
@@ -271,7 +272,29 @@ func templateByID(uuid string) (res content_sources.ApiTemplateResponse) {
 				},
 			},
 		}
+	} else if uuid == TemplateID3 {
+		res = content_sources.ApiTemplateResponse{
+			Uuid:            common.ToPtr(uuid),
+			Name:            common.ToPtr("template3"),
+			RepositoryUuids: common.ToPtr([]string{RepoBaseID, RepoAppstrID}),
+			Date:            common.ToPtr("2000-01-30T00:00:00Z"),
+			Snapshots: &[]content_sources.ApiSnapshotResponse{
+				{
+					Uuid:           common.ToPtr(SnapshotBaseID),
+					RepositoryUuid: common.ToPtr(RepoBaseID),
+					RepositoryPath: common.ToPtr("/template/snapshot2/base"),
+					Url:            common.ToPtr("http://snappy-url/snappy/baseos"),
+				},
+				{
+					Uuid:           common.ToPtr(SnapshotAppstrID),
+					RepositoryUuid: common.ToPtr(RepoAppstrID),
+					RepositoryPath: common.ToPtr("/template/snapshot2/appstream"),
+					Url:            common.ToPtr("http://snappy-url/snappy/appstream"),
+				},
+			},
+		}
 	}
+
 	return res
 }
 


### PR DESCRIPTION
Similar to this [PR](https://github.com/osbuild/image-builder-crc/pull/1578), if we build an image with a template that has no custom repositories, the payload repositories will be empty so we need to omit them correctly from the compose request.