### PR TITLE
v1: send template uuid/name in compose request (HMS-6297)

### DIFF
--- a/internal/clients/composer/openapi.v2.gen.go
+++ b/internal/clients/composer/openapi.v2.gen.go
@@ -1386,6 +1386,12 @@ type Subscription struct {
 	// Rhc Optional flag to use rhc to register the system, which also always enables Insights.
 	Rhc       *bool  `json:"rhc,omitempty"`
 	ServerUrl string `json:"server_url"`
+
+	// TemplateName Optional value to register with a template when using rhc to register the system with Insights.
+	TemplateName *string `json:"template_name,omitempty"`
+
+	// TemplateUuid Optional value to register with a template when registering the system with Insights.
+	TemplateUuid *string `json:"template_uuid,omitempty"`
 }
 
 // Timezone Timezone configuration

--- a/internal/clients/composer/openapi.v2.yml
+++ b/internal/clients/composer/openapi.v2.yml
@@ -2229,6 +2229,14 @@ components:
           format: uri
           description: |
             Optional value to set proxy option when registering the system to Insights
+        template_uuid:
+          type: string
+          description: |
+            Optional value to register with a template when registering the system with Insights.
+        template_name:
+          type: string
+          description: |
+            Optional value to register with a template when using rhc to register the system with Insights.
     User:
       type: object
       additionalProperties: false

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -784,9 +784,12 @@ type ImageRequest struct {
 
 	// ContentTemplate ID of the content template. A content template and snapshot date cannot both be specified.
 	// If a content template is specified, the snapshot date used will be the one from the content template.
-	ContentTemplate *string    `json:"content_template,omitempty"`
-	ImageType       ImageTypes `json:"image_type"`
-	Ostree          *OSTree    `json:"ostree,omitempty"`
+	ContentTemplate *string `json:"content_template,omitempty"`
+
+	// ContentTemplateName Name of the content template. Used when registering the system to Insights.
+	ContentTemplateName *string    `json:"content_template_name,omitempty"`
+	ImageType           ImageTypes `json:"image_type"`
+	Ostree              *OSTree    `json:"ostree,omitempty"`
 
 	// Size Size of image, in bytes. When set to 0 the image size is a minimum
 	// defined by the image type.

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1254,6 +1254,10 @@ components:
           description: |
             ID of the content template. A content template and snapshot date cannot both be specified.
             If a content template is specified, the snapshot date used will be the one from the content template.
+        content_template_name:
+          type: string
+          description: |
+            Name of the content template. Used when registering the system to Insights.
         aap_registration:
           $ref: '#/components/schemas/AAPRegistration'
     ImageTypes:

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -839,6 +839,18 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 			ServerUrl:           cust.Subscription.ServerUrl,
 			InsightsClientProxy: &h.server.insightsClientProxy,
 		}
+
+		if d != nil && cr.ImageRequests[0].ContentTemplate != nil {
+			major, minor, err := d.RHELMajorMinor()
+			if err != nil {
+				return nil, err
+			}
+			if (major >= 9 && minor >= 6) && cr.ImageRequests[0].ContentTemplateName != nil {
+				res.Subscription.TemplateName = cr.ImageRequests[0].ContentTemplateName
+			} else {
+				res.Subscription.TemplateUuid = cr.ImageRequests[0].ContentTemplate
+			}
+		}
 	}
 
 	if cust.Packages != nil {

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -2892,6 +2892,9 @@ func TestComposeCustomizations(t *testing.T) {
 							Id:       mocks.RepoPLID,
 						},
 					},
+					Subscription: &v1.Subscription{
+						Insights: true,
+					},
 				},
 				ImageRequests: []v1.ImageRequest{
 					{
@@ -2905,6 +2908,7 @@ func TestComposeCustomizations(t *testing.T) {
 					},
 				},
 			},
+			// content template with 2 rhel repos with registration
 			composerRequest: composer.ComposeRequest{
 				Customizations: &composer.Customizations{
 					CustomRepositories: nil,
@@ -2915,6 +2919,16 @@ func TestComposeCustomizations(t *testing.T) {
 							Gpgkey:   common.ToPtr("some-gpg-key"),
 							Rhsm:     common.ToPtr(false),
 						},
+					},
+					Subscription: &composer.Subscription{
+						ActivationKey:       "",
+						BaseUrl:             "",
+						Insights:            true,
+						Rhc:                 common.ToPtr(false),
+						Organization:        "0",
+						ServerUrl:           "",
+						InsightsClientProxy: common.ToPtr(""),
+						TemplateUuid:        common.ToPtr(mocks.TemplateID),
 					},
 				},
 				Distribution: "rhel-9.5",


### PR DESCRIPTION
If a template is being used, the template name or UUID is sent in the compose request for system registration. If the RHEL version is >= 9.6, the name is used for registration. Any older version uses the UUID for registration.

JIRA: [HMS-6297](https://issues.redhat.com/browse/HMS-6297)