### PR TITLE
v1: app change aap controller url example

### DIFF
--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1483,7 +1483,7 @@ components:
       properties:
         ansible_controller_url:
           type: string
-          example: "example.towerhost.net"
+          example: "https://aap-gw.example.com"
         job_template_id:
           type: integer
           example: 38


### PR DESCRIPTION
This is a minor fix but the example uses a hostname and not the full url.