### PR TITLE
v1: add PatchURL to compose request

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -214,6 +214,7 @@ func main() {
 		DistributionsDir:    conf.DistributionsDir,
 		FedoraAuth:          conf.FedoraAuth,
 		InsightsClientProxy: conf.InsightsClientProxy,
+		PatchURL:            conf.PatchURL,
 	}
 
 	_, err = v1.Attach(serverConfig)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,7 @@ type ImageBuilderConfig struct {
 	UnleashURL               string `env:"UNLEASH_URL"`
 	UnleashToken             string `env:"UNLEASH_TOKEN"`
 	InsightsClientProxy      string `env:"INSIGHTS_CLIENT_PROXY"`
+	PatchURL                 string `env:"PATCH_URL"`
 }
 
 func (ibc *ImageBuilderConfig) IsDebug() bool {

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -848,6 +848,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 			if ((major >= 9 && minor >= 6) || (major >= 10)) && cr.ImageRequests[0].ContentTemplateName != nil {
 				res.Subscription.TemplateName = cr.ImageRequests[0].ContentTemplateName
 			} else {
+				res.Subscription.PatchUrl = &h.server.patchURL
 				res.Subscription.TemplateUuid = cr.ImageRequests[0].ContentTemplate
 			}
 		}

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -2929,6 +2929,7 @@ func TestComposeCustomizations(t *testing.T) {
 						ServerUrl:           "",
 						InsightsClientProxy: common.ToPtr(""),
 						TemplateUuid:        common.ToPtr(mocks.TemplateID),
+						PatchUrl:            common.ToPtr(""),
 					},
 				},
 				Distribution: "rhel-9.5",

--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -49,6 +49,7 @@ type Server struct {
 	distributionsDir    string
 	fedoraAuth          bool
 	insightsClientProxy string
+	patchURL            string
 }
 
 type ServerConfig struct {
@@ -69,6 +70,7 @@ type ServerConfig struct {
 	DistributionsDir    string
 	FedoraAuth          bool
 	InsightsClientProxy string
+	PatchURL            string
 }
 
 type AWSConfig struct {
@@ -127,6 +129,7 @@ func Attach(conf *ServerConfig) (*Server, error) {
 		conf.DistributionsDir,
 		conf.FedoraAuth,
 		conf.InsightsClientProxy,
+		conf.PatchURL,
 	}
 	var h Handlers
 	h.server = &s

--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -351,4 +351,6 @@ parameters:
       "local", "staging" or "production".
   - name: INSIGHTS_CLIENT_PROXY
     value: ""
+  - name: PATCH_URL
+    value: ""
 


### PR DESCRIPTION
PatchURL is loaded in from the environment and passed down the compose request when registering on-boot with a template for RHEL <= 9.5. It is required for system registration.

related: https://github.com/osbuild/osbuild-composer/pull/4756

jira: https://issues.redhat.com/browse/HMS-8558