### PR TITLE
v1: aap service file missing header

### DIFF
--- a/internal/tmpl/aap-first-boot.tmpl.service
+++ b/internal/tmpl/aap-first-boot.tmpl.service
@@ -1,3 +1,4 @@
+[Unit]
 Description=Ansible Automations Platform first boot registration
 ConditionFileIsExecutable=/usr/local/sbin/aap-first-boot-reg
 ConditionPathExists=!/var/local/.aap-first-boot-reg-done

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -2982,7 +2982,8 @@ func TestComposeCustomizations(t *testing.T) {
 							EnsureParents: common.ToPtr(true),
 						},
 						{
-							Data: common.ToPtr(`Description=Ansible Automations Platform first boot registration
+							Data: common.ToPtr(`[Unit]
+Description=Ansible Automations Platform first boot registration
 ConditionFileIsExecutable=/usr/local/sbin/aap-first-boot-reg
 ConditionPathExists=!/var/local/.aap-first-boot-reg-done
 Wants=network-online.target


### PR DESCRIPTION
There was a copy & paste error and the `[Unit]` header was missing from the service file.