### PR TITLE
AAP: import/export (HMS-8836) (HMS-8837)

### DIFF
--- a/internal/common/testdata/exported_blueprint.json
+++ b/internal/common/testdata/exported_blueprint.json
@@ -8,6 +8,12 @@
   ],
   "snapshot_date": "2012-12-20",
   "customizations": {
+    "aap_registration": {
+      "ansible_callback_url": "https://aap-gw.example.com/api/controller/v2/job_templates/42/callback/",
+      "host_config_key": "",
+      "skip_tls_verification": false,
+      "tls_certificate_authority": "-----BEGIN CERTIFICATE-----\nMIIC0DCCAbigAwIBAgIUI...\n-----END CERTIFICATE-----"
+    },
     "custom_repositories": [
       {
         "baseurl": [

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -514,8 +514,9 @@ type CustomRepository struct {
 
 // Customizations defines model for Customizations.
 type Customizations struct {
-	Cacerts    *CACertsCustomization `json:"cacerts,omitempty"`
-	Containers *[]Container          `json:"containers,omitempty"`
+	AAPRegistration *AAPRegistration      `json:"aap_registration,omitempty"`
+	Cacerts         *CACertsCustomization `json:"cacerts,omitempty"`
+	Containers      *[]Container          `json:"containers,omitempty"`
 
 	// CustomRepositories List of custom repositories.
 	CustomRepositories *[]CustomRepository `json:"custom_repositories,omitempty"`
@@ -794,8 +795,6 @@ type IgnitionFirstboot struct {
 
 // ImageRequest defines model for ImageRequest.
 type ImageRequest struct {
-	AAPRegistration *AAPRegistration `json:"aap_registration,omitempty"`
-
 	// Architecture CPU architecture of the image, x86_64 and aarch64 are currently supported.
 	Architecture ImageRequestArchitecture `json:"architecture"`
 

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1258,8 +1258,6 @@ components:
           type: string
           description: |
             Name of the content template. Used when registering the system to Insights.
-        aap_registration:
-          $ref: '#/components/schemas/AAPRegistration'
     ImageTypes:
       type: string
       enum:
@@ -1783,6 +1781,8 @@ components:
           $ref: '#/components/schemas/Installer'
         cacerts:
           $ref: '#/components/schemas/CACertsCustomization'
+        aap_registration:
+          $ref: '#/components/schemas/AAPRegistration'
     Container:
       type: object
       required:

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -87,6 +87,12 @@ func (bb *BlueprintBody) RedactCertificates() {
 	bb.Customizations.Cacerts = nil
 }
 
+func (bb *BlueprintBody) RedactAAPRegistration() {
+	if bb.Customizations.AAPRegistration != nil {
+		bb.Customizations.AAPRegistration.HostConfigKey = ""
+	}
+}
+
 // Merges Password or SshKey from other User struct to this User struct if it is not set
 func (u *User) MergeExisting(other User) {
 	if u.Password == nil {
@@ -176,6 +182,12 @@ func WithRedactedPasswords() BlueprintBodyOption {
 func WithRedactedCertificates() BlueprintBodyOption {
 	return func(bp *BlueprintBody) {
 		bp.RedactCertificates()
+	}
+}
+
+func WithRedactedAAPRegistration() BlueprintBodyOption {
+	return func(bp *BlueprintBody) {
+		bp.RedactAAPRegistration()
 	}
 }
 
@@ -369,9 +381,11 @@ func (h *Handlers) ExportBlueprint(ctx echo.Context, id openapi_types.UUID) erro
 		blueprintEntry,
 		WithRedactedPasswords(),
 		WithRedactedCertificates(),
+		WithRedactedAAPRegistration(),
 		WithRedactedFiles([]string{
 			"/etc/systemd/system/register-satellite.service",
 			"/usr/local/sbin/register-satellite",
+			"/usr/local/sbin/aap-first-boot-reg",
 		}),
 	)
 	if err != nil {

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -1272,7 +1272,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 		}
 	}
 
-	if aap := cr.ImageRequests[0].AAPRegistration; aap != nil {
+	if aap := cust.AAPRegistration; aap != nil {
 		script, err := tmpl.RenderAAPRegistrationScript(ctx.Request().Context(), tmpl.AAPRegistrationParams{
 			HostConfigKey:       aap.HostConfigKey,
 			AnsibleCallbackUrl:  aap.AnsibleCallbackUrl,

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -2955,8 +2955,14 @@ func TestComposeCustomizations(t *testing.T) {
 		// aap first boot registration
 		{
 			imageBuilderRequest: v1.ComposeRequest{
-				Customizations: &v1.Customizations{},
-				Distribution:   "rhel-8",
+				Customizations: &v1.Customizations{
+					AAPRegistration: &v1.AAPRegistration{
+						AnsibleCallbackUrl:      "http://some-url.org/api/controller/v2/job_templates/38/callback/",
+						HostConfigKey:           "some-key",
+						TlsCertificateAuthority: "---BEGIN CERTIFICATE---\nMIIC0DCCAbigAwIBAgIUI...\n---END CERTIFICATE---",
+					},
+				},
+				Distribution: "rhel-8",
 				ImageRequests: []v1.ImageRequest{
 					{
 						Architecture: "x86_64",
@@ -2964,11 +2970,6 @@ func TestComposeCustomizations(t *testing.T) {
 						UploadRequest: v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
-						},
-						AAPRegistration: &v1.AAPRegistration{
-							AnsibleCallbackUrl:      "http://some-url.org/api/controller/v2/job_templates/38/callback/",
-							HostConfigKey:           "some-key",
-							TlsCertificateAuthority: "---BEGIN CERTIFICATE---\nMIIC0DCCAbigAwIBAgIUI...\n---END CERTIFICATE---",
 						},
 					},
 				},


### PR DESCRIPTION
AAP was in image_request, but since it is not an extra registration and more a firstboot, I moved it to customizations. Also edited tests for import and export.

Just one question - do I understand correctly that when exporting a bp, we want to redact certificates (I also removed config key), but when importing, we expect the user to have the certificates in the request? In my head it made sense, so hopefully that's ok :)