### PR TITLE
cmd/oscap: format configs to be readable

### DIFF
--- a/cmd/oscap/main.go
+++ b/cmd/oscap/main.go
@@ -227,7 +227,7 @@ func generateJson(dir, datastreamDistro, profileDescription, profile string) {
 	customizations.Openscap = &openscap
 
 	// Write it all down on the fileSystem
-	bArray, err := json.Marshal(customizations)
+	bArray, err := json.MarshalIndent(customizations, "", "  ")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Use json.MarshalIndent() to make the test configuration files readable and easier to diff when they're updated.