### PR TITLE
v1: pass template name in compose request for RHEL 10

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -845,7 +845,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 			if err != nil {
 				return nil, err
 			}
-			if (major >= 9 && minor >= 6) && cr.ImageRequests[0].ContentTemplateName != nil {
+			if ((major >= 9 && minor >= 6) || (major >= 10)) && cr.ImageRequests[0].ContentTemplateName != nil {
 				res.Subscription.TemplateName = cr.ImageRequests[0].ContentTemplateName
 			} else {
 				res.Subscription.TemplateUuid = cr.ImageRequests[0].ContentTemplate


### PR DESCRIPTION
This fixes a small issue the registering on boot for RHEL 10, when building from a template. When registering to insights, systems buit with RHEL 10 images (or higher) must use the template name.