### PR TITLE
refactor: add documentation to paginator

### DIFF
--- a/internal/common/pagination.go
+++ b/internal/common/pagination.go
@@ -2,13 +2,15 @@ package common
 
 import "fmt"
 
+// Paginator is a generic type that provides pagination functionality.
+// It allows you to paginate through a slice of items of any type T.
 type Paginator[T any] struct {
 	items  []T
-	count  int
 	limit  int
 	offset int
 }
 
+// NewPaginator creates a new Paginator instance with the provided items, limit, and offset.
 func NewPaginator[T any](items []T, limit, offset int) (*Paginator[T], error) {
 	if limit <= 0 {
 		return nil, fmt.Errorf("limit cannot be less than or equal to zero: %d", limit)
@@ -19,43 +21,46 @@ func NewPaginator[T any](items []T, limit, offset int) (*Paginator[T], error) {
 
 	return &Paginator[T]{
 		items:  items,
-		count:  len(items),
 		limit:  limit,
 		offset: offset,
 	}, nil
 }
 
+// Limit returns the limit of items per page.
 func (p *Paginator[T]) Limit() int {
 	return p.limit
 }
 
+// Offset returns the current offset for pagination.
 func (p *Paginator[T]) Offset() int {
 	return p.offset
 }
 
+// Count returns the total number of items in the paginator.
 func (p *Paginator[T]) Count() int {
-	return p.count
+	return len(p.items)
 }
 
-// GetPage returns the items for the current page based on the limit and offset.
+// Page returns the items for the current page based on the limit and offset.
 // It returns an empty slice if the offset is greater than or equal to the total count.
-func (p *Paginator[T]) GetPage() []T {
+func (p *Paginator[T]) Page() []T {
 	start := p.offset
 	end := start + p.limit
-	if start >= p.count {
+	if start >= p.Count() {
 		return []T{}
 	}
-	if end > p.count {
-		end = p.count
+	if end > p.Count() {
+		end = p.Count()
 	}
 	return p.items[start:end]
 }
 
 // LasetPageOffset returns the last page offset based on the total count and page size defined by the limit.
 func (p *Paginator[T]) LastPageOffset() int {
-	return CalculateLastPageOffset(p.count, p.limit)
+	return CalculateLastPageOffset(p.Count(), p.limit)
 }
 
+// CalculateLastPageOffset calculates the offset for the last page based on the total count and limit.
 func CalculateLastPageOffset(count, limit int) int {
 	if limit >= count {
 		return 0

--- a/internal/common/pagination_test.go
+++ b/internal/common/pagination_test.go
@@ -144,7 +144,7 @@ func TestGetPage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			paginator, err := common.NewPaginator(tc.items, tc.limit, tc.offset)
 			require.NoError(t, err)
-			page := paginator.GetPage()
+			page := paginator.Page()
 			assert.Equal(t, tc.page, page)
 		})
 	}

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -216,7 +216,7 @@ func (h *Handlers) GetPackages(ctx echo.Context, params GetPackagesParams) error
 				RoutePrefix(), h.server.spec.Info.Version, params.Search, params.Distribution, params.Architecture,
 				paginator.LastPageOffset(), paginator.Limit()),
 		},
-		Data: paginator.GetPage(),
+		Data: paginator.Page(),
 	})
 }
 
@@ -582,7 +582,7 @@ func (h *Handlers) GetComposeSBOMs(ctx echo.Context, composeId uuid.UUID, params
 			Last: fmt.Sprintf("%v/v%v/composes/%v/sboms?offset=%v&limit=%v",
 				RoutePrefix(), h.server.spec.Info.Version, composeId, paginator.LastPageOffset(), paginator.Limit()),
 		},
-		Data: paginator.GetPage(),
+		Data: paginator.Page(),
 	}
 
 	return ctx.JSON(http.StatusOK, status)


### PR DESCRIPTION
Small nitpicks for the paginator, mostly docs, inconsistency for getters (some having the prefix while others dont) and useless memory consumption for count.

It is worth noting that in the review (https://github.com/osbuild/image-builder-crc/pull/1610) I expressed an opinion to avoid getters for the fields alltogether and export all the three fields. The type currently is mutable due to the fact that it does not copy the slice, so exposing those fields does not change a thing about immutability. However, type inference for generics only works with functions, so it would create it a little more verbose which I do not like:

```go
p := common.Paginator[int]{values, limit, offset}
```

Therefore I am not including such a change. 