### PR TITLE
renovate.json: disable gomod manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,22 +4,7 @@
     "schedule:earlyMondays"
   ],
   "prConcurrentLimit": 3,
-  "packageRules": [
-    {
-      "groupName": "go dependencies patch updates",
-      "groupSlug": "go-deps-patch",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "matchUpdateTypes": [
-        "patch"
-      ]
-    }
-  ],
-  "postUpdateOptions": [
-    "gomodTidy"
-  ]
+  "gomod": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
Gobump is also enabled, and it can limit go version upgrades.