### PR TITLE
oscap: add missing rhel9 and rhel10 distros

### DIFF
--- a/internal/v1/handler_oscap.go
+++ b/internal/v1/handler_oscap.go
@@ -67,6 +67,10 @@ func OscapProfiles(distribution Distributions) (DistributionProfileResponse, err
 		fallthrough
 	case Rhel94:
 		fallthrough
+	case Rhel95:
+		fallthrough
+	case Rhel96:
+		fallthrough
 	case Rhel96Nightly:
 		fallthrough
 	case Rhel97Nightly:

--- a/internal/v1/handler_oscap.go
+++ b/internal/v1/handler_oscap.go
@@ -97,6 +97,32 @@ func OscapProfiles(distribution Distributions) (DistributionProfileResponse, err
 			XccdfOrgSsgprojectContentProfileStig,
 			XccdfOrgSsgprojectContentProfileStigGui,
 		}, nil
+	case Rhel100:
+		fallthrough
+	case Rhel10Nightly:
+		fallthrough
+	case Rhel100Nightly:
+		fallthrough
+	case Rhel101Nightly:
+		fallthrough
+	case Rhel10:
+		return DistributionProfileResponse{
+			XccdfOrgSsgprojectContentProfileAnssiBp28Enhanced,
+			XccdfOrgSsgprojectContentProfileAnssiBp28High,
+			XccdfOrgSsgprojectContentProfileAnssiBp28Intermediary,
+			XccdfOrgSsgprojectContentProfileAnssiBp28Minimal,
+			XccdfOrgSsgprojectContentProfileCis,
+			XccdfOrgSsgprojectContentProfileCisServerL1,
+			XccdfOrgSsgprojectContentProfileCisWorkstationL1,
+			XccdfOrgSsgprojectContentProfileCisWorkstationL2,
+			XccdfOrgSsgprojectContentProfileE8,
+			XccdfOrgSsgprojectContentProfileHipaa,
+			XccdfOrgSsgprojectContentProfileIsmO,
+			XccdfOrgSsgprojectContentProfilePciDss,
+			XccdfOrgSsgprojectContentProfileStig,
+			XccdfOrgSsgprojectContentProfileStigGui,
+		}, nil
+
 	case Rhel90:
 		fallthrough
 	default:


### PR DESCRIPTION
Enable oscap customizations for some missing rhel9 distros and for rhel10