### PR TITLE
Add distribution field to recommendation request and response models

### DIFF
--- a/internal/clients/recommendations/openapi.v3.gen.go
+++ b/internal/clients/recommendations/openapi.v3.gen.go
@@ -10,13 +10,15 @@ type GetModelVersion200Response struct {
 
 // RecommendPackageRequest defines model for RecommendPackageRequest.
 type RecommendPackageRequest struct {
+	Distribution        string   `json:"distribution"`
 	Packages            []string `json:"packages"`
 	RecommendedPackages int32    `json:"recommendedPackages"`
 }
 
 // RecommendationsResponse defines model for RecommendationsResponse.
 type RecommendationsResponse struct {
-	Packages []string `json:"packages"`
+	ModelVersion string   `json:"modelVersion"`
+	Packages     []string `json:"packages"`
 }
 
 // RefreshModel200Response defines model for RefreshModel200Response.

--- a/internal/clients/recommendations/recommendations.v3.json
+++ b/internal/clients/recommendations/recommendations.v3.json
@@ -92,6 +92,7 @@
     "schemas": {
       "RecommendationsResponse": {
         "required": [
+          "modelVersion",
           "packages"
         ],
         "type": "object",
@@ -101,11 +102,15 @@
             "items": {
               "type": "string"
             }
+          },
+          "modelVersion": {
+            "type": "string"
           }
         }
       },
       "RecommendPackageRequest": {
         "required": [
+          "distribution",
           "packages",
           "recommendedPackages"
         ],
@@ -120,6 +125,9 @@
           "recommendedPackages": {
             "type": "integer",
             "format": "int32"
+          },
+          "distribution": {
+            "type": "string"
           }
         }
       },

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -948,13 +948,19 @@ type Readiness struct {
 
 // RecommendPackageRequest defines model for RecommendPackageRequest.
 type RecommendPackageRequest struct {
-	Packages            []string `json:"packages"`
-	RecommendedPackages int32    `json:"recommendedPackages"`
+	// Distribution List of all distributions that image builder supports. A user might not have access to
+	// restricted distributions.
+	//
+	// Restricted distributions include the RHEL nightlies and the Fedora distributions.
+	Distribution        Distributions `json:"distribution"`
+	Packages            []string      `json:"packages"`
+	RecommendedPackages int32         `json:"recommendedPackages"`
 }
 
 // RecommendationsResponse defines model for RecommendationsResponse.
 type RecommendationsResponse struct {
-	Packages []string `json:"packages"`
+	ModelVersion *string  `json:"modelVersion,omitempty"`
+	Packages     []string `json:"packages"`
 }
 
 // Repository defines model for Repository.

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1557,6 +1557,7 @@ components:
       required:
         - packages
         - recommendedPackages
+        - distribution
       type: object
       properties:
         packages:
@@ -1567,6 +1568,8 @@ components:
           type: integer
           format: int32
           default: 3
+        distribution:
+          $ref: '#/components/schemas/Distributions'
     RecommendationsResponse:
       required:
         - packages
@@ -1576,6 +1579,8 @@ components:
           type: array
           items:
             type: string
+        modelVersion:
+          type: string
     ClonesResponse:
       required:
         - meta

--- a/internal/v1/api_distributions.go
+++ b/internal/v1/api_distributions.go
@@ -1,0 +1,5 @@
+package v1
+
+func (d Distributions) String() string {
+	return string(d)
+}

--- a/internal/v1/handler_recommend_package_test.go
+++ b/internal/v1/handler_recommend_package_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -13,18 +12,19 @@ import (
 	v1 "github.com/osbuild/image-builder-crc/internal/v1"
 )
 
-func TestRecommendPackage_Success_with_StatusForbidden(t *testing.T) {
+func TestRecommendPackage(t *testing.T) {
 	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") == "Bearer" {
-			w.WriteHeader(http.StatusForbidden)
-			return
-		}
-		require.Equal(t, "", r.Header.Get("Authorization"))
+		require.Equal(t, "Bearer accesstoken", r.Header.Get("Authorization"))
+
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
+		w.WriteHeader(http.StatusOK)
+
 		result := v1.RecommendationsResponse{
-			Packages: []string{"vim", "python"},
+			Packages: []string{
+				"recommended1",
+			},
 		}
+
 		err := json.NewEncoder(w).Encode(result)
 		require.NoError(t, err)
 	}))
@@ -32,196 +32,24 @@ func TestRecommendPackage_Success_with_StatusForbidden(t *testing.T) {
 
 	srv := startServer(t, &testServerClientsConf{RecommendURL: apiSrv.URL}, &v1.ServerConfig{})
 	defer srv.Shutdown(t)
-	payload := v1.RecommendPackageRequest{
-		Packages: []string{
-			"some",
-			"packages",
-		},
-		RecommendedPackages: func() int32 {
-			recommendedPackages := int32(3)
-			return recommendedPackages
-		}(),
-	}
-	respStatusCode, body := tutils.PostResponseBody(t, apiSrv.URL+"/", payload)
-	require.Equal(t, http.StatusCreated, respStatusCode)
-	var result v1.RecommendationsResponse
-	expectedResult := v1.RecommendationsResponse{
-		Packages: []string{"vim", "python"},
-	}
-	err := json.Unmarshal([]byte(body), &result)
-	require.NoError(t, err)
-	require.Equal(t, expectedResult, result)
-}
 
-func TestRecommendPackage_Success_with_StatusUnauthorized(t *testing.T) {
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") == "Bearer" {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		require.Equal(t, "", r.Header.Get("Authorization"))
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		result := v1.RecommendationsResponse{
-			Packages: []string{"vim", "python"},
-		}
-		err := json.NewEncoder(w).Encode(result)
-		require.NoError(t, err)
-	}))
-	defer apiSrv.Close()
-
-	srv := startServer(t, &testServerClientsConf{RecommendURL: apiSrv.URL}, &v1.ServerConfig{})
-	defer srv.Shutdown(t)
-	payload := v1.RecommendPackageRequest{
-		Packages: []string{
-			"some",
-			"packages",
-		},
-		RecommendedPackages: func() int32 {
-			recommendedPackages := int32(3)
-			return recommendedPackages
-		}(),
-	}
-
-	respStatusCode, body := tutils.PostResponseBody(t, apiSrv.URL+"/", payload)
-	require.Equal(t, http.StatusCreated, respStatusCode)
-	var result v1.RecommendationsResponse
-	expectedResult := v1.RecommendationsResponse{
-		Packages: []string{"vim", "python"},
-	}
-	err := json.Unmarshal([]byte(body), &result)
-	require.NoError(t, err)
-	require.Equal(t, expectedResult, result)
-}
-
-func TestRecommendPackage_Success_with_no_packages(t *testing.T) {
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") == "Bearer" {
-			w.WriteHeader(http.StatusForbidden)
-			return
-		}
-
-		require.Equal(t, "", r.Header.Get("Authorization"))
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		var result v1.RecommendationsResponse
-		err := json.NewEncoder(w).Encode(result)
-		require.NoError(t, err)
-	}))
-	defer apiSrv.Close()
-
-	srv := startServer(t, &testServerClientsConf{RecommendURL: apiSrv.URL}, &v1.ServerConfig{})
-	defer srv.Shutdown(t)
-	payload := v1.RecommendPackageRequest{
-		Packages: []string{
-			"some",
-			"packages",
-		},
-		RecommendedPackages: func() int32 {
-			recommendedPackages := int32(3)
-			return recommendedPackages
-		}(),
-	}
-	respStatusCode, body := tutils.PostResponseBody(t, apiSrv.URL+"/", payload)
-	require.Equal(t, http.StatusCreated, respStatusCode)
-	var result v1.RecommendationsResponse
-	expectedResult := v1.RecommendationsResponse{
-		Packages: nil,
-	}
-	err := json.Unmarshal([]byte(body), &result)
-	require.NoError(t, err)
-	require.Equal(t, expectedResult, result)
-}
-
-func TestRecommendPackage_Success_with_packages(t *testing.T) {
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") == "Bearer" {
-			w.WriteHeader(http.StatusForbidden)
-			return
-		}
-
-		require.Equal(t, "", r.Header.Get("Authorization"))
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		result := v1.RecommendationsResponse{
-			Packages: []string{"vim", "python"},
-		}
-		err := json.NewEncoder(w).Encode(result)
-		require.NoError(t, err)
-	}))
-	defer apiSrv.Close()
-
-	srv := startServer(t, &testServerClientsConf{RecommendURL: apiSrv.URL}, &v1.ServerConfig{})
-	defer srv.Shutdown(t)
-	payload := v1.RecommendPackageRequest{
-		Packages: []string{
-			"some",
-			"packages",
-		},
-		RecommendedPackages: func() int32 {
-			recommendedPackages := int32(3)
-			return recommendedPackages
-		}(),
-	}
-	respStatusCode, body := tutils.PostResponseBody(t, apiSrv.URL+"/", payload)
-	require.Equal(t, http.StatusCreated, respStatusCode)
-	var result v1.RecommendationsResponse
-	expectedResult := v1.RecommendationsResponse{
-		Packages: []string{"vim", "python"},
-	}
-	err := json.Unmarshal([]byte(body), &result)
-	require.NoError(t, err)
-	require.Equal(t, expectedResult, result)
-}
-
-func TestRecommendPackage_with_authenticationServer(t *testing.T) {
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		result := v1.RecommendationsResponse{
-			Packages: []string{"vim", "python"},
-		}
-		err := json.NewEncoder(w).Encode(result)
-		require.NoError(t, err)
-		require.Equal(t, "Bearer dog_token", r.Header.Get("Authorization"))
-	}))
-	defer apiSrv.Close()
-
-	oauthMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.NoError(t, r.ParseForm())
-		require.Equal(t, "client_credentials", r.PostForm.Get("grant_type"))
-		require.Equal(t, "secret", r.PostForm.Get("client_secret"))
-		require.Equal(t, "id", r.PostForm.Get("client_id"))
-
-		err := json.NewEncoder(w).Encode(struct {
-			AccessToken string    `json:"access_token"`
-			Expiration  time.Time `json:"expiration"`
-		}{
-			AccessToken: "dog_token",
-			Expiration:  time.Now().Add(time.Hour),
-		})
-
-		require.NoError(t, err)
-	}))
-	defer oauthMock.Close()
-
-	srv := startServer(t, &testServerClientsConf{RecommendURL: apiSrv.URL, OAuthURL: oauthMock.URL}, &v1.ServerConfig{})
-	defer srv.Shutdown(t)
 	payload := v1.RecommendPackageRequest{
 		Distribution: "rhel-8",
 		Packages: []string{
 			"some",
 			"packages",
 		},
-		RecommendedPackages: func() int32 {
-			recommendedPackages := int32(3)
-			return recommendedPackages
-		}(),
+		RecommendedPackages: 1,
 	}
-	respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/experimental/recommendations", payload)
-	require.Equal(t, http.StatusOK, respStatusCode)
+
+	code, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/experimental/recommendations", payload)
+	require.Equal(t, http.StatusOK, code)
+
 	var result v1.RecommendationsResponse
 	expectedResult := v1.RecommendationsResponse{
-		Packages: []string{"vim", "python"},
+		Packages: []string{"recommended1"},
 	}
+
 	err := json.Unmarshal([]byte(body), &result)
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)

--- a/internal/v1/handler_recommend_package_test.go
+++ b/internal/v1/handler_recommend_package_test.go
@@ -206,6 +206,7 @@ func TestRecommendPackage_with_authenticationServer(t *testing.T) {
 	srv := startServer(t, &testServerClientsConf{RecommendURL: apiSrv.URL, OAuthURL: oauthMock.URL}, &v1.ServerConfig{})
 	defer srv.Shutdown(t)
 	payload := v1.RecommendPackageRequest{
+		Distribution: "rhel-8",
 		Packages: []string{
 			"some",
 			"packages",

--- a/internal/v1/server_test.go
+++ b/internal/v1/server_test.go
@@ -151,11 +151,16 @@ func startServer(t *testing.T, tscc *testServerClientsConf, conf *v1.ServerConfi
 	})
 	require.NoError(t, err)
 
-	recommendToken := &oauth2.LazyToken{
-		Url:          tscc.OAuthURL,
-		ClientId:     "id",
-		ClientSecret: "secret",
-		AccessToken:  "token",
+	var recommendToken oauth2.Tokener
+	if tscc.OAuthURL != "" {
+		recommendToken = &oauth2.LazyToken{
+			Url:          tscc.OAuthURL,
+			ClientId:     "id",
+			ClientSecret: "secret",
+			AccessToken:  "token",
+		}
+	} else {
+		recommendToken = &oauth2.DummyToken{}
 	}
 	recommendClient, err := recommendations.NewClient(recommendations.RecommendationsClientConfig{
 		URL:     tscc.RecommendURL,


### PR DESCRIPTION
Introduce a distribution field in the recommendation request and response models to support additional filtering.

Refactor tests to accommodate these changes and also drop some unneeded test cases - the token has proper tests already there is no reason to test it again in the recommendation package. This is done in a separate commit.
