### PR TITLE
Support MCP clientId for metrics

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -22,6 +22,7 @@ const (
 // Defines values for ClientId.
 const (
 	Api ClientId = "api"
+	Mcp ClientId = "mcp"
 	Ui  ClientId = "ui"
 )
 

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1319,7 +1319,7 @@ components:
           nullable: true
     ClientId:
       type: string
-      enum: ["api", "ui"]
+      enum: ["api", "ui", "mcp"]
       default: "api"
     ComposeResponse:
       required:

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -546,7 +546,9 @@ func (h *Handlers) ComposeBlueprint(ctx echo.Context, id openapi_types.UUID) err
 	}
 	composeResponses := make([]ComposeResponse, 0, len(blueprint.ImageRequests))
 	clientId := ClientId("api")
-	if ctx.Request().Header.Get("X-ImageBuilder-ui") != "" {
+	if ctx.Request().Header.Get("X-ImageBuilder-ui") == "mcp" {
+		clientId = "mcp"
+	} else if ctx.Request().Header.Get("X-ImageBuilder-ui") != "" {
 		clientId = "ui"
 	}
 	for _, imageRequest := range blueprint.ImageRequests {


### PR DESCRIPTION
For now we won't differentiate between possible local or hosted MCP deployments.
Still can be used for metrics UI / API vs MCP.
