### PR TITLE
Add support for Disk customizations

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/oapi-codegen/runtime"
 	openapi_types "github.com/oapi-codegen/runtime/types"
+	"github.com/osbuild/image-builder-crc/internal/clients/composer"
 )
 
 // Defines values for AzureUploadRequestOptionsHyperVGeneration.
@@ -335,6 +336,12 @@ type BlueprintsResponse struct {
 	Meta  ListResponseMeta  `json:"meta"`
 }
 
+// BtrfsSubvolume defines model for BtrfsSubvolume.
+type BtrfsSubvolume = composer.BtrfsSubvolume
+
+// BtrfsVolume defines model for BtrfsVolume.
+type BtrfsVolume = composer.BtrfsVolume
+
 // CACertsCustomization defines model for CACertsCustomization.
 type CACertsCustomization struct {
 	PemCerts []string `json:"pem_certs"`
@@ -511,6 +518,7 @@ type Customizations struct {
 	// CustomRepositories List of custom repositories.
 	CustomRepositories *[]CustomRepository `json:"custom_repositories,omitempty"`
 	Directories        *[]Directory        `json:"directories,omitempty"`
+	Disk               *Disk               `json:"disk,omitempty"`
 
 	// EnabledModules List of dnf modules to enable, so that packages can be installed from them.
 	EnabledModules *[]Module `json:"enabled_modules,omitempty"`
@@ -610,6 +618,9 @@ type Directory_User struct {
 	union json.RawMessage
 }
 
+// Disk defines model for Disk.
+type Disk = composer.Disk
+
 // DistributionItem defines model for DistributionItem.
 type DistributionItem struct {
 	Description string `json:"description"`
@@ -700,6 +711,9 @@ type Filesystem struct {
 	MinSize    uint64 `json:"min_size"`
 	Mountpoint string `json:"mountpoint"`
 }
+
+// FilesystemTyped defines model for FilesystemTyped.
+type FilesystemTyped = composer.FilesystemTyped
 
 // FirewallCustomization Firewalld configuration
 type FirewallCustomization struct {
@@ -858,6 +872,9 @@ type Locale struct {
 	Languages *[]string `json:"languages,omitempty"`
 }
 
+// LogicalVolume defines model for LogicalVolume.
+type LogicalVolume = composer.LogicalVolume
+
 // Module defines model for Module.
 type Module struct {
 	// Name Name of the module to enable.
@@ -941,6 +958,9 @@ type PackagesResponse struct {
 	Links ListResponseLinks `json:"links"`
 	Meta  ListResponseMeta  `json:"meta"`
 }
+
+// Partition defines model for Partition.
+type Partition = composer.Partition
 
 // Readiness defines model for Readiness.
 type Readiness struct {
@@ -1069,6 +1089,12 @@ type Version struct {
 	BuildTime   *string `json:"build_time,omitempty"`
 	Version     string  `json:"version"`
 }
+
+// VolumeGroup defines model for VolumeGroup.
+type VolumeGroup = composer.VolumeGroup
+
+// Minsize size with data units
+type Minsize = string
 
 // GetBlueprintsParams defines parameters for GetBlueprints.
 type GetBlueprintsParams struct {

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1730,6 +1730,8 @@ components:
           maxItems: 128
           items:
             $ref: '#/components/schemas/Filesystem'
+        disk:
+          $ref: '#/components/schemas/Disk'
         users:
           type: array
           items:
@@ -2274,3 +2276,148 @@ components:
           example: '22'
           description: |
             Stream to enable.
+    Disk:
+      x-go-type: composer.Disk
+      type: object
+      required:
+        - partitions
+      properties:
+        type:
+          type: string
+          enum:
+            - gpt
+            - dos
+          description: |
+            Type of the partition table
+        minsize:
+          $ref: '#/components/schemas/minsize'
+        partitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Partition'
+    Partition:
+      x-go-type: composer.Partition
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/FilesystemTyped'
+        - $ref: '#/components/schemas/BtrfsVolume'
+        - $ref: '#/components/schemas/VolumeGroup'
+    FilesystemTyped:
+      x-go-type: composer.FilesystemTyped
+      type: object
+      required:
+        - fs_type
+      properties:
+        type:
+          type: string
+          enum:
+            - plain
+        part_type:
+          type: string
+          description: |
+            The partition type GUID for GPT partitions. For DOS partitions, this field can be used to set the (2 hex digit) partition type. If not set, the type will be automatically set based on the mountpoint or the payload type.
+        minsize:
+          $ref: '#/components/schemas/minsize'
+        mountpoint:
+          type: string
+        label:
+          type: string
+        fs_type:
+          type: string
+          enum:
+            - ext4
+            - xfs
+            - vfat
+            - swap
+          description: |
+            The filesystem type. Swap partitions must have an empty mountpoint.
+    BtrfsVolume:
+      x-go-type: composer.BtrfsVolume
+      type: object
+      required:
+        - type
+        - subvolumes
+      properties:
+        type:
+          type: string
+          enum:
+            - btrfs
+        part_type:
+          type: string
+          description: |
+            The partition type GUID for GPT partitions. For DOS partitions, this field can be used to set the (2 hex digit) partition type. If not set, the type will be automatically set based on the mountpoint or the payload type.
+        minsize:
+          $ref: '#/components/schemas/minsize'
+        subvolumes:
+          type: array
+          items:
+            $ref: '#/components/schemas/BtrfsSubvolume'
+    BtrfsSubvolume:
+      x-go-type: composer.BtrfsSubvolume
+      type: object
+      required:
+        - name
+        - mountpoint
+      properties:
+        name:
+          type: string
+          description: |
+            The name of the subvolume, which defines the location (path) on the root volume
+        mountpoint:
+          type: string
+          description: |
+            Mountpoint for the subvolume
+    VolumeGroup:
+      x-go-type: composer.VolumeGroup
+      type: object
+      required:
+        - type
+        - logical_volumes
+      properties:
+        type:
+          type: string
+          enum:
+            - lvm
+        part_type:
+          type: string
+          description: |
+            The partition type GUID for GPT partitions. For DOS partitions, this field can be used to set the (2 hex digit) partition type. If not set, the type will be automatically set based on the mountpoint or the payload type.
+        name:
+          type: string
+          description: |
+            Volume group name (will be automatically generated if omitted)
+        minsize:
+          $ref: '#/components/schemas/minsize'
+        logical_volumes:
+          type: array
+          items:
+            $ref: '#/components/schemas/LogicalVolume'
+    LogicalVolume:
+      x-go-type: composer.LogicalVolume
+      type: object
+      required:
+        - fs_type
+      properties:
+        name:
+          type: string
+        minsize:
+          $ref: '#/components/schemas/minsize'
+        mountpoint:
+          type: string
+          description: |
+            Mountpoint for the logical volume
+        label:
+          type: string
+        fs_type:
+          type: string
+          enum:
+            - ext4
+            - xfs
+            - vfat
+            - swap
+          description: |
+            The filesystem type for the logical volume. Swap LVs must have an empty mountpoint.
+    minsize:
+      type: string
+      example: "2 GiB"
+      description: 'size with data units'

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -1329,5 +1329,8 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 		}
 	}
 
+	// IB API Disk uses the same type as the osbuild-composer Disk
+	res.Disk = cust.Disk
+
 	return res, nil
 }


### PR DESCRIPTION
Add support for the new Disk (advanced partitioning) customizations to the API by directly importing the type from the osbuild-composer cloud API.

I initially [copied the types to the API yaml directly](https://github.com/achilleas-k/image-builder-crc/blob/df26e9a9af8c5396de1cd32410a9d7dc8d1fa3ee/internal/v1/api.yaml#L2366C5-L2503), which created  bunch of changes to existing variables in the generated code.  That was fine, easy to update all references to work.  The problem is that it becomes [a bit of a pain to convert from one to the other](https://github.com/achilleas-k/image-builder-crc/blob/df26e9a9af8c5396de1cd32410a9d7dc8d1fa3ee/internal/v1/handler_compose_image.go#L1341-L1415), because of the way the union types work.
I also tried [converting via serialization](https://github.com/achilleas-k/image-builder-crc/blob/f72924da96dc2001d9fa79c7d7f0416c3f3d5b49/internal/v1/handler_compose_image.go#L1341-L1364), which works but is a bit stupid or inefficient.

In the end, I think the way I did it in this PR, by using the osbuild-composer types directly, is the way to go and we should be doing it for all types.  Ultimately, for Blueprint types, we should start importing the github.com/osbuild/blueprint types everywhere (and later, the new osbuild/blueprint-schema types).

DRAFT: Depends on osbuild/osbuild-composer#4740