### PR TITLE
distributions: generate package lists for rhel-9.6

### DIFF
--- a/distributions/rhel-9.6/rhel-9.6-aarch64-appstream-packages.json
+++ b/distributions/rhel-9.6/rhel-9.6-aarch64-appstream-packages.json
@@ -1,0 +1,18754 @@
+[
+  {
+    "name": "389-ds-base",
+    "summary": "389 Directory Server (base)"
+  },
+  {
+    "name": "389-ds-base-libs",
+    "summary": "Core libraries for 389 Directory Server"
+  },
+  {
+    "name": "389-ds-base-snmp",
+    "summary": "SNMP Agent for 389 Directory Server"
+  },
+  {
+    "name": "a52dec",
+    "summary": "Small test program for liba52"
+  },
+  {
+    "name": "aajohan-comfortaa-fonts",
+    "summary": "Modern style true type font"
+  },
+  {
+    "name": "aardvark-dns",
+    "summary": "Authoritative DNS server for A/AAAA container records"
+  },
+  {
+    "name": "abattis-cantarell-fonts",
+    "summary": "Humanist sans serif font"
+  },
+  {
+    "name": "accountsservice",
+    "summary": "D-Bus interfaces for querying and manipulating user account information"
+  },
+  {
+    "name": "accountsservice-libs",
+    "summary": "Client-side library to talk to accountsservice"
+  },
+  {
+    "name": "acpid",
+    "summary": "ACPI Event Daemon"
+  },
+  {
+    "name": "adobe-mappings-cmap",
+    "summary": "CMap resources for Adobe's character collections"
+  },
+  {
+    "name": "adobe-mappings-cmap-deprecated",
+    "summary": "Deprecated CMap resources for Adobe's character collections"
+  },
+  {
+    "name": "adobe-mappings-pdf",
+    "summary": "PDF mapping resources from Adobe"
+  },
+  {
+    "name": "adobe-source-code-pro-fonts",
+    "summary": "A set of mono-spaced OpenType fonts designed for coding environments"
+  },
+  {
+    "name": "adwaita-cursor-theme",
+    "summary": "Adwaita cursor theme"
+  },
+  {
+    "name": "adwaita-gtk2-theme",
+    "summary": "Adwaita gtk2 theme"
+  },
+  {
+    "name": "adwaita-icon-theme",
+    "summary": "Adwaita icon theme"
+  },
+  {
+    "name": "adwaita-qt5",
+    "summary": "Adwaita Qt5 theme"
+  },
+  {
+    "name": "afterburn",
+    "summary": "Simple cloud provider agent"
+  },
+  {
+    "name": "afterburn-dracut",
+    "summary": "Dracut modules for afterburn"
+  },
+  {
+    "name": "aide",
+    "summary": "Intrusion detection environment"
+  },
+  {
+    "name": "alsa-firmware",
+    "summary": "Firmware for several ALSA-supported sound cards"
+  },
+  {
+    "name": "alsa-lib",
+    "summary": "The Advanced Linux Sound Architecture (ALSA) library"
+  },
+  {
+    "name": "alsa-lib-devel",
+    "summary": "Development files from the ALSA library"
+  },
+  {
+    "name": "alsa-plugins-arcamav",
+    "summary": "Arcam AV amplifier plugin for ALSA"
+  },
+  {
+    "name": "alsa-plugins-maemo",
+    "summary": "Maemo plugin for ALSA"
+  },
+  {
+    "name": "alsa-plugins-oss",
+    "summary": "Oss PCM output plugin for ALSA"
+  },
+  {
+    "name": "alsa-plugins-pulseaudio",
+    "summary": "Alsa to PulseAudio backend"
+  },
+  {
+    "name": "alsa-plugins-samplerate",
+    "summary": "External rate converter plugin for ALSA"
+  },
+  {
+    "name": "alsa-plugins-speex",
+    "summary": "Rate Converter Plugin Using Speex Resampler"
+  },
+  {
+    "name": "alsa-plugins-upmix",
+    "summary": "Upmixer channel expander plugin for ALSA"
+  },
+  {
+    "name": "alsa-plugins-usbstream",
+    "summary": "USB stream plugin for ALSA"
+  },
+  {
+    "name": "alsa-plugins-vdownmix",
+    "summary": "Downmixer to stereo plugin for ALSA"
+  },
+  {
+    "name": "alsa-sof-firmware",
+    "summary": "Firmware and topology files for Sound Open Firmware project"
+  },
+  {
+    "name": "alsa-tools-firmware",
+    "summary": "ALSA tools for uploading firmware to some soundcards"
+  },
+  {
+    "name": "alsa-ucm",
+    "summary": "ALSA Use Case Manager configuration"
+  },
+  {
+    "name": "alsa-utils",
+    "summary": "Advanced Linux Sound Architecture (ALSA) utilities"
+  },
+  {
+    "name": "anaconda",
+    "summary": "Graphical system installer"
+  },
+  {
+    "name": "anaconda-core",
+    "summary": "Core of the Anaconda installer"
+  },
+  {
+    "name": "anaconda-dracut",
+    "summary": "The anaconda dracut module"
+  },
+  {
+    "name": "anaconda-gui",
+    "summary": "Graphical user interface for the Anaconda installer"
+  },
+  {
+    "name": "anaconda-install-env-deps",
+    "summary": "Installation environment specific dependencies"
+  },
+  {
+    "name": "anaconda-install-img-deps",
+    "summary": "Installation image specific dependencies"
+  },
+  {
+    "name": "anaconda-tui",
+    "summary": "Textual user interface for the Anaconda installer"
+  },
+  {
+    "name": "anaconda-user-help",
+    "summary": "Content for the Anaconda built-in help system"
+  },
+  {
+    "name": "anaconda-widgets",
+    "summary": "A set of custom GTK+ widgets for use with anaconda"
+  },
+  {
+    "name": "annobin",
+    "summary": "Annotate and examine compiled binary files"
+  },
+  {
+    "name": "annobin-annocheck",
+    "summary": "A tool for checking the security hardening status of binaries"
+  },
+  {
+    "name": "ansible-collection-microsoft-sql",
+    "summary": "The Ansible collection for Microsoft SQL Server management"
+  },
+  {
+    "name": "ansible-collection-redhat-rhel_mgmt",
+    "summary": "Ansible Collection of general system management and utility modules and other plugins"
+  },
+  {
+    "name": "ansible-core",
+    "summary": "SSH-based configuration management, deployment, and task execution system"
+  },
+  {
+    "name": "ansible-freeipa",
+    "summary": "Roles and playbooks to deploy FreeIPA servers, replicas and clients"
+  },
+  {
+    "name": "ansible-freeipa-collection",
+    "summary": "freeipa.ansible_freeipa collection"
+  },
+  {
+    "name": "ansible-freeipa-tests",
+    "summary": "ansible-freeipa tests"
+  },
+  {
+    "name": "ansible-pcp",
+    "summary": "Ansible Metric collection for Performance Co-Pilot"
+  },
+  {
+    "name": "ansible-test",
+    "summary": "Tool for testing ansible plugin and module code"
+  },
+  {
+    "name": "ant",
+    "summary": "Java build tool"
+  },
+  {
+    "name": "ant-antlr",
+    "summary": "Optional antlr tasks for ant"
+  },
+  {
+    "name": "ant-apache-bcel",
+    "summary": "Optional apache bcel tasks for ant"
+  },
+  {
+    "name": "ant-apache-bsf",
+    "summary": "Optional apache bsf tasks for ant"
+  },
+  {
+    "name": "ant-apache-oro",
+    "summary": "Optional apache oro tasks for ant"
+  },
+  {
+    "name": "ant-apache-regexp",
+    "summary": "Optional apache regexp tasks for ant"
+  },
+  {
+    "name": "ant-apache-resolver",
+    "summary": "Optional apache resolver tasks for ant"
+  },
+  {
+    "name": "ant-apache-xalan2",
+    "summary": "Optional apache xalan2 tasks for ant"
+  },
+  {
+    "name": "ant-commons-logging",
+    "summary": "Optional commons logging tasks for ant"
+  },
+  {
+    "name": "ant-commons-net",
+    "summary": "Optional commons net tasks for ant"
+  },
+  {
+    "name": "ant-javamail",
+    "summary": "Optional javamail tasks for ant"
+  },
+  {
+    "name": "ant-jdepend",
+    "summary": "Optional jdepend tasks for ant"
+  },
+  {
+    "name": "ant-jmf",
+    "summary": "Optional jmf tasks for ant"
+  },
+  {
+    "name": "ant-jsch",
+    "summary": "Optional jsch tasks for ant"
+  },
+  {
+    "name": "ant-junit",
+    "summary": "Optional junit tasks for ant"
+  },
+  {
+    "name": "ant-junit5",
+    "summary": "Optional junit5 tasks for ant"
+  },
+  {
+    "name": "ant-lib",
+    "summary": "Core part of ant"
+  },
+  {
+    "name": "ant-openjdk11",
+    "summary": "OpenJDK 11 binding for Ant"
+  },
+  {
+    "name": "ant-openjdk17",
+    "summary": "OpenJDK 17 binding for Ant"
+  },
+  {
+    "name": "ant-openjdk21",
+    "summary": "OpenJDK 21 binding for Ant"
+  },
+  {
+    "name": "ant-openjdk8",
+    "summary": "OpenJDK 8 binding for Ant"
+  },
+  {
+    "name": "ant-swing",
+    "summary": "Optional swing tasks for ant"
+  },
+  {
+    "name": "ant-testutil",
+    "summary": "Test utility classes for ant"
+  },
+  {
+    "name": "ant-xz",
+    "summary": "Optional xz tasks for ant"
+  },
+  {
+    "name": "anthy-unicode",
+    "summary": "Japanese character set input library for Unicode"
+  },
+  {
+    "name": "antlr-tool",
+    "summary": "ANother Tool for Language Recognition"
+  },
+  {
+    "name": "apache-commons-cli",
+    "summary": "Command Line Interface Library for Java"
+  },
+  {
+    "name": "apache-commons-codec",
+    "summary": "Implementations of common encoders and decoders"
+  },
+  {
+    "name": "apache-commons-io",
+    "summary": "Utilities to assist with developing IO functionality"
+  },
+  {
+    "name": "apache-commons-lang3",
+    "summary": "Provides a host of helper utilities for the java.lang API"
+  },
+  {
+    "name": "apache-commons-logging",
+    "summary": "Apache Commons Logging"
+  },
+  {
+    "name": "apache-commons-net",
+    "summary": "Internet protocol suite Java library"
+  },
+  {
+    "name": "apcu-panel",
+    "summary": "APCu control panel"
+  },
+  {
+    "name": "appstream",
+    "summary": "Utilities to generate, maintain and access the AppStream database"
+  },
+  {
+    "name": "appstream-data",
+    "summary": "Cached AppStream metadata"
+  },
+  {
+    "name": "apr",
+    "summary": "Apache Portable Runtime library"
+  },
+  {
+    "name": "apr-devel",
+    "summary": "APR library development kit"
+  },
+  {
+    "name": "apr-util",
+    "summary": "Apache Portable Runtime Utility library"
+  },
+  {
+    "name": "apr-util-bdb",
+    "summary": "APR utility library Berkeley DB driver"
+  },
+  {
+    "name": "apr-util-devel",
+    "summary": "APR utility library development kit"
+  },
+  {
+    "name": "apr-util-ldap",
+    "summary": "APR utility library LDAP support"
+  },
+  {
+    "name": "apr-util-mysql",
+    "summary": "APR utility library MySQL DBD driver"
+  },
+  {
+    "name": "apr-util-odbc",
+    "summary": "APR utility library ODBC DBD driver"
+  },
+  {
+    "name": "apr-util-openssl",
+    "summary": "APR utility library OpenSSL crypto support"
+  },
+  {
+    "name": "apr-util-pgsql",
+    "summary": "APR utility library PostgreSQL DBD driver"
+  },
+  {
+    "name": "apr-util-sqlite",
+    "summary": "APR utility library SQLite DBD driver"
+  },
+  {
+    "name": "asciidoc",
+    "summary": "Text based document generation"
+  },
+  {
+    "name": "aspnetcore-runtime-6.0",
+    "summary": "ASP.NET Core 6.0 runtime"
+  },
+  {
+    "name": "aspnetcore-runtime-7.0",
+    "summary": "ASP.NET Core 7.0 runtime"
+  },
+  {
+    "name": "aspnetcore-runtime-8.0",
+    "summary": "ASP.NET Core 8.0 runtime"
+  },
+  {
+    "name": "aspnetcore-runtime-9.0",
+    "summary": "ASP.NET Core 9.0 runtime"
+  },
+  {
+    "name": "aspnetcore-runtime-dbg-8.0",
+    "summary": "Managed debug symbols for the ASP.NET Core 8.0 runtime"
+  },
+  {
+    "name": "aspnetcore-runtime-dbg-9.0",
+    "summary": "Managed debug symbols for the ASP.NET Core 9.0 runtime"
+  },
+  {
+    "name": "aspnetcore-targeting-pack-6.0",
+    "summary": "Targeting Pack for Microsoft.AspNetCore.App 6.0"
+  },
+  {
+    "name": "aspnetcore-targeting-pack-7.0",
+    "summary": "Targeting Pack for Microsoft.AspNetCore.App 7.0"
+  },
+  {
+    "name": "aspnetcore-targeting-pack-8.0",
+    "summary": "Targeting Pack for Microsoft.AspNetCore.App 8.0"
+  },
+  {
+    "name": "aspnetcore-targeting-pack-9.0",
+    "summary": "Targeting Pack for Microsoft.AspNetCore.App 9.0"
+  },
+  {
+    "name": "assertj-core",
+    "summary": "Library of assertions similar to fest-assert"
+  },
+  {
+    "name": "at-spi2-atk",
+    "summary": "A GTK+ module that bridges ATK to D-Bus at-spi"
+  },
+  {
+    "name": "at-spi2-atk-devel",
+    "summary": "A GTK+ module that bridges ATK to D-Bus at-spi"
+  },
+  {
+    "name": "at-spi2-core",
+    "summary": "Protocol definitions and daemon for D-Bus at-spi"
+  },
+  {
+    "name": "at-spi2-core-devel",
+    "summary": "Development files and headers for at-spi2-core"
+  },
+  {
+    "name": "atinject",
+    "summary": "Dependency injection specification for Java (JSR-330)"
+  },
+  {
+    "name": "atk",
+    "summary": "Interfaces for accessibility support"
+  },
+  {
+    "name": "atk-devel",
+    "summary": "Development files for the ATK accessibility toolkit"
+  },
+  {
+    "name": "atkmm",
+    "summary": "C++ interface for the ATK library"
+  },
+  {
+    "name": "atlas-devel",
+    "summary": "Development libraries for ATLAS"
+  },
+  {
+    "name": "audit-libs-devel",
+    "summary": "Header files for libaudit"
+  },
+  {
+    "name": "augeas",
+    "summary": "A library for changing configuration files"
+  },
+  {
+    "name": "augeas-libs",
+    "summary": "Libraries for augeas"
+  },
+  {
+    "name": "authselect-compat",
+    "summary": "Tool to provide minimum backwards compatibility with authconfig"
+  },
+  {
+    "name": "autoconf",
+    "summary": "A GNU tool for automatically configuring source code"
+  },
+  {
+    "name": "autoconf-archive",
+    "summary": "The Autoconf Macro Archive"
+  },
+  {
+    "name": "autoconf-latest",
+    "summary": "Meta package to include latest version of autoconf"
+  },
+  {
+    "name": "autoconf271",
+    "summary": "A GNU tool for automatically configuring source code"
+  },
+  {
+    "name": "autocorr-af",
+    "summary": "Afrikaans auto-correction rules"
+  },
+  {
+    "name": "autocorr-bg",
+    "summary": "Bulgarian auto-correction rules"
+  },
+  {
+    "name": "autocorr-ca",
+    "summary": "Catalan auto-correction rules"
+  },
+  {
+    "name": "autocorr-cs",
+    "summary": "Czech auto-correction rules"
+  },
+  {
+    "name": "autocorr-da",
+    "summary": "Danish auto-correction rules"
+  },
+  {
+    "name": "autocorr-de",
+    "summary": "German auto-correction rules"
+  },
+  {
+    "name": "autocorr-dsb",
+    "summary": "Lower auto-correction rules"
+  },
+  {
+    "name": "autocorr-el",
+    "summary": "Greek auto-correction rules"
+  },
+  {
+    "name": "autocorr-en",
+    "summary": "English auto-correction rules"
+  },
+  {
+    "name": "autocorr-es",
+    "summary": "Spanish auto-correction rules"
+  },
+  {
+    "name": "autocorr-fa",
+    "summary": "Farsi auto-correction rules"
+  },
+  {
+    "name": "autocorr-fi",
+    "summary": "Finnish auto-correction rules"
+  },
+  {
+    "name": "autocorr-fr",
+    "summary": "French auto-correction rules"
+  },
+  {
+    "name": "autocorr-ga",
+    "summary": "Irish auto-correction rules"
+  },
+  {
+    "name": "autocorr-hr",
+    "summary": "Croatian auto-correction rules"
+  },
+  {
+    "name": "autocorr-hsb",
+    "summary": "Upper auto-correction rules"
+  },
+  {
+    "name": "autocorr-hu",
+    "summary": "Hungarian auto-correction rules"
+  },
+  {
+    "name": "autocorr-is",
+    "summary": "Icelandic auto-correction rules"
+  },
+  {
+    "name": "autocorr-it",
+    "summary": "Italian auto-correction rules"
+  },
+  {
+    "name": "autocorr-ja",
+    "summary": "Japanese auto-correction rules"
+  },
+  {
+    "name": "autocorr-ko",
+    "summary": "Korean auto-correction rules"
+  },
+  {
+    "name": "autocorr-lb",
+    "summary": "Luxembourgish auto-correction rules"
+  },
+  {
+    "name": "autocorr-lt",
+    "summary": "Lithuanian auto-correction rules"
+  },
+  {
+    "name": "autocorr-mn",
+    "summary": "Mongolian auto-correction rules"
+  },
+  {
+    "name": "autocorr-nl",
+    "summary": "Dutch auto-correction rules"
+  },
+  {
+    "name": "autocorr-pl",
+    "summary": "Polish auto-correction rules"
+  },
+  {
+    "name": "autocorr-pt",
+    "summary": "Portuguese auto-correction rules"
+  },
+  {
+    "name": "autocorr-ro",
+    "summary": "Romanian auto-correction rules"
+  },
+  {
+    "name": "autocorr-ru",
+    "summary": "Russian auto-correction rules"
+  },
+  {
+    "name": "autocorr-sk",
+    "summary": "Slovak auto-correction rules"
+  },
+  {
+    "name": "autocorr-sl",
+    "summary": "Slovenian auto-correction rules"
+  },
+  {
+    "name": "autocorr-sr",
+    "summary": "Serbian auto-correction rules"
+  },
+  {
+    "name": "autocorr-sv",
+    "summary": "Swedish auto-correction rules"
+  },
+  {
+    "name": "autocorr-tr",
+    "summary": "Turkish auto-correction rules"
+  },
+  {
+    "name": "autocorr-vi",
+    "summary": "Vietnamese auto-correction rules"
+  },
+  {
+    "name": "autocorr-vro",
+    "summary": "V\u00f5ro auto-correction rules"
+  },
+  {
+    "name": "autocorr-zh",
+    "summary": "Chinese auto-correction rules"
+  },
+  {
+    "name": "automake",
+    "summary": "A GNU tool for automatically creating Makefiles"
+  },
+  {
+    "name": "avahi-autoipd",
+    "summary": "Link-local IPv4 address automatic configuration daemon (IPv4LL)"
+  },
+  {
+    "name": "avahi-glib",
+    "summary": "Glib libraries for avahi"
+  },
+  {
+    "name": "avahi-tools",
+    "summary": "Command line tools for mDNS browsing and publishing"
+  },
+  {
+    "name": "awscli2",
+    "summary": "Universal Command Line Environment for AWS, version 2"
+  },
+  {
+    "name": "babel",
+    "summary": "Tools for internationalizing Python applications"
+  },
+  {
+    "name": "babl",
+    "summary": "A dynamic, any to any, pixel format conversion library"
+  },
+  {
+    "name": "bacula-client",
+    "summary": "Bacula backup client"
+  },
+  {
+    "name": "bacula-common",
+    "summary": "Common Bacula files"
+  },
+  {
+    "name": "bacula-console",
+    "summary": "Bacula management console"
+  },
+  {
+    "name": "bacula-director",
+    "summary": "Bacula Director files"
+  },
+  {
+    "name": "bacula-libs",
+    "summary": "Bacula libraries"
+  },
+  {
+    "name": "bacula-libs-sql",
+    "summary": "Bacula SQL libraries"
+  },
+  {
+    "name": "bacula-logwatch",
+    "summary": "Bacula Director logwatch scripts"
+  },
+  {
+    "name": "bacula-storage",
+    "summary": "Bacula storage daemon files"
+  },
+  {
+    "name": "baobab",
+    "summary": "A graphical directory tree analyzer"
+  },
+  {
+    "name": "bcc",
+    "summary": "BPF Compiler Collection (BCC)"
+  },
+  {
+    "name": "bcc-tools",
+    "summary": "Command line tools for BPF Compiler Collection (BCC)"
+  },
+  {
+    "name": "bcel",
+    "summary": "Byte Code Engineering Library"
+  },
+  {
+    "name": "bind",
+    "summary": "The Berkeley Internet Name Domain (BIND) DNS (Domain Name System) server"
+  },
+  {
+    "name": "bind-chroot",
+    "summary": "A chroot runtime environment for the ISC BIND DNS server, named(8)"
+  },
+  {
+    "name": "bind-dnssec-doc",
+    "summary": "Manual pages of DNSSEC utilities"
+  },
+  {
+    "name": "bind-dnssec-utils",
+    "summary": "DNSSEC keys and zones management utilities"
+  },
+  {
+    "name": "bind-dyndb-ldap",
+    "summary": "LDAP back-end plug-in for BIND"
+  },
+  {
+    "name": "bind-libs",
+    "summary": "Libraries used by the BIND DNS packages"
+  },
+  {
+    "name": "bind-license",
+    "summary": "License of the BIND DNS suite"
+  },
+  {
+    "name": "bind-utils",
+    "summary": "Utilities for querying DNS name servers"
+  },
+  {
+    "name": "bind9.18",
+    "summary": "The Berkeley Internet Name Domain (BIND) DNS (Domain Name System) server"
+  },
+  {
+    "name": "bind9.18-chroot",
+    "summary": "A chroot runtime environment for the ISC BIND DNS server, named(8)"
+  },
+  {
+    "name": "bind9.18-dnssec-utils",
+    "summary": "DNSSEC keys and zones management utilities"
+  },
+  {
+    "name": "bind9.18-dyndb-ldap",
+    "summary": "LDAP back-end plug-in for BIND"
+  },
+  {
+    "name": "bind9.18-libs",
+    "summary": "Libraries used by the BIND DNS packages"
+  },
+  {
+    "name": "bind9.18-utils",
+    "summary": "Utilities for querying DNS name servers"
+  },
+  {
+    "name": "binutils-devel",
+    "summary": "BFD and opcodes static and dynamic libraries and header files"
+  },
+  {
+    "name": "bison",
+    "summary": "A GNU general-purpose parser generator"
+  },
+  {
+    "name": "bison-runtime",
+    "summary": "Runtime support files used by Bison-generated parsers"
+  },
+  {
+    "name": "bitmap-fangsongti-fonts",
+    "summary": "Selected CJK bitmap fonts for Anaconda"
+  },
+  {
+    "name": "blas",
+    "summary": "The Basic Linear Algebra Subprograms library"
+  },
+  {
+    "name": "blivet-data",
+    "summary": "Data for the blivet python module."
+  },
+  {
+    "name": "blktrace",
+    "summary": "Utilities for performing block layer IO tracing in the Linux kernel"
+  },
+  {
+    "name": "bluez-cups",
+    "summary": "CUPS printer backend for Bluetooth printers"
+  },
+  {
+    "name": "bluez-obexd",
+    "summary": "Object Exchange daemon for sharing content"
+  },
+  {
+    "name": "bmc-snmp-proxy",
+    "summary": "Reconfigure SNMP to include host SNMP agent within BMC"
+  },
+  {
+    "name": "bogofilter",
+    "summary": "Fast anti-spam filtering by Bayesian statistical analysis"
+  },
+  {
+    "name": "boom-boot",
+    "summary": "A set of libraries and tools for managing boot loader entries"
+  },
+  {
+    "name": "boom-boot-conf",
+    "summary": "A set of libraries and tools for managing boot loader entries"
+  },
+  {
+    "name": "boom-boot-grub2",
+    "summary": "A set of libraries and tools for managing boot loader entries"
+  },
+  {
+    "name": "boost",
+    "summary": "The free peer-reviewed portable C++ source libraries"
+  },
+  {
+    "name": "boost-atomic",
+    "summary": "Run-time component of boost atomic library"
+  },
+  {
+    "name": "boost-chrono",
+    "summary": "Run-time component of boost chrono library"
+  },
+  {
+    "name": "boost-container",
+    "summary": "Run-time component of boost container library"
+  },
+  {
+    "name": "boost-context",
+    "summary": "Run-time component of boost context switching library"
+  },
+  {
+    "name": "boost-contract",
+    "summary": "Run-time component of boost contract library"
+  },
+  {
+    "name": "boost-coroutine",
+    "summary": "Run-time component of boost coroutine library"
+  },
+  {
+    "name": "boost-date-time",
+    "summary": "Run-time component of boost date-time library"
+  },
+  {
+    "name": "boost-devel",
+    "summary": "The Boost C++ headers and shared development libraries"
+  },
+  {
+    "name": "boost-fiber",
+    "summary": "Run-time component of boost fiber library"
+  },
+  {
+    "name": "boost-filesystem",
+    "summary": "Run-time component of boost filesystem library"
+  },
+  {
+    "name": "boost-graph",
+    "summary": "Run-time component of boost graph library"
+  },
+  {
+    "name": "boost-iostreams",
+    "summary": "Run-time component of boost iostreams library"
+  },
+  {
+    "name": "boost-json",
+    "summary": "Run-time component of boost json library"
+  },
+  {
+    "name": "boost-locale",
+    "summary": "Run-time component of boost locale library"
+  },
+  {
+    "name": "boost-log",
+    "summary": "Run-time component of boost logging library"
+  },
+  {
+    "name": "boost-math",
+    "summary": "Math functions for boost TR1 library"
+  },
+  {
+    "name": "boost-nowide",
+    "summary": "Standard library functions with UTF-8 API on Windows"
+  },
+  {
+    "name": "boost-numpy3",
+    "summary": "Run-time component of boost numpy library for Python 3"
+  },
+  {
+    "name": "boost-program-options",
+    "summary": "Run-time component of boost program_options library"
+  },
+  {
+    "name": "boost-python3",
+    "summary": "Run-time component of boost python library for Python 3"
+  },
+  {
+    "name": "boost-random",
+    "summary": "Run-time component of boost random library"
+  },
+  {
+    "name": "boost-regex",
+    "summary": "Run-time component of boost regular expression library"
+  },
+  {
+    "name": "boost-serialization",
+    "summary": "Run-time component of boost serialization library"
+  },
+  {
+    "name": "boost-stacktrace",
+    "summary": "Run-time component of boost stacktrace library"
+  },
+  {
+    "name": "boost-system",
+    "summary": "Run-time component of boost system support library"
+  },
+  {
+    "name": "boost-test",
+    "summary": "Run-time component of boost test library"
+  },
+  {
+    "name": "boost-thread",
+    "summary": "Run-time component of boost thread library"
+  },
+  {
+    "name": "boost-timer",
+    "summary": "Run-time component of boost timer library"
+  },
+  {
+    "name": "boost-type_erasure",
+    "summary": "Run-time component of boost type erasure library"
+  },
+  {
+    "name": "boost-wave",
+    "summary": "Run-time component of boost C99/C++ preprocessing library"
+  },
+  {
+    "name": "bootc",
+    "summary": "Bootable container system"
+  },
+  {
+    "name": "bootupd",
+    "summary": "Bootloader updater"
+  },
+  {
+    "name": "Box2D",
+    "summary": "A 2D Physics Engine for Games"
+  },
+  {
+    "name": "bpftool",
+    "summary": "Inspection and simple manipulation of eBPF programs and maps"
+  },
+  {
+    "name": "bpftrace",
+    "summary": "High-level tracing language for Linux eBPF"
+  },
+  {
+    "name": "brlapi",
+    "summary": "Application Programming Interface for BRLTTY"
+  },
+  {
+    "name": "brltty",
+    "summary": "Braille display driver for Linux/Unix"
+  },
+  {
+    "name": "brltty-at-spi2",
+    "summary": "AtSpi2 driver for BRLTTY"
+  },
+  {
+    "name": "brltty-docs",
+    "summary": "Documentation for BRLTTY"
+  },
+  {
+    "name": "brltty-dracut",
+    "summary": "brltty module for Dracut"
+  },
+  {
+    "name": "brltty-espeak-ng",
+    "summary": "eSpeak-NG driver for BRLTTY"
+  },
+  {
+    "name": "brltty-xw",
+    "summary": "XWindow driver for BRLTTY"
+  },
+  {
+    "name": "brotli",
+    "summary": "Lossless compression algorithm"
+  },
+  {
+    "name": "brotli-devel",
+    "summary": "Lossless compression algorithm (development files)"
+  },
+  {
+    "name": "bsdtar",
+    "summary": "Manipulate tape archives"
+  },
+  {
+    "name": "bsf",
+    "summary": "Bean Scripting Framework"
+  },
+  {
+    "name": "buildah",
+    "summary": "A command line tool used for creating OCI Images"
+  },
+  {
+    "name": "buildah-tests",
+    "summary": "Tests for buildah"
+  },
+  {
+    "name": "butane",
+    "summary": "Butane config transpiler"
+  },
+  {
+    "name": "byacc",
+    "summary": "Berkeley Yacc, a parser generator"
+  },
+  {
+    "name": "byte-buddy",
+    "summary": "Runtime code generation for the Java virtual machine"
+  },
+  {
+    "name": "byteman",
+    "summary": "Java agent-based bytecode injection tool"
+  },
+  {
+    "name": "byteman-bmunit",
+    "summary": "TestNG and JUnit integration for Byteman."
+  },
+  {
+    "name": "byteman-javadoc",
+    "summary": "Javadoc for byteman"
+  },
+  {
+    "name": "bzip2-devel",
+    "summary": "Libraries and header files for apps which will use bzip2"
+  },
+  {
+    "name": "c-ares-devel",
+    "summary": "Development files for c-ares"
+  },
+  {
+    "name": "c2esp",
+    "summary": "CUPS driver for Kodak AiO printers"
+  },
+  {
+    "name": "cairo",
+    "summary": "A 2D graphics library"
+  },
+  {
+    "name": "cairo-devel",
+    "summary": "Development files for cairo"
+  },
+  {
+    "name": "cairo-gobject",
+    "summary": "GObject bindings for cairo"
+  },
+  {
+    "name": "cairo-gobject-devel",
+    "summary": "Development files for cairo-gobject"
+  },
+  {
+    "name": "cairomm",
+    "summary": "C++ API for the cairo graphics library"
+  },
+  {
+    "name": "capstone",
+    "summary": "A lightweight multi-platform, multi-architecture disassembly framework"
+  },
+  {
+    "name": "cargo",
+    "summary": "Rust's package manager and build tool"
+  },
+  {
+    "name": "cargo-doc",
+    "summary": "Documentation for Cargo"
+  },
+  {
+    "name": "cdi-api",
+    "summary": "CDI API"
+  },
+  {
+    "name": "cdrskin",
+    "summary": "Limited cdrecord compatibility wrapper to ease migration to libburn"
+  },
+  {
+    "name": "cepces",
+    "summary": "Certificate Enrollment through CEP/CES"
+  },
+  {
+    "name": "cepces-certmonger",
+    "summary": "certmonger integration for cepces"
+  },
+  {
+    "name": "cepces-selinux",
+    "summary": "SELinux support for cepces"
+  },
+  {
+    "name": "certmonger",
+    "summary": "Certificate status monitor and PKI enrollment client"
+  },
+  {
+    "name": "chan",
+    "summary": "Pure C implementation of Go channels"
+  },
+  {
+    "name": "check",
+    "summary": "A unit test framework for C"
+  },
+  {
+    "name": "check-devel",
+    "summary": "Libraries and headers for developing programs with check"
+  },
+  {
+    "name": "checkpolicy",
+    "summary": "SELinux policy compiler"
+  },
+  {
+    "name": "cheese-libs",
+    "summary": "Webcam display and capture widgets"
+  },
+  {
+    "name": "chrome-gnome-shell",
+    "summary": "Support for managing GNOME Shell Extensions through web browsers"
+  },
+  {
+    "name": "cim-schema",
+    "summary": "Common Information Model (CIM) Schema"
+  },
+  {
+    "name": "cjose",
+    "summary": "C library implementing the Javascript Object Signing and Encryption (JOSE)"
+  },
+  {
+    "name": "clang",
+    "summary": "A C language family front-end for LLVM"
+  },
+  {
+    "name": "clang-analyzer",
+    "summary": "A source code analysis framework"
+  },
+  {
+    "name": "clang-devel",
+    "summary": "Development header files for clang"
+  },
+  {
+    "name": "clang-libs",
+    "summary": "Runtime library for clang"
+  },
+  {
+    "name": "clang-resource-filesystem",
+    "summary": "Filesystem package that owns the clang resource directory"
+  },
+  {
+    "name": "clang-tools-extra",
+    "summary": "Extra tools for clang"
+  },
+  {
+    "name": "cldr-emoji-annotation",
+    "summary": "Emoji annotation files in CLDR"
+  },
+  {
+    "name": "cldr-emoji-annotation-dtd",
+    "summary": "DTD files of CLDR common"
+  },
+  {
+    "name": "clevis",
+    "summary": "Automated decryption framework"
+  },
+  {
+    "name": "clevis-dracut",
+    "summary": "Dracut integration for clevis"
+  },
+  {
+    "name": "clevis-luks",
+    "summary": "LUKS integration for clevis"
+  },
+  {
+    "name": "clevis-pin-pkcs11",
+    "summary": "PKCS#11 for clevis"
+  },
+  {
+    "name": "clevis-pin-tpm2",
+    "summary": "Clevis PIN for unlocking with TPM2 supporting Authorized Policies"
+  },
+  {
+    "name": "clevis-systemd",
+    "summary": "systemd integration for clevis"
+  },
+  {
+    "name": "clevis-udisks2",
+    "summary": "UDisks2/Storaged integration for clevis"
+  },
+  {
+    "name": "clippy",
+    "summary": "Lints to catch common mistakes and improve your Rust code"
+  },
+  {
+    "name": "cloud-init",
+    "summary": "Cloud instance init scripts"
+  },
+  {
+    "name": "cloud-utils-growpart",
+    "summary": "Script for growing a partition"
+  },
+  {
+    "name": "clucene-contribs-lib",
+    "summary": "Language specific text analyzers for clucene"
+  },
+  {
+    "name": "clucene-core",
+    "summary": "Core clucene module"
+  },
+  {
+    "name": "clutter",
+    "summary": "Open Source software library for creating rich graphical user interfaces"
+  },
+  {
+    "name": "clutter-gst3",
+    "summary": "GStreamer integration library for Clutter"
+  },
+  {
+    "name": "clutter-gtk",
+    "summary": "A basic GTK clutter widget"
+  },
+  {
+    "name": "cmake",
+    "summary": "Cross-platform make system"
+  },
+  {
+    "name": "cmake-data",
+    "summary": "Common data-files for cmake"
+  },
+  {
+    "name": "cmake-doc",
+    "summary": "Documentation for cmake"
+  },
+  {
+    "name": "cmake-filesystem",
+    "summary": "Directories used by CMake modules"
+  },
+  {
+    "name": "cmake-gui",
+    "summary": "Qt GUI for cmake"
+  },
+  {
+    "name": "cmake-rpm-macros",
+    "summary": "Common RPM macros for cmake"
+  },
+  {
+    "name": "cockpit-composer",
+    "summary": "Composer GUI for use with Cockpit"
+  },
+  {
+    "name": "cockpit-files",
+    "summary": "A filesystem browser for Cockpit"
+  },
+  {
+    "name": "cockpit-leapp",
+    "summary": "Leapp in-place upgrade Cockpit UI"
+  },
+  {
+    "name": "cockpit-machines",
+    "summary": "Cockpit user interface for virtual machines"
+  },
+  {
+    "name": "cockpit-ostree",
+    "summary": "Cockpit user interface for rpm-ostree"
+  },
+  {
+    "name": "cockpit-packagekit",
+    "summary": "Cockpit user interface for packages"
+  },
+  {
+    "name": "cockpit-pcp",
+    "summary": "Cockpit PCP integration"
+  },
+  {
+    "name": "cockpit-podman",
+    "summary": "Cockpit component for Podman containers"
+  },
+  {
+    "name": "cockpit-session-recording",
+    "summary": "Cockpit Session Recording"
+  },
+  {
+    "name": "cockpit-storaged",
+    "summary": "Cockpit user interface for storage, using udisks"
+  },
+  {
+    "name": "cogl",
+    "summary": "A library for using 3D graphics hardware to draw pretty pictures"
+  },
+  {
+    "name": "color-filesystem",
+    "summary": "Color filesystem layout"
+  },
+  {
+    "name": "colord",
+    "summary": "Color daemon"
+  },
+  {
+    "name": "colord-gtk",
+    "summary": "GTK support library for colord"
+  },
+  {
+    "name": "colord-libs",
+    "summary": "Color daemon library"
+  },
+  {
+    "name": "command-line-assistant",
+    "summary": "A simple wrapper to interact with RAG"
+  },
+  {
+    "name": "command-line-assistant-selinux",
+    "summary": "CLAD SELinux policy"
+  },
+  {
+    "name": "compat-hesiod",
+    "summary": "Development libraries and headers for Hesiod"
+  },
+  {
+    "name": "compat-libgfortran-48",
+    "summary": "Compatibility Fortran runtime library version 4.8.5"
+  },
+  {
+    "name": "compat-openssl11",
+    "summary": "Utilities from the general purpose cryptography library with TLS implementation"
+  },
+  {
+    "name": "compat-paratype-pt-sans-fonts-f33-f34",
+    "summary": "Fedora-33 & 34 compatibility package"
+  },
+  {
+    "name": "compiler-rt",
+    "summary": "LLVM \"compiler-rt\" runtime libraries"
+  },
+  {
+    "name": "composefs",
+    "summary": "Tools to handle creating and mounting composefs images"
+  },
+  {
+    "name": "composefs-libs",
+    "summary": "Libraries for composefs"
+  },
+  {
+    "name": "conmon",
+    "summary": "OCI container runtime monitor"
+  },
+  {
+    "name": "conntrack-tools",
+    "summary": "Manipulate netfilter connection tracking table and run High Availability"
+  },
+  {
+    "name": "console-login-helper-messages",
+    "summary": "Combines motd, issue, profile features to show system information to the user before/on login"
+  },
+  {
+    "name": "console-login-helper-messages-issuegen",
+    "summary": "Issue generator scripts showing SSH keys and IP address"
+  },
+  {
+    "name": "console-login-helper-messages-motdgen",
+    "summary": "Message of the day generator script showing system information"
+  },
+  {
+    "name": "console-login-helper-messages-profile",
+    "summary": "Profile script showing systemd failed units"
+  },
+  {
+    "name": "console-setup",
+    "summary": "Tools for configuring the console using X Window System key maps"
+  },
+  {
+    "name": "container-selinux",
+    "summary": "SELinux policies for container runtimes"
+  },
+  {
+    "name": "container-tools",
+    "summary": "A meta-package witch container tools such as podman, buildah, skopeo, etc."
+  },
+  {
+    "name": "containernetworking-plugins",
+    "summary": "CNI network plugins"
+  },
+  {
+    "name": "containers-common",
+    "summary": "Common configuration and documentation for containers"
+  },
+  {
+    "name": "containers-common-extra",
+    "summary": "Extra dependencies for Podman and Buildah"
+  },
+  {
+    "name": "convmv",
+    "summary": "Convert filename encodings"
+  },
+  {
+    "name": "copy-jdk-configs",
+    "summary": "JDKs configuration files copier"
+  },
+  {
+    "name": "coreos-installer",
+    "summary": "Installer for Fedora CoreOS and RHEL CoreOS"
+  },
+  {
+    "name": "coreos-installer-bootinfra",
+    "summary": "coreos-installer boot-time infrastructure for use on Fedora/RHEL CoreOS"
+  },
+  {
+    "name": "coreos-installer-dracut",
+    "summary": "Dracut module for running coreos-installer in the initrd"
+  },
+  {
+    "name": "corosynclib",
+    "summary": "The Corosync Cluster Engine Libraries"
+  },
+  {
+    "name": "cpp",
+    "summary": "The C Preprocessor"
+  },
+  {
+    "name": "crash",
+    "summary": "Kernel analysis utility for live systems, netdump, diskdump, kdump, LKCD or mcore dumpfiles"
+  },
+  {
+    "name": "crash-gcore-command",
+    "summary": "Gcore extension module for the crash utility"
+  },
+  {
+    "name": "crash-trace-command",
+    "summary": "Trace extension module for the crash utility"
+  },
+  {
+    "name": "createrepo_c",
+    "summary": "Creates a common metadata repository"
+  },
+  {
+    "name": "createrepo_c-libs",
+    "summary": "Library for repodata manipulation"
+  },
+  {
+    "name": "crit",
+    "summary": "CRIU image tool"
+  },
+  {
+    "name": "criu",
+    "summary": "Tool for Checkpoint/Restore in User-space"
+  },
+  {
+    "name": "criu-libs",
+    "summary": "Libraries for criu"
+  },
+  {
+    "name": "crun",
+    "summary": "OCI runtime written in C"
+  },
+  {
+    "name": "cscope",
+    "summary": "C source code tree search and browse tool"
+  },
+  {
+    "name": "culmus-aharoni-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-caladings-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-david-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-drugulin-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-ellinia-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-fonts-common",
+    "summary": "Common files of culmus-fonts"
+  },
+  {
+    "name": "culmus-frank-ruehl-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-hadasim-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-miriam-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-miriam-mono-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-nachlieli-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-simple-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-stamashkenaz-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-stamsefarad-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-yehuda-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "CUnit",
+    "summary": "Unit testing framework for C"
+  },
+  {
+    "name": "cups",
+    "summary": "CUPS printing system"
+  },
+  {
+    "name": "cups-client",
+    "summary": "CUPS printing system - client programs"
+  },
+  {
+    "name": "cups-devel",
+    "summary": "CUPS printing system - development environment"
+  },
+  {
+    "name": "cups-filesystem",
+    "summary": "CUPS printing system - directory layout"
+  },
+  {
+    "name": "cups-filters",
+    "summary": "OpenPrinting CUPS filters and backends"
+  },
+  {
+    "name": "cups-filters-libs",
+    "summary": "OpenPrinting CUPS filters and backends - cupsfilters and fontembed libraries"
+  },
+  {
+    "name": "cups-ipptool",
+    "summary": "CUPS printing system - tool for performing IPP requests"
+  },
+  {
+    "name": "cups-lpd",
+    "summary": "CUPS printing system - lpd emulation"
+  },
+  {
+    "name": "cups-pk-helper",
+    "summary": "A helper that makes system-config-printer use PolicyKit"
+  },
+  {
+    "name": "cups-printerapp",
+    "summary": "CUPS printing system - tools for printer application"
+  },
+  {
+    "name": "cxl-cli",
+    "summary": "Manage CXL devices"
+  },
+  {
+    "name": "cyrus-imapd",
+    "summary": "A high-performance email, contacts and calendar server"
+  },
+  {
+    "name": "cyrus-imapd-libs",
+    "summary": "Runtime libraries for cyrus-imapd"
+  },
+  {
+    "name": "cyrus-imapd-utils",
+    "summary": "Cyrus IMAP server administration utilities"
+  },
+  {
+    "name": "cyrus-sasl-devel",
+    "summary": "Files needed for developing applications with Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-gs2",
+    "summary": "GS2 support for Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-ldap",
+    "summary": "LDAP auxprop support for Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-md5",
+    "summary": "CRAM-MD5 and DIGEST-MD5 authentication support for Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-ntlm",
+    "summary": "NTLM authentication support for Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-sql",
+    "summary": "SQL auxprop support for Cyrus SASL"
+  },
+  {
+    "name": "daxctl",
+    "summary": "Manage Device-DAX instances"
+  },
+  {
+    "name": "dbus-daemon",
+    "summary": "D-BUS message bus"
+  },
+  {
+    "name": "dbus-devel",
+    "summary": "Development files for D-BUS"
+  },
+  {
+    "name": "dbus-glib",
+    "summary": "GLib bindings for D-Bus"
+  },
+  {
+    "name": "dbus-glib-devel",
+    "summary": "Libraries and headers for the D-Bus GLib bindings"
+  },
+  {
+    "name": "dbus-x11",
+    "summary": "X11-requiring add-ons for D-BUS"
+  },
+  {
+    "name": "dconf",
+    "summary": "A configuration system"
+  },
+  {
+    "name": "dconf-editor",
+    "summary": "Configuration editor for dconf"
+  },
+  {
+    "name": "dcraw",
+    "summary": "Tool for decoding raw image data from digital cameras"
+  },
+  {
+    "name": "ddiskit",
+    "summary": "Tool for Red Hat Enterprise Linux Driver Update Disk creation"
+  },
+  {
+    "name": "debugedit",
+    "summary": "Tools for debuginfo creation"
+  },
+  {
+    "name": "dejavu-lgc-sans-fonts",
+    "summary": "A variable-width Latin-Greek-Cyrillic sans-serif font family"
+  },
+  {
+    "name": "dejavu-lgc-sans-mono-fonts",
+    "summary": "A variable-width Latin-Greek-Cyrillic mono-space font family"
+  },
+  {
+    "name": "dejavu-lgc-serif-fonts",
+    "summary": "A variable-width Latin-Greek-Cyrillic serif font family"
+  },
+  {
+    "name": "delve",
+    "summary": "A debugger for the Go programming language"
+  },
+  {
+    "name": "desktop-file-utils",
+    "summary": "Utilities for manipulating .desktop files"
+  },
+  {
+    "name": "devhelp",
+    "summary": "API documentation browser"
+  },
+  {
+    "name": "devhelp-libs",
+    "summary": "Library to embed Devhelp in other applications"
+  },
+  {
+    "name": "dialog",
+    "summary": "A utility for creating TTY dialog boxes"
+  },
+  {
+    "name": "diffstat",
+    "summary": "A utility which provides statistics based on the output of diff"
+  },
+  {
+    "name": "disruptor",
+    "summary": "Concurrent Programming Framework"
+  },
+  {
+    "name": "dlm-lib",
+    "summary": "Library for dlm"
+  },
+  {
+    "name": "dnf-bootc",
+    "summary": "Package manager - additional bootc dependencies"
+  },
+  {
+    "name": "dnsconfd",
+    "summary": "Local DNS cache configuration daemon"
+  },
+  {
+    "name": "dnsconfd-dracut",
+    "summary": "dnsconfd dracut module"
+  },
+  {
+    "name": "dnsconfd-micro",
+    "summary": "Minimized native implementation of Dnsconfd"
+  },
+  {
+    "name": "dnsconfd-selinux",
+    "summary": "dnsconfd SELinux policy"
+  },
+  {
+    "name": "dnsconfd-unbound",
+    "summary": "dnsconfd unbound module"
+  },
+  {
+    "name": "dnsmasq",
+    "summary": "A lightweight DHCP/caching DNS server"
+  },
+  {
+    "name": "dnsmasq-utils",
+    "summary": "Utilities for manipulating DHCP server leases"
+  },
+  {
+    "name": "docbook-dtds",
+    "summary": "SGML and XML document type definitions for DocBook"
+  },
+  {
+    "name": "docbook-style-xsl",
+    "summary": "Norman Walsh's XSL stylesheets for DocBook XML"
+  },
+  {
+    "name": "docbook5-style-xsl",
+    "summary": "Norman Walsh's XSL stylesheets for DocBook 5.X"
+  },
+  {
+    "name": "docbook5-style-xsl-extensions",
+    "summary": "Norman Walsh's XSL stylesheets extensions for DocBook 5.X"
+  },
+  {
+    "name": "dotconf",
+    "summary": "Libraries to parse configuration files"
+  },
+  {
+    "name": "dotnet-apphost-pack-6.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 6.0"
+  },
+  {
+    "name": "dotnet-apphost-pack-7.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 7.0"
+  },
+  {
+    "name": "dotnet-apphost-pack-8.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 8.0"
+  },
+  {
+    "name": "dotnet-apphost-pack-9.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 9.0"
+  },
+  {
+    "name": "dotnet-host",
+    "summary": ".NET command line launcher"
+  },
+  {
+    "name": "dotnet-hostfxr-6.0",
+    "summary": ".NET command line host resolver"
+  },
+  {
+    "name": "dotnet-hostfxr-7.0",
+    "summary": ".NET command line host resolver"
+  },
+  {
+    "name": "dotnet-hostfxr-8.0",
+    "summary": ".NET command line host resolver"
+  },
+  {
+    "name": "dotnet-hostfxr-9.0",
+    "summary": ".NET command line host resolver"
+  },
+  {
+    "name": "dotnet-runtime-6.0",
+    "summary": "NET 6.0 runtime"
+  },
+  {
+    "name": "dotnet-runtime-7.0",
+    "summary": "NET 7.0 runtime"
+  },
+  {
+    "name": "dotnet-runtime-8.0",
+    "summary": "NET 8.0 runtime"
+  },
+  {
+    "name": "dotnet-runtime-9.0",
+    "summary": "NET 9.0 runtime"
+  },
+  {
+    "name": "dotnet-runtime-dbg-8.0",
+    "summary": "Managed debug symbols NET 8.0 runtime"
+  },
+  {
+    "name": "dotnet-runtime-dbg-9.0",
+    "summary": "Managed debug symbols NET 9.0 runtime"
+  },
+  {
+    "name": "dotnet-sdk-6.0",
+    "summary": ".NET 6.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-7.0",
+    "summary": ".NET 7.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-8.0",
+    "summary": ".NET 8.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-8.0-source-built-artifacts",
+    "summary": "Internal package for building .NET 8.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-9.0",
+    "summary": ".NET 9.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-aot-9.0",
+    "summary": "Ahead-of-Time (AOT) support for the .NET 9.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-dbg-8.0",
+    "summary": "Managed debug symbols for the .NET 8.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-dbg-9.0",
+    "summary": "Managed debug symbols for the .NET 9.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-targeting-pack-6.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 6.0"
+  },
+  {
+    "name": "dotnet-targeting-pack-7.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 7.0"
+  },
+  {
+    "name": "dotnet-targeting-pack-8.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 8.0"
+  },
+  {
+    "name": "dotnet-targeting-pack-9.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 9.0"
+  },
+  {
+    "name": "dotnet-templates-6.0",
+    "summary": ".NET 6.0 templates"
+  },
+  {
+    "name": "dotnet-templates-7.0",
+    "summary": ".NET 7.0 templates"
+  },
+  {
+    "name": "dotnet-templates-8.0",
+    "summary": ".NET 8.0 templates"
+  },
+  {
+    "name": "dotnet-templates-9.0",
+    "summary": ".NET 9.0 templates"
+  },
+  {
+    "name": "double-conversion",
+    "summary": "Library providing binary-decimal and decimal-binary routines for IEEE doubles"
+  },
+  {
+    "name": "dovecot",
+    "summary": "Secure imap and pop3 server"
+  },
+  {
+    "name": "dovecot-mysql",
+    "summary": "MySQL back end for dovecot"
+  },
+  {
+    "name": "dovecot-pgsql",
+    "summary": "Postgres SQL back end for dovecot"
+  },
+  {
+    "name": "dovecot-pigeonhole",
+    "summary": "Sieve and managesieve plug-in for dovecot"
+  },
+  {
+    "name": "dpdk",
+    "summary": "Set of libraries and drivers for fast packet processing"
+  },
+  {
+    "name": "dpdk-devel",
+    "summary": "Data Plane Development Kit development files"
+  },
+  {
+    "name": "dpdk-doc",
+    "summary": "Data Plane Development Kit API documentation"
+  },
+  {
+    "name": "dpdk-tools",
+    "summary": "Tools for setting up Data Plane Development Kit environment"
+  },
+  {
+    "name": "dracut-caps",
+    "summary": "dracut modules to build a dracut initramfs which drops capabilities"
+  },
+  {
+    "name": "dracut-live",
+    "summary": "dracut modules to build a dracut initramfs with live image capabilities"
+  },
+  {
+    "name": "drgn",
+    "summary": "Programmable debugger"
+  },
+  {
+    "name": "driverctl",
+    "summary": "Device driver control utility"
+  },
+  {
+    "name": "dtc",
+    "summary": "Device Tree Compiler"
+  },
+  {
+    "name": "dwarves",
+    "summary": "Debugging Information Manipulation Tools (pahole & friends)"
+  },
+  {
+    "name": "dwz",
+    "summary": "DWARF optimization and duplicate removal tool"
+  },
+  {
+    "name": "dyninst",
+    "summary": "An API for Run-time Code Generation"
+  },
+  {
+    "name": "e2fsprogs-devel",
+    "summary": "Ext2/3/4 file system specific libraries and headers"
+  },
+  {
+    "name": "ecj",
+    "summary": "Eclipse Compiler for Java"
+  },
+  {
+    "name": "edk2-aarch64",
+    "summary": "UEFI firmware for aarch64 virtual machines"
+  },
+  {
+    "name": "efi-srpm-macros",
+    "summary": "Common SRPM Macros for building EFI-related packages"
+  },
+  {
+    "name": "efivar",
+    "summary": "Tools to manage UEFI variables"
+  },
+  {
+    "name": "egl-utils",
+    "summary": "EGL utilities"
+  },
+  {
+    "name": "egl-wayland",
+    "summary": "Wayland EGL External Platform library"
+  },
+  {
+    "name": "elfutils-debuginfod",
+    "summary": "HTTP ELF/DWARF file server addressed by build-id"
+  },
+  {
+    "name": "elfutils-debuginfod-client-devel",
+    "summary": "Libraries and headers to build debuginfod client applications"
+  },
+  {
+    "name": "elfutils-devel",
+    "summary": "Development libraries to handle compiled objects"
+  },
+  {
+    "name": "elfutils-libelf-devel",
+    "summary": "Development support for libelf"
+  },
+  {
+    "name": "emacs",
+    "summary": "GNU Emacs text editor"
+  },
+  {
+    "name": "emacs-auctex",
+    "summary": "Enhanced TeX modes for Emacs"
+  },
+  {
+    "name": "emacs-common",
+    "summary": "Emacs common files"
+  },
+  {
+    "name": "emacs-filesystem",
+    "summary": "Emacs filesystem layout"
+  },
+  {
+    "name": "emacs-lucid",
+    "summary": "GNU Emacs text editor with LUCID toolkit X support"
+  },
+  {
+    "name": "emacs-nox",
+    "summary": "GNU Emacs text editor without X support"
+  },
+  {
+    "name": "enchant",
+    "summary": "An Enchanting Spell Checking Library"
+  },
+  {
+    "name": "enchant2",
+    "summary": "An Enchanting Spell Checking Library"
+  },
+  {
+    "name": "enscript",
+    "summary": "A plain ASCII to PostScript converter"
+  },
+  {
+    "name": "esc",
+    "summary": "Enterprise Security Client Smart Card Client"
+  },
+  {
+    "name": "espeak-ng",
+    "summary": "eSpeak NG Text-to-Speech"
+  },
+  {
+    "name": "evince",
+    "summary": "Document viewer"
+  },
+  {
+    "name": "evince-libs",
+    "summary": "Libraries for the evince document viewer"
+  },
+  {
+    "name": "evince-nautilus",
+    "summary": "Evince extension for nautilus"
+  },
+  {
+    "name": "evince-previewer",
+    "summary": "Evince previewer"
+  },
+  {
+    "name": "evince-thumbnailer",
+    "summary": "Evince thumbnailer"
+  },
+  {
+    "name": "evolution",
+    "summary": "Mail and calendar client for GNOME"
+  },
+  {
+    "name": "evolution-bogofilter",
+    "summary": "Bogofilter plugin for Evolution"
+  },
+  {
+    "name": "evolution-data-server",
+    "summary": "Backend data server for Evolution"
+  },
+  {
+    "name": "evolution-data-server-devel",
+    "summary": "Development files for building against evolution-data-server"
+  },
+  {
+    "name": "evolution-data-server-doc",
+    "summary": "Documentation files for evolution-data-server"
+  },
+  {
+    "name": "evolution-data-server-langpacks",
+    "summary": "Translations for evolution-data-server"
+  },
+  {
+    "name": "evolution-data-server-perl",
+    "summary": "Supplemental utilities that require Perl"
+  },
+  {
+    "name": "evolution-data-server-tests",
+    "summary": "Tests for the evolution-data-server package"
+  },
+  {
+    "name": "evolution-data-server-ui",
+    "summary": "libedataserverui library from evolution-data-server"
+  },
+  {
+    "name": "evolution-data-server-ui-devel",
+    "summary": "Development files for building against libedataserverui from evolution-data-server"
+  },
+  {
+    "name": "evolution-ews",
+    "summary": "Evolution extension for Exchange Web Services"
+  },
+  {
+    "name": "evolution-ews-langpacks",
+    "summary": "Translations for evolution-ews"
+  },
+  {
+    "name": "evolution-help",
+    "summary": "Help files for evolution"
+  },
+  {
+    "name": "evolution-langpacks",
+    "summary": "Translations for evolution"
+  },
+  {
+    "name": "evolution-mapi",
+    "summary": "Evolution extension for MS Exchange 2007 servers"
+  },
+  {
+    "name": "evolution-mapi-langpacks",
+    "summary": "Translations for evolution-mapi"
+  },
+  {
+    "name": "evolution-pst",
+    "summary": "PST importer plugin for Evolution"
+  },
+  {
+    "name": "evolution-spamassassin",
+    "summary": "SpamAssassin plugin for Evolution"
+  },
+  {
+    "name": "exchange-bmc-os-info",
+    "summary": "Let OS and BMC exchange info"
+  },
+  {
+    "name": "exempi",
+    "summary": "Library for easy parsing of XMP metadata"
+  },
+  {
+    "name": "exiv2",
+    "summary": "Exif and Iptc metadata manipulation library"
+  },
+  {
+    "name": "exiv2-libs",
+    "summary": "Exif and Iptc metadata manipulation library"
+  },
+  {
+    "name": "expat-devel",
+    "summary": "Libraries and header files to develop applications using expat"
+  },
+  {
+    "name": "expect",
+    "summary": "A program-script interaction and testing utility"
+  },
+  {
+    "name": "fabtests",
+    "summary": "Test suite for libfabric API"
+  },
+  {
+    "name": "fapolicyd",
+    "summary": "Application Whitelisting Daemon"
+  },
+  {
+    "name": "fapolicyd-dnf-plugin",
+    "summary": "Fapolicyd dnf plugin"
+  },
+  {
+    "name": "fapolicyd-selinux",
+    "summary": "Fapolicyd selinux"
+  },
+  {
+    "name": "fdk-aac-free",
+    "summary": "Third-Party Modified Version of the Fraunhofer FDK AAC Codec Library for Android"
+  },
+  {
+    "name": "fdo-admin-cli",
+    "summary": "FDO admin tools implementation"
+  },
+  {
+    "name": "fdo-client",
+    "summary": "FDO Client implementation"
+  },
+  {
+    "name": "fdo-init",
+    "summary": "dracut module for device initialization"
+  },
+  {
+    "name": "fdo-manufacturing-server",
+    "summary": "FDO Manufacturing Server implementation"
+  },
+  {
+    "name": "fdo-owner-cli",
+    "summary": "FDO Owner tools implementation"
+  },
+  {
+    "name": "fdo-owner-onboarding-server",
+    "summary": "FDO Owner Onboarding Server implementation"
+  },
+  {
+    "name": "fdo-rendezvous-server",
+    "summary": "FDO Rendezvous Server implementation"
+  },
+  {
+    "name": "fence-agents-all",
+    "summary": "Set of unified programs capable of host isolation (\"fencing\")"
+  },
+  {
+    "name": "fence-agents-amt-ws",
+    "summary": "Fence agent for Intel AMT (WS-Man) devices"
+  },
+  {
+    "name": "fence-agents-apc",
+    "summary": "Fence agent for APC devices"
+  },
+  {
+    "name": "fence-agents-apc-snmp",
+    "summary": "Fence agents for APC devices (SNMP)"
+  },
+  {
+    "name": "fence-agents-bladecenter",
+    "summary": "Fence agent for IBM BladeCenter"
+  },
+  {
+    "name": "fence-agents-brocade",
+    "summary": "Fence agent for Brocade switches"
+  },
+  {
+    "name": "fence-agents-cisco-mds",
+    "summary": "Fence agent for Cisco MDS 9000 series"
+  },
+  {
+    "name": "fence-agents-cisco-ucs",
+    "summary": "Fence agent for Cisco UCS series"
+  },
+  {
+    "name": "fence-agents-common",
+    "summary": "Common base for Fence Agents"
+  },
+  {
+    "name": "fence-agents-drac5",
+    "summary": "Fence agent for Dell DRAC 5"
+  },
+  {
+    "name": "fence-agents-eaton-snmp",
+    "summary": "Fence agent for Eaton network power switches"
+  },
+  {
+    "name": "fence-agents-emerson",
+    "summary": "Fence agent for Emerson devices (SNMP)"
+  },
+  {
+    "name": "fence-agents-eps",
+    "summary": "Fence agent for ePowerSwitch 8M+ power switches"
+  },
+  {
+    "name": "fence-agents-heuristics-ping",
+    "summary": "Pseudo fence agent to affect other agents based on ping-heuristics"
+  },
+  {
+    "name": "fence-agents-hpblade",
+    "summary": "Fence agent for HP BladeSystem devices"
+  },
+  {
+    "name": "fence-agents-ibm-powervs",
+    "summary": "Fence agent for IBM PowerVS"
+  },
+  {
+    "name": "fence-agents-ibm-vpc",
+    "summary": "Fence agent for IBM Cloud VPC"
+  },
+  {
+    "name": "fence-agents-ibmblade",
+    "summary": "Fence agent for IBM BladeCenter"
+  },
+  {
+    "name": "fence-agents-ifmib",
+    "summary": "Fence agent for devices with IF-MIB interfaces"
+  },
+  {
+    "name": "fence-agents-ilo-moonshot",
+    "summary": "Fence agent for HP iLO Moonshot devices"
+  },
+  {
+    "name": "fence-agents-ilo-mp",
+    "summary": "Fence agent for HP iLO MP devices"
+  },
+  {
+    "name": "fence-agents-ilo-ssh",
+    "summary": "Fence agents for HP iLO devices over SSH"
+  },
+  {
+    "name": "fence-agents-ilo2",
+    "summary": "Fence agents for HP iLO2 devices"
+  },
+  {
+    "name": "fence-agents-intelmodular",
+    "summary": "Fence agent for devices with Intel Modular interfaces"
+  },
+  {
+    "name": "fence-agents-ipdu",
+    "summary": "Fence agent for IBM iPDU network power switches"
+  },
+  {
+    "name": "fence-agents-ipmilan",
+    "summary": "Fence agents for devices with IPMI interface"
+  },
+  {
+    "name": "fence-agents-kdump",
+    "summary": "Fence agent for use with kdump crash recovery service"
+  },
+  {
+    "name": "fence-agents-kubevirt",
+    "summary": "Fence agent for KubeVirt platform"
+  },
+  {
+    "name": "fence-agents-lpar",
+    "summary": "Fence agent for IBM LPAR"
+  },
+  {
+    "name": "fence-agents-mpath",
+    "summary": "Fence agent for reservations over Device Mapper Multipath"
+  },
+  {
+    "name": "fence-agents-redfish",
+    "summary": "Fence agent for Redfish"
+  },
+  {
+    "name": "fence-agents-rhevm",
+    "summary": "Fence agent for RHEV-M"
+  },
+  {
+    "name": "fence-agents-rsa",
+    "summary": "Fence agent for IBM RSA II"
+  },
+  {
+    "name": "fence-agents-rsb",
+    "summary": "Fence agent for Fujitsu RSB"
+  },
+  {
+    "name": "fence-agents-sbd",
+    "summary": "Fence agent for SBD (storage-based death)"
+  },
+  {
+    "name": "fence-agents-scsi",
+    "summary": "Fence agent for SCSI persistent reservations"
+  },
+  {
+    "name": "fence-agents-virsh",
+    "summary": "Fence agent for virtual machines based on libvirt"
+  },
+  {
+    "name": "fence-agents-vmware-rest",
+    "summary": "Fence agent for VMWare with REST API"
+  },
+  {
+    "name": "fence-agents-vmware-soap",
+    "summary": "Fence agent for VMWare with SOAP API v4.1+"
+  },
+  {
+    "name": "fence-agents-wti",
+    "summary": "Fence agent for WTI Network power switches"
+  },
+  {
+    "name": "festival",
+    "summary": "Speech synthesis and text-to-speech system"
+  },
+  {
+    "name": "festival-data",
+    "summary": "Data files for the Festival speech synthesis system"
+  },
+  {
+    "name": "festvox-slt-arctic-hts",
+    "summary": "US English female speaker \"SLT\" for Festival"
+  },
+  {
+    "name": "fetchmail",
+    "summary": "A remote mail retrieval and forwarding utility"
+  },
+  {
+    "name": "fftw",
+    "summary": "A Fast Fourier Transform library"
+  },
+  {
+    "name": "fftw-devel",
+    "summary": "Headers, libraries and docs for the FFTW library"
+  },
+  {
+    "name": "fftw-libs",
+    "summary": "FFTW run-time library"
+  },
+  {
+    "name": "fftw-libs-double",
+    "summary": "FFTW library, double precision"
+  },
+  {
+    "name": "fftw-libs-long",
+    "summary": "FFTW library, long double precision"
+  },
+  {
+    "name": "fftw-libs-single",
+    "summary": "FFTW library, single precision"
+  },
+  {
+    "name": "fftw-openmpi-devel",
+    "summary": "Headers, libraries and docs for the FFTW OpenMPI library"
+  },
+  {
+    "name": "fftw-openmpi-libs",
+    "summary": "FFTW OpenMPI run-time library"
+  },
+  {
+    "name": "fftw-openmpi-libs-double",
+    "summary": "FFTW OpenMPI library, double precision"
+  },
+  {
+    "name": "fftw-openmpi-libs-long",
+    "summary": "FFTW OpenMPI library, long double precision"
+  },
+  {
+    "name": "fftw-openmpi-libs-single",
+    "summary": "FFTW OpenMPI library, single precision"
+  },
+  {
+    "name": "fftw-openmpi-static",
+    "summary": "Static versions of the FFTW OpenMPI libraries"
+  },
+  {
+    "name": "fftw-static",
+    "summary": "Static versions of the FFTW libraries"
+  },
+  {
+    "name": "fido2-tools",
+    "summary": "FIDO2 tools"
+  },
+  {
+    "name": "fio",
+    "summary": "Multithreaded IO generation tool"
+  },
+  {
+    "name": "fio-engine-http",
+    "summary": "HTTP engine for fio."
+  },
+  {
+    "name": "fio-engine-libaio",
+    "summary": "Linux libaio engine for fio."
+  },
+  {
+    "name": "fio-engine-nbd",
+    "summary": "Network Block Device engine for fio."
+  },
+  {
+    "name": "fio-engine-rados",
+    "summary": "Rados engine for fio."
+  },
+  {
+    "name": "fio-engine-rbd",
+    "summary": "Rados Block Device engine for fio."
+  },
+  {
+    "name": "fio-engine-rdma",
+    "summary": "RDMA engine for fio."
+  },
+  {
+    "name": "firefox",
+    "summary": "Mozilla Firefox Web browser"
+  },
+  {
+    "name": "firefox-x11",
+    "summary": "Firefox X11 launcher."
+  },
+  {
+    "name": "firewall-applet",
+    "summary": "Firewall panel applet"
+  },
+  {
+    "name": "firewall-config",
+    "summary": "Firewall configuration application"
+  },
+  {
+    "name": "flac-libs",
+    "summary": "Libraries for the Free Lossless Audio Codec"
+  },
+  {
+    "name": "flashrom",
+    "summary": "Simple program for reading/writing flash chips content"
+  },
+  {
+    "name": "flatpak",
+    "summary": "Application deployment framework for desktop apps"
+  },
+  {
+    "name": "flatpak-builder",
+    "summary": "Tool to build flatpaks from source"
+  },
+  {
+    "name": "flatpak-libs",
+    "summary": "Libraries for flatpak"
+  },
+  {
+    "name": "flatpak-selinux",
+    "summary": "SELinux policy module for flatpak"
+  },
+  {
+    "name": "flatpak-session-helper",
+    "summary": "User D-Bus service used by flatpak and others"
+  },
+  {
+    "name": "flatpak-spawn",
+    "summary": "Command-line frontend for the org.freedesktop.Flatpak service"
+  },
+  {
+    "name": "flatpak-xdg-utils",
+    "summary": "Command-line tools for use inside Flatpak sandboxes"
+  },
+  {
+    "name": "flex",
+    "summary": "A tool for generating scanners (text pattern recognizers)"
+  },
+  {
+    "name": "flex-doc",
+    "summary": "Documentation for the flex scanner generator"
+  },
+  {
+    "name": "flexiblas",
+    "summary": "A BLAS/LAPACK wrapper library with runtime exchangeable backends"
+  },
+  {
+    "name": "flexiblas-devel",
+    "summary": "Development headers and libraries for FlexiBLAS"
+  },
+  {
+    "name": "flexiblas-netlib",
+    "summary": "FlexiBLAS wrapper library"
+  },
+  {
+    "name": "flexiblas-netlib64",
+    "summary": "FlexiBLAS wrapper library (64-bit)"
+  },
+  {
+    "name": "flexiblas-openblas-openmp",
+    "summary": "FlexiBLAS wrappers for OpenBLAS"
+  },
+  {
+    "name": "flexiblas-openblas-openmp64",
+    "summary": "FlexiBLAS wrappers for OpenBLAS (64-bit)"
+  },
+  {
+    "name": "flexiblas-openblas-serial",
+    "summary": "FlexiBLAS wrappers for OpenBLAS"
+  },
+  {
+    "name": "flite",
+    "summary": "Small, fast speech synthesis engine (text-to-speech)"
+  },
+  {
+    "name": "fltk",
+    "summary": "C++ user interface toolkit"
+  },
+  {
+    "name": "fontawesome-fonts",
+    "summary": "Iconic font set"
+  },
+  {
+    "name": "fontconfig",
+    "summary": "Font configuration and customization library"
+  },
+  {
+    "name": "fontconfig-devel",
+    "summary": "Font configuration and customization library"
+  },
+  {
+    "name": "fonts-srpm-macros",
+    "summary": "Source-stage rpm automation for fonts packages"
+  },
+  {
+    "name": "foomatic",
+    "summary": "Tools for using the foomatic database of printers and printer drivers"
+  },
+  {
+    "name": "foomatic-db",
+    "summary": "Database of printers and printer drivers"
+  },
+  {
+    "name": "foomatic-db-filesystem",
+    "summary": "Directory layout for the foomatic package"
+  },
+  {
+    "name": "foomatic-db-ppds",
+    "summary": "PPDs from printer manufacturers"
+  },
+  {
+    "name": "freeglut",
+    "summary": "A freely licensed alternative to the GLUT library"
+  },
+  {
+    "name": "freeglut-devel",
+    "summary": "Freeglut developmental libraries and header files"
+  },
+  {
+    "name": "freeipmi",
+    "summary": "IPMI remote console and system management software"
+  },
+  {
+    "name": "freeipmi-bmc-watchdog",
+    "summary": "IPMI BMC watchdog"
+  },
+  {
+    "name": "freeipmi-ipmidetectd",
+    "summary": "IPMI node detection monitoring daemon"
+  },
+  {
+    "name": "freeipmi-ipmiseld",
+    "summary": "IPMI SEL syslog logging daemon"
+  },
+  {
+    "name": "freeradius",
+    "summary": "High-performance and highly configurable free RADIUS server"
+  },
+  {
+    "name": "freeradius-devel",
+    "summary": "FreeRADIUS development files"
+  },
+  {
+    "name": "freeradius-doc",
+    "summary": "FreeRADIUS documentation"
+  },
+  {
+    "name": "freeradius-krb5",
+    "summary": "Kerberos 5 support for freeradius"
+  },
+  {
+    "name": "freeradius-ldap",
+    "summary": "LDAP support for freeradius"
+  },
+  {
+    "name": "freeradius-utils",
+    "summary": "FreeRADIUS utilities"
+  },
+  {
+    "name": "freerdp",
+    "summary": "Free implementation of the Remote Desktop Protocol (RDP)"
+  },
+  {
+    "name": "freerdp-libs",
+    "summary": "Core libraries implementing the RDP protocol"
+  },
+  {
+    "name": "freetype-devel",
+    "summary": "FreeType development libraries and header files"
+  },
+  {
+    "name": "fribidi",
+    "summary": "Library implementing the Unicode Bidirectional Algorithm"
+  },
+  {
+    "name": "fribidi-devel",
+    "summary": "Libraries and include files for FriBidi"
+  },
+  {
+    "name": "frr",
+    "summary": "Routing daemon"
+  },
+  {
+    "name": "frr-selinux",
+    "summary": "Selinux policy for FRR"
+  },
+  {
+    "name": "fstrm",
+    "summary": "Frame Streams implementation in C"
+  },
+  {
+    "name": "ftp",
+    "summary": "The standard UNIX FTP (File Transfer Protocol) client"
+  },
+  {
+    "name": "fuse-overlayfs",
+    "summary": "FUSE overlay+shiftfs implementation for rootless containers"
+  },
+  {
+    "name": "fuse3",
+    "summary": "File System in Userspace (FUSE) v3 utilities"
+  },
+  {
+    "name": "fuse3-devel",
+    "summary": "File System in Userspace (FUSE) v3 devel files"
+  },
+  {
+    "name": "fuse3-libs",
+    "summary": "File System in Userspace (FUSE) v3 libraries"
+  },
+  {
+    "name": "fwupd-plugin-flashrom",
+    "summary": "fwupd plugin using flashrom"
+  },
+  {
+    "name": "fxload",
+    "summary": "A helper program to download firmware into FX and FX2 EZ-USB devices"
+  },
+  {
+    "name": "galera",
+    "summary": "Synchronous multi-master wsrep provider (replication engine)"
+  },
+  {
+    "name": "gawk-all-langpacks",
+    "summary": "Additional localisation files for gawk utility"
+  },
+  {
+    "name": "gc",
+    "summary": "A garbage collector for C and C++"
+  },
+  {
+    "name": "gcc",
+    "summary": "Various compilers (C, C++, Objective-C, ...)"
+  },
+  {
+    "name": "gcc-c++",
+    "summary": "C++ support for GCC"
+  },
+  {
+    "name": "gcc-gfortran",
+    "summary": "Fortran support"
+  },
+  {
+    "name": "gcc-plugin-annobin",
+    "summary": "The annobin plugin for gcc, built by the installed version of gcc"
+  },
+  {
+    "name": "gcc-toolset-12",
+    "summary": "Package that installs gcc-toolset-12"
+  },
+  {
+    "name": "gcc-toolset-12-annobin-annocheck",
+    "summary": "A tool for checking the security hardening status of binaries"
+  },
+  {
+    "name": "gcc-toolset-12-annobin-docs",
+    "summary": "Documentation and shell scripts for use with annobin"
+  },
+  {
+    "name": "gcc-toolset-12-annobin-plugin-gcc",
+    "summary": "annobin gcc plugin"
+  },
+  {
+    "name": "gcc-toolset-12-binutils",
+    "summary": "A GNU collection of binary utilities"
+  },
+  {
+    "name": "gcc-toolset-12-binutils-devel",
+    "summary": "BFD and opcodes static and dynamic libraries and header files"
+  },
+  {
+    "name": "gcc-toolset-12-binutils-gold",
+    "summary": "The GOLD linker, a faster alternative to the BFD linker"
+  },
+  {
+    "name": "gcc-toolset-12-build",
+    "summary": "Package shipping basic build configuration"
+  },
+  {
+    "name": "gcc-toolset-12-dwz",
+    "summary": "DWARF optimization and duplicate removal tool"
+  },
+  {
+    "name": "gcc-toolset-12-gcc",
+    "summary": "GCC version 12"
+  },
+  {
+    "name": "gcc-toolset-12-gcc-c++",
+    "summary": "C++ support for GCC version 12"
+  },
+  {
+    "name": "gcc-toolset-12-gcc-gfortran",
+    "summary": "Fortran support for GCC 12"
+  },
+  {
+    "name": "gcc-toolset-12-gcc-plugin-annobin",
+    "summary": "The annobin plugin for gcc, built by the installed version of gcc"
+  },
+  {
+    "name": "gcc-toolset-12-gcc-plugin-devel",
+    "summary": "Support for compiling GCC plugins"
+  },
+  {
+    "name": "gcc-toolset-12-gdb",
+    "summary": "A GNU source-level debugger for C, C++, Fortran, Go and other languages"
+  },
+  {
+    "name": "gcc-toolset-12-libasan-devel",
+    "summary": "The Address Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-12-libatomic-devel",
+    "summary": "The GNU Atomic static library"
+  },
+  {
+    "name": "gcc-toolset-12-libgccjit",
+    "summary": "Library for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-12-libgccjit-devel",
+    "summary": "Support for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-12-libgccjit-docs",
+    "summary": "Documentation for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-12-libitm-devel",
+    "summary": "The GNU Transactional Memory support"
+  },
+  {
+    "name": "gcc-toolset-12-liblsan-devel",
+    "summary": "The Leak Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-12-libstdc++-devel",
+    "summary": "Header files and libraries for C++ development"
+  },
+  {
+    "name": "gcc-toolset-12-libstdc++-docs",
+    "summary": "Documentation for the GNU standard C++ library"
+  },
+  {
+    "name": "gcc-toolset-12-libtsan-devel",
+    "summary": "The Thread Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-12-libubsan-devel",
+    "summary": "The Undefined Behavior Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-12-runtime",
+    "summary": "Package that handles gcc-toolset-12 Software Collection."
+  },
+  {
+    "name": "gcc-toolset-13",
+    "summary": "Package that installs gcc-toolset-13"
+  },
+  {
+    "name": "gcc-toolset-13-annobin-annocheck",
+    "summary": "A tool for checking the security hardening status of binaries"
+  },
+  {
+    "name": "gcc-toolset-13-annobin-docs",
+    "summary": "Documentation and shell scripts for use with annobin"
+  },
+  {
+    "name": "gcc-toolset-13-annobin-plugin-gcc",
+    "summary": "annobin gcc plugin"
+  },
+  {
+    "name": "gcc-toolset-13-binutils",
+    "summary": "A GNU collection of binary utilities"
+  },
+  {
+    "name": "gcc-toolset-13-binutils-devel",
+    "summary": "BFD and opcodes static and dynamic libraries and header files"
+  },
+  {
+    "name": "gcc-toolset-13-binutils-gold",
+    "summary": "The GOLD linker, a faster alternative to the BFD linker"
+  },
+  {
+    "name": "gcc-toolset-13-dwz",
+    "summary": "DWARF optimization and duplicate removal tool"
+  },
+  {
+    "name": "gcc-toolset-13-gcc",
+    "summary": "GCC version 13"
+  },
+  {
+    "name": "gcc-toolset-13-gcc-c++",
+    "summary": "C++ support for GCC version 13"
+  },
+  {
+    "name": "gcc-toolset-13-gcc-gfortran",
+    "summary": "Fortran support for GCC 13"
+  },
+  {
+    "name": "gcc-toolset-13-gcc-plugin-annobin",
+    "summary": "The annobin plugin for gcc, built by the installed version of gcc"
+  },
+  {
+    "name": "gcc-toolset-13-gcc-plugin-devel",
+    "summary": "Support for compiling GCC plugins"
+  },
+  {
+    "name": "gcc-toolset-13-gdb",
+    "summary": "A GNU source-level debugger for C, C++, Fortran, Go and other languages"
+  },
+  {
+    "name": "gcc-toolset-13-libasan-devel",
+    "summary": "The Address Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-13-libatomic-devel",
+    "summary": "The GNU Atomic static library"
+  },
+  {
+    "name": "gcc-toolset-13-libgccjit",
+    "summary": "Library for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-13-libgccjit-devel",
+    "summary": "Support for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-13-libitm-devel",
+    "summary": "The GNU Transactional Memory support"
+  },
+  {
+    "name": "gcc-toolset-13-liblsan-devel",
+    "summary": "The Leak Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-13-libstdc++-devel",
+    "summary": "Header files and libraries for C++ development"
+  },
+  {
+    "name": "gcc-toolset-13-libstdc++-docs",
+    "summary": "Documentation for the GNU standard C++ library"
+  },
+  {
+    "name": "gcc-toolset-13-libtsan-devel",
+    "summary": "The Thread Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-13-libubsan-devel",
+    "summary": "The Undefined Behavior Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-13-runtime",
+    "summary": "Package that handles gcc-toolset-13 Software Collection."
+  },
+  {
+    "name": "gcc-toolset-14",
+    "summary": "Package that installs gcc-toolset-14"
+  },
+  {
+    "name": "gcc-toolset-14-annobin-annocheck",
+    "summary": "A tool for checking the security hardening status of binaries"
+  },
+  {
+    "name": "gcc-toolset-14-annobin-docs",
+    "summary": "Documentation and shell scripts for use with annobin"
+  },
+  {
+    "name": "gcc-toolset-14-annobin-plugin-gcc",
+    "summary": "annobin gcc plugin"
+  },
+  {
+    "name": "gcc-toolset-14-binutils",
+    "summary": "A GNU collection of binary utilities"
+  },
+  {
+    "name": "gcc-toolset-14-binutils-devel",
+    "summary": "BFD and opcodes static and dynamic libraries and header files"
+  },
+  {
+    "name": "gcc-toolset-14-binutils-gold",
+    "summary": "The GOLD linker, a faster alternative to the BFD linker"
+  },
+  {
+    "name": "gcc-toolset-14-binutils-gprofng",
+    "summary": "Next Generating code profiling tool"
+  },
+  {
+    "name": "gcc-toolset-14-dwz",
+    "summary": "DWARF optimization and duplicate removal tool"
+  },
+  {
+    "name": "gcc-toolset-14-gcc",
+    "summary": "GCC version 14"
+  },
+  {
+    "name": "gcc-toolset-14-gcc-c++",
+    "summary": "C++ support for GCC version 14"
+  },
+  {
+    "name": "gcc-toolset-14-gcc-gfortran",
+    "summary": "Fortran support for GCC 14"
+  },
+  {
+    "name": "gcc-toolset-14-gcc-plugin-annobin",
+    "summary": "The annobin plugin for gcc, built by the installed version of gcc"
+  },
+  {
+    "name": "gcc-toolset-14-gcc-plugin-devel",
+    "summary": "Support for compiling GCC plugins"
+  },
+  {
+    "name": "gcc-toolset-14-libasan-devel",
+    "summary": "The Address Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-14-libatomic-devel",
+    "summary": "The GNU Atomic static library"
+  },
+  {
+    "name": "gcc-toolset-14-libgccjit",
+    "summary": "Library for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-14-libgccjit-devel",
+    "summary": "Support for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-14-libitm-devel",
+    "summary": "The GNU Transactional Memory support"
+  },
+  {
+    "name": "gcc-toolset-14-liblsan-devel",
+    "summary": "The Leak Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-14-libstdc++-devel",
+    "summary": "Header files and libraries for C++ development"
+  },
+  {
+    "name": "gcc-toolset-14-libstdc++-docs",
+    "summary": "Documentation for the GNU standard C++ library"
+  },
+  {
+    "name": "gcc-toolset-14-libtsan-devel",
+    "summary": "The Thread Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-14-libubsan-devel",
+    "summary": "The Undefined Behavior Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-14-runtime",
+    "summary": "Package that handles gcc-toolset-14 Software Collection."
+  },
+  {
+    "name": "gcr",
+    "summary": "A library for bits of crypto UI and parsing"
+  },
+  {
+    "name": "gcr-base",
+    "summary": "Library files for gcr"
+  },
+  {
+    "name": "gcr-devel",
+    "summary": "Development files for gcr"
+  },
+  {
+    "name": "gd",
+    "summary": "A graphics library for quick creation of PNG or JPEG images"
+  },
+  {
+    "name": "gd-devel",
+    "summary": "The development libraries and header files for gd"
+  },
+  {
+    "name": "gdb",
+    "summary": "A stub package for GNU source-level debugger"
+  },
+  {
+    "name": "gdb-doc",
+    "summary": "Documentation for GDB (the GNU source-level debugger)"
+  },
+  {
+    "name": "gdb-gdbserver",
+    "summary": "A standalone server for GDB (the GNU source-level debugger)"
+  },
+  {
+    "name": "gdb-headless",
+    "summary": "A GNU source-level debugger for C, C++, Fortran, Go and other languages"
+  },
+  {
+    "name": "gdb-minimal",
+    "summary": "A GNU source-level debugger for C, C++, Fortran, Go and other languages (minimal version)"
+  },
+  {
+    "name": "gdisk",
+    "summary": "An fdisk-like partitioning tool for GPT disks"
+  },
+  {
+    "name": "gdk-pixbuf2",
+    "summary": "An image loading library"
+  },
+  {
+    "name": "gdk-pixbuf2-devel",
+    "summary": "Development files for gdk-pixbuf2"
+  },
+  {
+    "name": "gdk-pixbuf2-modules",
+    "summary": "Additional image modules for gdk-pixbuf2"
+  },
+  {
+    "name": "gdm",
+    "summary": "The GNOME Display Manager"
+  },
+  {
+    "name": "gedit",
+    "summary": "Text editor for the GNOME desktop"
+  },
+  {
+    "name": "gedit-plugin-bookmarks",
+    "summary": "gedit bookmarks plugin"
+  },
+  {
+    "name": "gedit-plugin-bracketcompletion",
+    "summary": "gedit bracketcompletion plugin"
+  },
+  {
+    "name": "gedit-plugin-codecomment",
+    "summary": "gedit codecomment plugin"
+  },
+  {
+    "name": "gedit-plugin-colorpicker",
+    "summary": "gedit colorpicker plugin"
+  },
+  {
+    "name": "gedit-plugin-colorschemer",
+    "summary": "gedit colorschemer plugin"
+  },
+  {
+    "name": "gedit-plugin-commander",
+    "summary": "gedit commander plugin"
+  },
+  {
+    "name": "gedit-plugin-drawspaces",
+    "summary": "gedit drawspaces plugin"
+  },
+  {
+    "name": "gedit-plugin-findinfiles",
+    "summary": "gedit findinfiles plugin"
+  },
+  {
+    "name": "gedit-plugin-joinlines",
+    "summary": "gedit joinlines plugin"
+  },
+  {
+    "name": "gedit-plugin-multiedit",
+    "summary": "gedit multiedit plugin"
+  },
+  {
+    "name": "gedit-plugin-sessionsaver",
+    "summary": "gedit sessionsaver plugin"
+  },
+  {
+    "name": "gedit-plugin-smartspaces",
+    "summary": "gedit smartspaces plugin"
+  },
+  {
+    "name": "gedit-plugin-synctex",
+    "summary": "gedit synctex plugin"
+  },
+  {
+    "name": "gedit-plugin-terminal",
+    "summary": "gedit terminal plugin"
+  },
+  {
+    "name": "gedit-plugin-textsize",
+    "summary": "gedit textsize plugin"
+  },
+  {
+    "name": "gedit-plugin-translate",
+    "summary": "gedit translate plugin"
+  },
+  {
+    "name": "gedit-plugin-wordcompletion",
+    "summary": "gedit wordcompletion plugin"
+  },
+  {
+    "name": "gedit-plugins",
+    "summary": "Plugins for gedit"
+  },
+  {
+    "name": "gedit-plugins-data",
+    "summary": "Common data required by plugins"
+  },
+  {
+    "name": "gegl04",
+    "summary": "Graph based image processing framework"
+  },
+  {
+    "name": "gegl04-devel-docs",
+    "summary": "Documentation files for developing with gegl04"
+  },
+  {
+    "name": "gegl04-tools",
+    "summary": "Command line tools for gegl04"
+  },
+  {
+    "name": "geoclue2",
+    "summary": "Geolocation service"
+  },
+  {
+    "name": "geoclue2-libs",
+    "summary": "Geoclue client library"
+  },
+  {
+    "name": "geocode-glib",
+    "summary": "Geocoding helper library"
+  },
+  {
+    "name": "geocode-glib-devel",
+    "summary": "Development files for geocode-glib"
+  },
+  {
+    "name": "geolite2-city",
+    "summary": "Free IP geolocation city database"
+  },
+  {
+    "name": "geolite2-country",
+    "summary": "Free IP geolocation country database"
+  },
+  {
+    "name": "gettext-common-devel",
+    "summary": "Common development files for gettext"
+  },
+  {
+    "name": "gettext-devel",
+    "summary": "Development files for gettext"
+  },
+  {
+    "name": "ghc-srpm-macros",
+    "summary": "RPM macros for building Haskell source packages"
+  },
+  {
+    "name": "ghostscript",
+    "summary": "Interpreter for PostScript language & PDF"
+  },
+  {
+    "name": "ghostscript-doc",
+    "summary": "Documentation files for Ghostscript"
+  },
+  {
+    "name": "ghostscript-tools-dvipdf",
+    "summary": "Ghostscript's 'dvipdf' utility"
+  },
+  {
+    "name": "ghostscript-tools-fonts",
+    "summary": "Ghostscript's font utilities"
+  },
+  {
+    "name": "ghostscript-tools-printing",
+    "summary": "Ghostscript's printing utilities"
+  },
+  {
+    "name": "ghostscript-x11",
+    "summary": "Ghostscript's X11-based driver for document rendering"
+  },
+  {
+    "name": "giflib",
+    "summary": "A library and utilities for processing GIFs"
+  },
+  {
+    "name": "gimp",
+    "summary": "GNU Image Manipulation Program"
+  },
+  {
+    "name": "gimp-libs",
+    "summary": "GIMP libraries"
+  },
+  {
+    "name": "git",
+    "summary": "Fast Version Control System"
+  },
+  {
+    "name": "git-all",
+    "summary": "Meta-package to pull in all git tools"
+  },
+  {
+    "name": "git-clang-format",
+    "summary": "Integration of clang-format for git"
+  },
+  {
+    "name": "git-core",
+    "summary": "Core package of git with minimal functionality"
+  },
+  {
+    "name": "git-core-doc",
+    "summary": "Documentation files for git-core"
+  },
+  {
+    "name": "git-credential-libsecret",
+    "summary": "Git helper for accessing credentials via libsecret"
+  },
+  {
+    "name": "git-daemon",
+    "summary": "Git protocol daemon"
+  },
+  {
+    "name": "git-email",
+    "summary": "Git tools for sending patches via email"
+  },
+  {
+    "name": "git-gui",
+    "summary": "Graphical interface to Git"
+  },
+  {
+    "name": "git-instaweb",
+    "summary": "Repository browser in gitweb"
+  },
+  {
+    "name": "git-lfs",
+    "summary": "Git extension for versioning large files"
+  },
+  {
+    "name": "git-subtree",
+    "summary": "Git tools to merge and split repositories"
+  },
+  {
+    "name": "git-svn",
+    "summary": "Git tools for interacting with Subversion repositories"
+  },
+  {
+    "name": "gitk",
+    "summary": "Git repository browser"
+  },
+  {
+    "name": "gitweb",
+    "summary": "Simple web interface to git repositories"
+  },
+  {
+    "name": "gjs",
+    "summary": "Javascript Bindings for GNOME"
+  },
+  {
+    "name": "gl-manpages",
+    "summary": "OpenGL manpages"
+  },
+  {
+    "name": "glade",
+    "summary": "User Interface Designer for GTK+"
+  },
+  {
+    "name": "glade-libs",
+    "summary": "Widget library for Glade UI designer"
+  },
+  {
+    "name": "glib2-devel",
+    "summary": "A library of handy utility functions"
+  },
+  {
+    "name": "glib2-doc",
+    "summary": "A library of handy utility functions"
+  },
+  {
+    "name": "glib2-tests",
+    "summary": "Tests for the glib2 package"
+  },
+  {
+    "name": "glibc-devel",
+    "summary": "Object files for development using standard C libraries."
+  },
+  {
+    "name": "glibc-doc",
+    "summary": "Documentation for GNU libc"
+  },
+  {
+    "name": "glibc-locale-source",
+    "summary": "The sources for the locales"
+  },
+  {
+    "name": "glibc-utils",
+    "summary": "Development utilities from GNU C library"
+  },
+  {
+    "name": "glibmm24",
+    "summary": "C++ interface for the GLib library"
+  },
+  {
+    "name": "glslang",
+    "summary": "OpenGL and OpenGL ES shader front end and validator"
+  },
+  {
+    "name": "glslc",
+    "summary": "A command line compiler for GLSL/HLSL to SPIR-V"
+  },
+  {
+    "name": "glusterfs",
+    "summary": "Distributed File System"
+  },
+  {
+    "name": "glusterfs-api",
+    "summary": "GlusterFS api library"
+  },
+  {
+    "name": "glusterfs-cli",
+    "summary": "GlusterFS CLI"
+  },
+  {
+    "name": "glusterfs-client-xlators",
+    "summary": "GlusterFS client-side translators"
+  },
+  {
+    "name": "glusterfs-cloudsync-plugins",
+    "summary": "Cloudsync Plugins"
+  },
+  {
+    "name": "glusterfs-fuse",
+    "summary": "Fuse client"
+  },
+  {
+    "name": "glusterfs-libs",
+    "summary": "GlusterFS common libraries"
+  },
+  {
+    "name": "glusterfs-rdma",
+    "summary": "GlusterFS rdma support for ib-verbs"
+  },
+  {
+    "name": "glx-utils",
+    "summary": "GLX utilities"
+  },
+  {
+    "name": "gmp-c++",
+    "summary": "C++ bindings for the GNU MP arbitrary precision library"
+  },
+  {
+    "name": "gmp-devel",
+    "summary": "Development tools for the GNU MP arbitrary precision library"
+  },
+  {
+    "name": "gnome-autoar",
+    "summary": "Archive library"
+  },
+  {
+    "name": "gnome-backgrounds",
+    "summary": "Desktop backgrounds packaged with the GNOME desktop"
+  },
+  {
+    "name": "gnome-backgrounds-extras",
+    "summary": "Additional GNOME Backgrounds"
+  },
+  {
+    "name": "gnome-bluetooth",
+    "summary": "Bluetooth graphical utilities"
+  },
+  {
+    "name": "gnome-bluetooth-libs",
+    "summary": "GTK+ Bluetooth device selection widgets"
+  },
+  {
+    "name": "gnome-calculator",
+    "summary": "A desktop calculator"
+  },
+  {
+    "name": "gnome-characters",
+    "summary": "Character map application for GNOME"
+  },
+  {
+    "name": "gnome-classic-session",
+    "summary": "GNOME \"classic\" mode session"
+  },
+  {
+    "name": "gnome-color-manager",
+    "summary": "Color management tools for GNOME"
+  },
+  {
+    "name": "gnome-common",
+    "summary": "Useful things common to building GNOME packages from scratch"
+  },
+  {
+    "name": "gnome-connections",
+    "summary": "A remote desktop client for the GNOME desktop environment"
+  },
+  {
+    "name": "gnome-control-center",
+    "summary": "Utilities to configure the GNOME desktop"
+  },
+  {
+    "name": "gnome-control-center-filesystem",
+    "summary": "GNOME Control Center directories"
+  },
+  {
+    "name": "gnome-desktop3",
+    "summary": "Library with common API for various GNOME modules"
+  },
+  {
+    "name": "gnome-desktop3-devel",
+    "summary": "Libraries and headers for gnome-desktop3"
+  },
+  {
+    "name": "gnome-devel-docs",
+    "summary": "GNOME developer documentation"
+  },
+  {
+    "name": "gnome-disk-utility",
+    "summary": "Disks"
+  },
+  {
+    "name": "gnome-extensions-app",
+    "summary": "Manage GNOME Shell extensions"
+  },
+  {
+    "name": "gnome-font-viewer",
+    "summary": "Utility for previewing fonts for GNOME"
+  },
+  {
+    "name": "gnome-initial-setup",
+    "summary": "Bootstrapping your OS"
+  },
+  {
+    "name": "gnome-keyring",
+    "summary": "Framework for managing passwords and other secrets"
+  },
+  {
+    "name": "gnome-keyring-pam",
+    "summary": "Pam module for unlocking keyrings"
+  },
+  {
+    "name": "gnome-kiosk",
+    "summary": "Window management and application launching for GNOME"
+  },
+  {
+    "name": "gnome-kiosk-script-session",
+    "summary": "Basic session used for running kiosk application from shell script"
+  },
+  {
+    "name": "gnome-kiosk-search-appliance",
+    "summary": "Example search application application that uses GNOME Kiosk"
+  },
+  {
+    "name": "gnome-logs",
+    "summary": "Log viewer for the systemd journal"
+  },
+  {
+    "name": "gnome-menus",
+    "summary": "A menu system for the GNOME project"
+  },
+  {
+    "name": "gnome-online-accounts",
+    "summary": "Single sign-on framework for GNOME"
+  },
+  {
+    "name": "gnome-online-accounts-devel",
+    "summary": "Development files for gnome-online-accounts"
+  },
+  {
+    "name": "gnome-photos",
+    "summary": "Access, organize and share your photos on GNOME"
+  },
+  {
+    "name": "gnome-photos-tests",
+    "summary": "Tests for gnome-photos"
+  },
+  {
+    "name": "gnome-remote-desktop",
+    "summary": "GNOME Remote Desktop screen share service"
+  },
+  {
+    "name": "gnome-screenshot",
+    "summary": "A screenshot utility for GNOME"
+  },
+  {
+    "name": "gnome-session",
+    "summary": "GNOME session manager"
+  },
+  {
+    "name": "gnome-session-wayland-session",
+    "summary": "Desktop file for wayland based gnome session"
+  },
+  {
+    "name": "gnome-session-xsession",
+    "summary": "Desktop file for gnome-session"
+  },
+  {
+    "name": "gnome-settings-daemon",
+    "summary": "The daemon sharing settings from GNOME to GTK+/KDE applications"
+  },
+  {
+    "name": "gnome-shell",
+    "summary": "Window management and application launching for GNOME"
+  },
+  {
+    "name": "gnome-shell-extension-apps-menu",
+    "summary": "Application menu for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-auto-move-windows",
+    "summary": "Assign specific workspaces to applications in GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-background-logo",
+    "summary": "Background logo extension for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-classification-banner",
+    "summary": "Display classification level banner in GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-common",
+    "summary": "Files common to GNOME Shell Extensions"
+  },
+  {
+    "name": "gnome-shell-extension-custom-menu",
+    "summary": "Add a custom menu to the desktop"
+  },
+  {
+    "name": "gnome-shell-extension-dash-to-dock",
+    "summary": "Show the dash outside the activities overview"
+  },
+  {
+    "name": "gnome-shell-extension-dash-to-panel",
+    "summary": "Show the dash in the top bar"
+  },
+  {
+    "name": "gnome-shell-extension-desktop-icons",
+    "summary": "Desktop icons support for the classic experience"
+  },
+  {
+    "name": "gnome-shell-extension-drive-menu",
+    "summary": "Drive status menu for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-gesture-inhibitor",
+    "summary": "Gesture inhibitor"
+  },
+  {
+    "name": "gnome-shell-extension-heads-up-display",
+    "summary": "Display persistent on-screen message"
+  },
+  {
+    "name": "gnome-shell-extension-launch-new-instance",
+    "summary": "Always launch a new application instance for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-move-notifications",
+    "summary": "Move GNOME Shell notifications"
+  },
+  {
+    "name": "gnome-shell-extension-native-window-placement",
+    "summary": "Native window placement for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-panel-favorites",
+    "summary": "Favorite launchers in GNOME Shell's top bar"
+  },
+  {
+    "name": "gnome-shell-extension-places-menu",
+    "summary": "Places status menu for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-screenshot-window-sizer",
+    "summary": "Screenshot window sizer for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-systemMonitor",
+    "summary": "System Monitor for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-top-icons",
+    "summary": "Show legacy icons on top"
+  },
+  {
+    "name": "gnome-shell-extension-updates-dialog",
+    "summary": "Show a modal dialog when there are software updates"
+  },
+  {
+    "name": "gnome-shell-extension-user-theme",
+    "summary": "Support for custom themes in GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-window-list",
+    "summary": "Display a window list at the bottom of the screen in GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-windowsNavigator",
+    "summary": "Support for keyboard selection of windows and workspaces in GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-workspace-indicator",
+    "summary": "Workspace indicator for GNOME Shell"
+  },
+  {
+    "name": "gnome-software",
+    "summary": "A software center for GNOME"
+  },
+  {
+    "name": "gnome-system-monitor",
+    "summary": "Process and resource monitor"
+  },
+  {
+    "name": "gnome-terminal",
+    "summary": "Terminal emulator for GNOME"
+  },
+  {
+    "name": "gnome-terminal-nautilus",
+    "summary": "GNOME Terminal extension for Nautilus"
+  },
+  {
+    "name": "gnome-themes-extra",
+    "summary": "GNOME Extra Themes"
+  },
+  {
+    "name": "gnome-tour",
+    "summary": "GNOME Tour and Greeter"
+  },
+  {
+    "name": "gnome-tweaks",
+    "summary": "Customize advanced GNOME 3 options"
+  },
+  {
+    "name": "gnome-user-docs",
+    "summary": "GNOME User Documentation"
+  },
+  {
+    "name": "gnu-efi",
+    "summary": "Development Libraries and headers for EFI"
+  },
+  {
+    "name": "gnupg2-smime",
+    "summary": "CMS encryption and signing tool and smart card support for GnuPG"
+  },
+  {
+    "name": "gnutls-c++",
+    "summary": "The C++ interface to GnuTLS"
+  },
+  {
+    "name": "gnutls-dane",
+    "summary": "A DANE protocol implementation for GnuTLS"
+  },
+  {
+    "name": "gnutls-devel",
+    "summary": "Development files for the gnutls package"
+  },
+  {
+    "name": "gnutls-utils",
+    "summary": "Command line tools for TLS protocol"
+  },
+  {
+    "name": "go-filesystem",
+    "summary": "Directories used by Go packages"
+  },
+  {
+    "name": "go-rpm-macros",
+    "summary": "Build-stage rpm automation for Go packages"
+  },
+  {
+    "name": "go-rpm-templates",
+    "summary": "RPM spec templates for Go packages"
+  },
+  {
+    "name": "go-srpm-macros",
+    "summary": "Source-stage rpm automation for Go packages"
+  },
+  {
+    "name": "go-toolset",
+    "summary": "Package that installs go-toolset"
+  },
+  {
+    "name": "golang",
+    "summary": "The Go Programming Language"
+  },
+  {
+    "name": "golang-bin",
+    "summary": "Golang core compiler tools"
+  },
+  {
+    "name": "golang-docs",
+    "summary": "Golang compiler docs"
+  },
+  {
+    "name": "golang-misc",
+    "summary": "Golang compiler miscellaneous sources"
+  },
+  {
+    "name": "golang-race",
+    "summary": "Race detetector library object files."
+  },
+  {
+    "name": "golang-src",
+    "summary": "Golang compiler source tree"
+  },
+  {
+    "name": "golang-tests",
+    "summary": "Golang compiler tests for stdlib"
+  },
+  {
+    "name": "google-carlito-fonts",
+    "summary": "Carlito, a sans-serif font family metric-compatible with Calibri font family"
+  },
+  {
+    "name": "google-crosextra-caladea-fonts",
+    "summary": "Serif font metric-compatible with Cambria font"
+  },
+  {
+    "name": "google-droid-sans-fonts",
+    "summary": "Droid Sans, a humanist sans-serif font family"
+  },
+  {
+    "name": "google-droid-sans-mono-fonts",
+    "summary": "Droid Sans Mono, a humanist mono-space sans-serif font family"
+  },
+  {
+    "name": "google-droid-serif-fonts",
+    "summary": "Droid Serif, a contemporary serif font family"
+  },
+  {
+    "name": "google-guice",
+    "summary": "Lightweight dependency injection framework for Java 5 and above"
+  },
+  {
+    "name": "google-noto-cjk-fonts-common",
+    "summary": "Common files for Noto CJK fonts"
+  },
+  {
+    "name": "google-noto-emoji-color-fonts",
+    "summary": "Google \u201cNoto Color Emoji\u201d colored emoji font"
+  },
+  {
+    "name": "google-noto-emoji-fonts",
+    "summary": "Google \u201cNoto Emoji\u201d Black-and-White emoji font"
+  },
+  {
+    "name": "google-noto-fonts-common",
+    "summary": "Common files for Noto fonts"
+  },
+  {
+    "name": "google-noto-sans-armenian-fonts",
+    "summary": "Noto Sans Armenian font"
+  },
+  {
+    "name": "google-noto-sans-avestan-fonts",
+    "summary": "Noto Sans Avestan font"
+  },
+  {
+    "name": "google-noto-sans-bengali-fonts",
+    "summary": "Noto Sans Bengali font"
+  },
+  {
+    "name": "google-noto-sans-bengali-ui-fonts",
+    "summary": "Noto Sans Bengali UI font"
+  },
+  {
+    "name": "google-noto-sans-brahmi-fonts",
+    "summary": "Noto Sans Brahmi font"
+  },
+  {
+    "name": "google-noto-sans-carian-fonts",
+    "summary": "Noto Sans Carian font"
+  },
+  {
+    "name": "google-noto-sans-cherokee-fonts",
+    "summary": "Noto Sans Cherokee font"
+  },
+  {
+    "name": "google-noto-sans-cjk-ttc-fonts",
+    "summary": "Sans OTC font files for google-noto-cjk-fonts"
+  },
+  {
+    "name": "google-noto-sans-coptic-fonts",
+    "summary": "Noto Sans Coptic font"
+  },
+  {
+    "name": "google-noto-sans-deseret-fonts",
+    "summary": "Noto Sans Deseret font"
+  },
+  {
+    "name": "google-noto-sans-devanagari-fonts",
+    "summary": "Noto Sans Devanagari font"
+  },
+  {
+    "name": "google-noto-sans-devanagari-ui-fonts",
+    "summary": "Noto Sans Devanagari UI font"
+  },
+  {
+    "name": "google-noto-sans-egyptian-hieroglyphs-fonts",
+    "summary": "Noto Sans Egyptian Hieroglyphs font"
+  },
+  {
+    "name": "google-noto-sans-ethiopic-fonts",
+    "summary": "Noto Sans Ethiopic font"
+  },
+  {
+    "name": "google-noto-sans-fonts",
+    "summary": "Noto Sans font"
+  },
+  {
+    "name": "google-noto-sans-georgian-fonts",
+    "summary": "Noto Sans Georgian font"
+  },
+  {
+    "name": "google-noto-sans-glagolitic-fonts",
+    "summary": "Noto Sans Glagolitic font"
+  },
+  {
+    "name": "google-noto-sans-gujarati-fonts",
+    "summary": "Noto Sans Gujarati font"
+  },
+  {
+    "name": "google-noto-sans-gujarati-ui-fonts",
+    "summary": "Noto Sans Gujarati UI font"
+  },
+  {
+    "name": "google-noto-sans-gurmukhi-fonts",
+    "summary": "Noto Sans Gurmukhi font"
+  },
+  {
+    "name": "google-noto-sans-hebrew-fonts",
+    "summary": "Noto Sans Hebrew font"
+  },
+  {
+    "name": "google-noto-sans-imperial-aramaic-fonts",
+    "summary": "Noto Sans Imperial Aramaic font"
+  },
+  {
+    "name": "google-noto-sans-kaithi-fonts",
+    "summary": "Noto Sans Kaithi font"
+  },
+  {
+    "name": "google-noto-sans-kannada-fonts",
+    "summary": "Noto Sans Kannada font"
+  },
+  {
+    "name": "google-noto-sans-kannada-ui-fonts",
+    "summary": "Noto Sans Kannada UI font"
+  },
+  {
+    "name": "google-noto-sans-kayah-li-fonts",
+    "summary": "Noto Sans Kayah Li font"
+  },
+  {
+    "name": "google-noto-sans-kharoshthi-fonts",
+    "summary": "Noto Sans Kharoshthi font"
+  },
+  {
+    "name": "google-noto-sans-khmer-fonts",
+    "summary": "Noto Sans Khmer font"
+  },
+  {
+    "name": "google-noto-sans-khmer-ui-fonts",
+    "summary": "Noto Sans Khmer UI font"
+  },
+  {
+    "name": "google-noto-sans-lao-fonts",
+    "summary": "Noto Sans Lao font"
+  },
+  {
+    "name": "google-noto-sans-lao-ui-fonts",
+    "summary": "Noto Sans Lao UI font"
+  },
+  {
+    "name": "google-noto-sans-lycian-fonts",
+    "summary": "Noto Sans Lycian font"
+  },
+  {
+    "name": "google-noto-sans-lydian-fonts",
+    "summary": "Noto Sans Lydian font"
+  },
+  {
+    "name": "google-noto-sans-malayalam-fonts",
+    "summary": "Noto Sans Malayalam font"
+  },
+  {
+    "name": "google-noto-sans-malayalam-ui-fonts",
+    "summary": "Noto Sans Malayalam UI font"
+  },
+  {
+    "name": "google-noto-sans-mono-fonts",
+    "summary": "Noto Sans Mono font"
+  },
+  {
+    "name": "google-noto-sans-nko-fonts",
+    "summary": "Noto Sans NKo font"
+  },
+  {
+    "name": "google-noto-sans-old-south-arabian-fonts",
+    "summary": "Noto Sans Old South Arabian font"
+  },
+  {
+    "name": "google-noto-sans-old-turkic-fonts",
+    "summary": "Noto Sans Old Turkic font"
+  },
+  {
+    "name": "google-noto-sans-osmanya-fonts",
+    "summary": "Noto Sans Osmanya font"
+  },
+  {
+    "name": "google-noto-sans-phoenician-fonts",
+    "summary": "Noto Sans Phoenician font"
+  },
+  {
+    "name": "google-noto-sans-shavian-fonts",
+    "summary": "Noto Sans Shavian font"
+  },
+  {
+    "name": "google-noto-sans-sinhala-fonts",
+    "summary": "Noto Sans Sinhala font"
+  },
+  {
+    "name": "google-noto-sans-sinhala-vf-fonts",
+    "summary": "Noto Sans Sinhala variable font"
+  },
+  {
+    "name": "google-noto-sans-symbols-fonts",
+    "summary": "Noto Sans Symbols font"
+  },
+  {
+    "name": "google-noto-sans-tamil-fonts",
+    "summary": "Noto Sans Tamil font"
+  },
+  {
+    "name": "google-noto-sans-tamil-ui-fonts",
+    "summary": "Noto Sans Tamil UI font"
+  },
+  {
+    "name": "google-noto-sans-telugu-fonts",
+    "summary": "Noto Sans Telugu font"
+  },
+  {
+    "name": "google-noto-sans-telugu-ui-fonts",
+    "summary": "Noto Sans Telugu UI font"
+  },
+  {
+    "name": "google-noto-sans-thaana-fonts",
+    "summary": "Noto Sans Thaana font"
+  },
+  {
+    "name": "google-noto-sans-thai-fonts",
+    "summary": "Noto Sans Thai font"
+  },
+  {
+    "name": "google-noto-sans-thai-ui-fonts",
+    "summary": "Noto Sans Thai UI font"
+  },
+  {
+    "name": "google-noto-sans-ugaritic-fonts",
+    "summary": "Noto Sans Ugaritic font"
+  },
+  {
+    "name": "google-noto-sans-vai-fonts",
+    "summary": "Noto Sans Vai font"
+  },
+  {
+    "name": "google-noto-serif-armenian-fonts",
+    "summary": "Noto Serif Armenian font"
+  },
+  {
+    "name": "google-noto-serif-cjk-ttc-fonts",
+    "summary": "Serif OTC font files for google-noto-cjk-fonts"
+  },
+  {
+    "name": "google-noto-serif-fonts",
+    "summary": "Noto Serif font"
+  },
+  {
+    "name": "google-noto-serif-georgian-fonts",
+    "summary": "Noto Serif Georgian font"
+  },
+  {
+    "name": "google-noto-serif-gurmukhi-vf-fonts",
+    "summary": "Noto Serif Gurmukhi variable font"
+  },
+  {
+    "name": "google-noto-serif-khmer-fonts",
+    "summary": "Noto Serif Khmer font"
+  },
+  {
+    "name": "google-noto-serif-lao-fonts",
+    "summary": "Noto Serif Lao font"
+  },
+  {
+    "name": "google-noto-serif-sinhala-vf-fonts",
+    "summary": "Noto Serif Sinhala variable font"
+  },
+  {
+    "name": "google-noto-serif-thai-fonts",
+    "summary": "Noto Serif Thai font"
+  },
+  {
+    "name": "google-roboto-slab-fonts",
+    "summary": "Google Roboto Slab fonts"
+  },
+  {
+    "name": "gperf",
+    "summary": "A perfect hash function generator"
+  },
+  {
+    "name": "gpgmepp",
+    "summary": "C++ bindings/wrapper for GPGME"
+  },
+  {
+    "name": "gpm",
+    "summary": "A mouse server for the Linux console"
+  },
+  {
+    "name": "gpm-devel",
+    "summary": "Development files for the gpm library"
+  },
+  {
+    "name": "gpm-libs",
+    "summary": "Dynamic library for gpm"
+  },
+  {
+    "name": "gpsd-minimal",
+    "summary": "Service daemon for mediating access to a GPS"
+  },
+  {
+    "name": "gpsd-minimal-clients",
+    "summary": "Clients for gpsd"
+  },
+  {
+    "name": "grafana",
+    "summary": "Metrics dashboard and graph editor"
+  },
+  {
+    "name": "grafana-pcp",
+    "summary": "Performance Co-Pilot Grafana Plugin"
+  },
+  {
+    "name": "grafana-selinux",
+    "summary": "SELinux policy module supporting grafana"
+  },
+  {
+    "name": "graphene",
+    "summary": "Thin layer of types for graphic libraries"
+  },
+  {
+    "name": "graphene-devel",
+    "summary": "Development files for graphene"
+  },
+  {
+    "name": "graphite2-devel",
+    "summary": "Files for developing with graphite2"
+  },
+  {
+    "name": "graphviz",
+    "summary": "Graph Visualization Tools"
+  },
+  {
+    "name": "graphviz-doc",
+    "summary": "PDF and HTML documents for graphviz"
+  },
+  {
+    "name": "graphviz-gd",
+    "summary": "Graphviz plugin for renderers based on gd"
+  },
+  {
+    "name": "graphviz-python3",
+    "summary": "Python 3 extension for graphviz"
+  },
+  {
+    "name": "graphviz-ruby",
+    "summary": "Ruby extension for graphviz"
+  },
+  {
+    "name": "greenboot",
+    "summary": "Generic Health Check Framework for systemd"
+  },
+  {
+    "name": "greenboot-default-health-checks",
+    "summary": "Series of optional and curated health checks"
+  },
+  {
+    "name": "groff",
+    "summary": "A document formatting system"
+  },
+  {
+    "name": "gsettings-desktop-schemas-devel",
+    "summary": "Development files for gsettings-desktop-schemas"
+  },
+  {
+    "name": "gsl",
+    "summary": "The GNU Scientific Library for numerical analysis"
+  },
+  {
+    "name": "gsl-devel",
+    "summary": "Libraries and the header files for GSL development"
+  },
+  {
+    "name": "gsm",
+    "summary": "Shared libraries for GSM speech compressor"
+  },
+  {
+    "name": "gsound",
+    "summary": "Small gobject library for playing system sounds"
+  },
+  {
+    "name": "gspell",
+    "summary": "Spell-checking library for GTK+"
+  },
+  {
+    "name": "gstreamer1",
+    "summary": "GStreamer streaming media framework runtime"
+  },
+  {
+    "name": "gstreamer1-devel",
+    "summary": "Libraries/include files for GStreamer streaming media framework"
+  },
+  {
+    "name": "gstreamer1-plugins-bad-free",
+    "summary": "GStreamer streaming media framework \"bad\" plugins"
+  },
+  {
+    "name": "gstreamer1-plugins-bad-free-libs",
+    "summary": "Runtime libraries for the GStreamer media framework \"bad\" plug-ins"
+  },
+  {
+    "name": "gstreamer1-plugins-base",
+    "summary": "GStreamer streaming media framework base plugins"
+  },
+  {
+    "name": "gstreamer1-plugins-base-devel",
+    "summary": "GStreamer Base Plugins Development files"
+  },
+  {
+    "name": "gstreamer1-plugins-base-tools",
+    "summary": "Tools for GStreamer streaming media framework base plugins"
+  },
+  {
+    "name": "gstreamer1-plugins-good",
+    "summary": "GStreamer plugins with good code and licensing"
+  },
+  {
+    "name": "gstreamer1-plugins-good-gtk",
+    "summary": "GStreamer \"good\" plugins gtk plugin"
+  },
+  {
+    "name": "gstreamer1-plugins-ugly-free",
+    "summary": "GStreamer streaming media framework \"ugly\" plugins"
+  },
+  {
+    "name": "gstreamer1-rtsp-server",
+    "summary": "GStreamer RTSP server library"
+  },
+  {
+    "name": "gtk-update-icon-cache",
+    "summary": "Icon theme caching utility"
+  },
+  {
+    "name": "gtk-vnc2",
+    "summary": "A GTK3 widget for VNC clients"
+  },
+  {
+    "name": "gtk2",
+    "summary": "GTK+ graphical user interface library"
+  },
+  {
+    "name": "gtk2-devel",
+    "summary": "Development files for GTK+"
+  },
+  {
+    "name": "gtk2-devel-docs",
+    "summary": "Developer documentation for GTK+"
+  },
+  {
+    "name": "gtk2-immodule-xim",
+    "summary": "XIM support for GTK+"
+  },
+  {
+    "name": "gtk2-immodules",
+    "summary": "Input methods for GTK+"
+  },
+  {
+    "name": "gtk3",
+    "summary": "GTK+ graphical user interface library"
+  },
+  {
+    "name": "gtk3-devel",
+    "summary": "Development files for GTK+"
+  },
+  {
+    "name": "gtk3-immodule-xim",
+    "summary": "XIM support for GTK+"
+  },
+  {
+    "name": "gtk4",
+    "summary": "GTK graphical user interface library"
+  },
+  {
+    "name": "gtk4-devel",
+    "summary": "Development files for GTK"
+  },
+  {
+    "name": "gtkmm30",
+    "summary": "C++ interface for the GTK+ library"
+  },
+  {
+    "name": "gtksourceview4",
+    "summary": "Source code editing widget"
+  },
+  {
+    "name": "guava",
+    "summary": "Google Core Libraries for Java"
+  },
+  {
+    "name": "gubbi-fonts",
+    "summary": "Free Kannada Opentype serif font"
+  },
+  {
+    "name": "guestfs-tools",
+    "summary": "Tools to access and modify virtual machine disk images"
+  },
+  {
+    "name": "gutenprint",
+    "summary": "Printer Drivers Package"
+  },
+  {
+    "name": "gutenprint-cups",
+    "summary": "CUPS drivers for Canon, Epson, HP and compatible printers"
+  },
+  {
+    "name": "gutenprint-doc",
+    "summary": "Documentation for gutenprint"
+  },
+  {
+    "name": "gutenprint-libs",
+    "summary": "libgutenprint library"
+  },
+  {
+    "name": "gvfs",
+    "summary": "Backends for the gio framework in GLib"
+  },
+  {
+    "name": "gvfs-client",
+    "summary": "Client modules of backends for the gio framework in GLib"
+  },
+  {
+    "name": "gvfs-devel",
+    "summary": "Development files for gvfs"
+  },
+  {
+    "name": "gvfs-fuse",
+    "summary": "FUSE support for gvfs"
+  },
+  {
+    "name": "gvfs-goa",
+    "summary": "GOA support for gvfs"
+  },
+  {
+    "name": "gvfs-gphoto2",
+    "summary": "gphoto2 support for gvfs"
+  },
+  {
+    "name": "gvfs-mtp",
+    "summary": "MTP support for gvfs"
+  },
+  {
+    "name": "gvfs-smb",
+    "summary": "Windows fileshare support for gvfs"
+  },
+  {
+    "name": "gvisor-tap-vsock",
+    "summary": "Go replacement for libslirp and VPNKit"
+  },
+  {
+    "name": "gvisor-tap-vsock-gvforwarder",
+    "summary": "Forward traffic from a tap interface over vsock"
+  },
+  {
+    "name": "gvnc",
+    "summary": "A GObject for VNC connections"
+  },
+  {
+    "name": "hamcrest",
+    "summary": "Library of matchers for building test expressions"
+  },
+  {
+    "name": "haproxy",
+    "summary": "HAProxy reverse proxy for high availability environments"
+  },
+  {
+    "name": "harfbuzz-devel",
+    "summary": "Development files for harfbuzz"
+  },
+  {
+    "name": "harfbuzz-icu",
+    "summary": "Harfbuzz ICU support library"
+  },
+  {
+    "name": "HdrHistogram_c",
+    "summary": "C port of the HdrHistogram"
+  },
+  {
+    "name": "hexedit",
+    "summary": "A hexadecimal file viewer and editor"
+  },
+  {
+    "name": "hicolor-icon-theme",
+    "summary": "Basic requirement for icon themes"
+  },
+  {
+    "name": "highcontrast-icon-theme",
+    "summary": "HighContrast icon theme"
+  },
+  {
+    "name": "highlight",
+    "summary": "Universal source code to formatted text converter"
+  },
+  {
+    "name": "hivex",
+    "summary": "Read and write Windows Registry binary hive files"
+  },
+  {
+    "name": "hivex-libs",
+    "summary": "Library for hivex"
+  },
+  {
+    "name": "hostapd",
+    "summary": "IEEE 802.11 AP, IEEE 802.1X/WPA/WPA2/EAP/RADIUS Authenticator"
+  },
+  {
+    "name": "hplip",
+    "summary": "HP Linux Imaging and Printing Project"
+  },
+  {
+    "name": "hplip-common",
+    "summary": "Files needed by the HPLIP printer and scanner drivers"
+  },
+  {
+    "name": "hplip-libs",
+    "summary": "HPLIP libraries"
+  },
+  {
+    "name": "ht-caladea-fonts",
+    "summary": "Caladea, a serif font family metric-compatible with Cambria font family"
+  },
+  {
+    "name": "http-parser",
+    "summary": "HTTP request/response parser for C"
+  },
+  {
+    "name": "httpcomponents-client",
+    "summary": "HTTP agent implementation based on httpcomponents HttpCore"
+  },
+  {
+    "name": "httpcomponents-core",
+    "summary": "Set of low level Java HTTP transport components for HTTP services"
+  },
+  {
+    "name": "httpd",
+    "summary": "Apache HTTP Server"
+  },
+  {
+    "name": "httpd-core",
+    "summary": "httpd minimal core"
+  },
+  {
+    "name": "httpd-devel",
+    "summary": "Development interfaces for the Apache HTTP Server"
+  },
+  {
+    "name": "httpd-filesystem",
+    "summary": "The basic directory layout for the Apache HTTP Server"
+  },
+  {
+    "name": "httpd-manual",
+    "summary": "Documentation for the Apache HTTP Server"
+  },
+  {
+    "name": "httpd-tools",
+    "summary": "Tools for use with the Apache HTTP Server"
+  },
+  {
+    "name": "hunspell",
+    "summary": "A spell checker and morphological analyzer library"
+  },
+  {
+    "name": "hunspell-af",
+    "summary": "Afrikaans hunspell dictionary"
+  },
+  {
+    "name": "hunspell-ak",
+    "summary": "Akan hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-am",
+    "summary": "Amharic hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ar",
+    "summary": "Arabic hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-as",
+    "summary": "Assamese hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ast",
+    "summary": "Asturian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-az",
+    "summary": "Azerbaijani hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-be",
+    "summary": "Belarusian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ber",
+    "summary": "Amazigh hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-bg",
+    "summary": "Bulgarian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-bn",
+    "summary": "Bengali hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-br",
+    "summary": "Breton hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ca",
+    "summary": "Catalan hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-cop",
+    "summary": "Coptic hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-cs",
+    "summary": "Czech hunspell dictionary"
+  },
+  {
+    "name": "hunspell-csb",
+    "summary": "Kashubian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-cv",
+    "summary": "Chuvash hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-cy",
+    "summary": "Welsh hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-da",
+    "summary": "Danish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-de",
+    "summary": "German hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-devel",
+    "summary": "Files for developing with hunspell"
+  },
+  {
+    "name": "hunspell-dsb",
+    "summary": "Lower Sorbian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-el",
+    "summary": "Greek hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-en",
+    "summary": "English hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-en-GB",
+    "summary": "UK English hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-en-US",
+    "summary": "US English hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-eo",
+    "summary": "Esperanto hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-es",
+    "summary": "Spanish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-es-AR",
+    "summary": "Argentine Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-BO",
+    "summary": "Bolivian Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-CL",
+    "summary": "Chilean Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-CO",
+    "summary": "Colombian Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-CR",
+    "summary": "Costa Rican Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-CU",
+    "summary": "Cuban Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-DO",
+    "summary": "Dominican Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-EC",
+    "summary": "Ecuadorian Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-ES",
+    "summary": "European Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-GT",
+    "summary": "Guatemalan Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-HN",
+    "summary": "Honduran Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-MX",
+    "summary": "Mexican Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-NI",
+    "summary": "Nicaraguan Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-PA",
+    "summary": "Panamanian Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-PE",
+    "summary": "Peruvian Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-PR",
+    "summary": "Puerto Rican Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-PY",
+    "summary": "Paraguayan Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-SV",
+    "summary": "Salvadoran Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-US",
+    "summary": "US Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-UY",
+    "summary": "Uruguayan Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-VE",
+    "summary": "Venezuelan Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-et",
+    "summary": "Estonian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-eu",
+    "summary": "Basque hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-fa",
+    "summary": "Farsi hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-filesystem",
+    "summary": "Hunspell filesystem layout"
+  },
+  {
+    "name": "hunspell-fj",
+    "summary": "Fijian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-fo",
+    "summary": "Faroese hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-fr",
+    "summary": "French hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-fur",
+    "summary": "Friulian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-fy",
+    "summary": "Frisian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ga",
+    "summary": "Irish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-gd",
+    "summary": "Scots Gaelic hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-gl",
+    "summary": "Galician hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-grc",
+    "summary": "Ancient Greek hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-gu",
+    "summary": "Gujarati hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-gv",
+    "summary": "Manx hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-haw",
+    "summary": "Hawaiian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-he",
+    "summary": "Hebrew hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-hi",
+    "summary": "Hindi hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-hil",
+    "summary": "Hiligaynon hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-hr",
+    "summary": "Croatian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-hsb",
+    "summary": "Upper Sorbian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ht",
+    "summary": "Haitian Creole hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-hu",
+    "summary": "Hungarian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-hy",
+    "summary": "Armenian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ia",
+    "summary": "Interlingua hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-id",
+    "summary": "Indonesian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-is",
+    "summary": "Icelandic hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-it",
+    "summary": "Italian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-kk",
+    "summary": "Kazakh hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-km",
+    "summary": "Khmer hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-kn",
+    "summary": "Kannada hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ko",
+    "summary": "Korean hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ku",
+    "summary": "Kurdish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ky",
+    "summary": "Kirghiz hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-la",
+    "summary": "Latin hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-lb",
+    "summary": "Luxembourgish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ln",
+    "summary": "Lingala hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-lt",
+    "summary": "Lithuanian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-lv",
+    "summary": "Latvian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mai",
+    "summary": "Maithili hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mg",
+    "summary": "Malagasy hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mi",
+    "summary": "Maori hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mk",
+    "summary": "Macedonian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ml",
+    "summary": "Malayalam hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mn",
+    "summary": "Mongolian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mos",
+    "summary": "Mossi hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mr",
+    "summary": "Marathi hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ms",
+    "summary": "Malay hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mt",
+    "summary": "Maltese hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-nb",
+    "summary": "Bokmaal hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-nds",
+    "summary": "Lowlands Saxon hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ne",
+    "summary": "Nepali hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-nl",
+    "summary": "Dutch hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-nn",
+    "summary": "Nynorsk hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-nr",
+    "summary": "Southern Ndebele hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-nso",
+    "summary": "Northern Sotho hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ny",
+    "summary": "Chichewa hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-oc",
+    "summary": "Occitan hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-om",
+    "summary": "Oromo hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-or",
+    "summary": "Odia hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-pa",
+    "summary": "Punjabi hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-pl",
+    "summary": "Polish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-pt",
+    "summary": "Portuguese hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-qu",
+    "summary": "Quechua Ecuador hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-quh",
+    "summary": "Quechua, South Bolivia hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ro",
+    "summary": "Romanian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ru",
+    "summary": "Russian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-rw",
+    "summary": "Kinyarwanda hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sc",
+    "summary": "Sardinian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-se",
+    "summary": "Northern Saami hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-shs",
+    "summary": "Shuswap hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-si",
+    "summary": "Sinhala hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sk",
+    "summary": "Slovak hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sl",
+    "summary": "Slovenian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-smj",
+    "summary": "Lule Saami hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-so",
+    "summary": "Somali hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sq",
+    "summary": "Albanian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sr",
+    "summary": "Serbian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ss",
+    "summary": "Swati hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-st",
+    "summary": "Southern Sotho hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sv",
+    "summary": "Swedish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sw",
+    "summary": "Swahili hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ta",
+    "summary": "Tamil hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-te",
+    "summary": "Telugu hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-tet",
+    "summary": "Tetum hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-th",
+    "summary": "Thai hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ti",
+    "summary": "Tigrigna hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-tk",
+    "summary": "Turkmen hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-tl",
+    "summary": "Tagalog hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-tn",
+    "summary": "Tswana hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-tpi",
+    "summary": "Tok Pisin hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ts",
+    "summary": "Tsonga hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-uk",
+    "summary": "Ukrainian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ur",
+    "summary": "Urdu hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-uz",
+    "summary": "Uzbek hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ve",
+    "summary": "Venda hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-vi",
+    "summary": "Vietnamese hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-wa",
+    "summary": "Walloon hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-xh",
+    "summary": "Xhosa hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-yi",
+    "summary": "Yiddish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-zu",
+    "summary": "Zulu hunspell dictionaries"
+  },
+  {
+    "name": "hwloc-devel",
+    "summary": "Headers and shared development libraries for hwloc"
+  },
+  {
+    "name": "hwloc-gui",
+    "summary": "The gui-based hwloc program(s)"
+  },
+  {
+    "name": "hyperv-daemons",
+    "summary": "Hyper-V daemons suite"
+  },
+  {
+    "name": "hyperv-daemons-license",
+    "summary": "License of the Hyper-V daemons suite"
+  },
+  {
+    "name": "hyperv-tools",
+    "summary": "Tools for Hyper-V guests"
+  },
+  {
+    "name": "hypervfcopyd",
+    "summary": "Hyper-V FCOPY daemon"
+  },
+  {
+    "name": "hypervkvpd",
+    "summary": "Hyper-V key value pair (KVP) daemon"
+  },
+  {
+    "name": "hypervvssd",
+    "summary": "Hyper-V VSS daemon"
+  },
+  {
+    "name": "hyphen",
+    "summary": "A text hyphenation library"
+  },
+  {
+    "name": "hyphen-af",
+    "summary": "Afrikaans hyphenation rules"
+  },
+  {
+    "name": "hyphen-as",
+    "summary": "Assamese hyphenation rules"
+  },
+  {
+    "name": "hyphen-be",
+    "summary": "Belarusian hyphenation rules"
+  },
+  {
+    "name": "hyphen-bg",
+    "summary": "Bulgarian hyphenation rules"
+  },
+  {
+    "name": "hyphen-bn",
+    "summary": "Bengali hyphenation rules"
+  },
+  {
+    "name": "hyphen-ca",
+    "summary": "Catalan hyphenation rules"
+  },
+  {
+    "name": "hyphen-cs",
+    "summary": "Czech hyphenation rules"
+  },
+  {
+    "name": "hyphen-cy",
+    "summary": "Welsh hyphenation rules"
+  },
+  {
+    "name": "hyphen-da",
+    "summary": "Danish hyphenation rules"
+  },
+  {
+    "name": "hyphen-de",
+    "summary": "German hyphenation rules"
+  },
+  {
+    "name": "hyphen-devel",
+    "summary": "Files for developing with hyphen"
+  },
+  {
+    "name": "hyphen-el",
+    "summary": "Greek hyphenation rules"
+  },
+  {
+    "name": "hyphen-en",
+    "summary": "English hyphenation rules"
+  },
+  {
+    "name": "hyphen-eo",
+    "summary": "Esperanto hyphen rules"
+  },
+  {
+    "name": "hyphen-es",
+    "summary": "Spanish hyphenation rules"
+  },
+  {
+    "name": "hyphen-et",
+    "summary": "Estonian hyphenation rules"
+  },
+  {
+    "name": "hyphen-eu",
+    "summary": "Basque hyphenation rules"
+  },
+  {
+    "name": "hyphen-fa",
+    "summary": "Farsi hyphenation rules"
+  },
+  {
+    "name": "hyphen-fr",
+    "summary": "French hyphenation rules"
+  },
+  {
+    "name": "hyphen-ga",
+    "summary": "Irish hyphenation rules"
+  },
+  {
+    "name": "hyphen-gl",
+    "summary": "Galician hyphenation rules"
+  },
+  {
+    "name": "hyphen-gu",
+    "summary": "Gujarati hyphenation rules"
+  },
+  {
+    "name": "hyphen-hi",
+    "summary": "Hindi hyphenation rules"
+  },
+  {
+    "name": "hyphen-hr",
+    "summary": "Croatian hyphenation rules"
+  },
+  {
+    "name": "hyphen-hu",
+    "summary": "Hungarian hyphenation rules"
+  },
+  {
+    "name": "hyphen-id",
+    "summary": "Indonesian hyphenation rules"
+  },
+  {
+    "name": "hyphen-it",
+    "summary": "Italian hyphenation rules"
+  },
+  {
+    "name": "hyphen-kn",
+    "summary": "Kannada hyphenation rules"
+  },
+  {
+    "name": "hyphen-lt",
+    "summary": "Lithuanian hyphenation rules"
+  },
+  {
+    "name": "hyphen-lv",
+    "summary": "Latvian hyphenation rules"
+  },
+  {
+    "name": "hyphen-ml",
+    "summary": "Malayalam hyphenation rules"
+  },
+  {
+    "name": "hyphen-mr",
+    "summary": "Marathi hyphenation rules"
+  },
+  {
+    "name": "hyphen-nb",
+    "summary": "Bokmaal hyphenation rules"
+  },
+  {
+    "name": "hyphen-nl",
+    "summary": "Dutch hyphenation rules"
+  },
+  {
+    "name": "hyphen-nn",
+    "summary": "Nynorsk hyphenation rules"
+  },
+  {
+    "name": "hyphen-or",
+    "summary": "Odia hyphenation rules"
+  },
+  {
+    "name": "hyphen-pa",
+    "summary": "Punjabi hyphenation rules"
+  },
+  {
+    "name": "hyphen-pl",
+    "summary": "Polish hyphenation rules"
+  },
+  {
+    "name": "hyphen-pt",
+    "summary": "Portuguese hyphenation rules"
+  },
+  {
+    "name": "hyphen-ro",
+    "summary": "Romanian hyphenation rules"
+  },
+  {
+    "name": "hyphen-ru",
+    "summary": "Russian hyphenation rules"
+  },
+  {
+    "name": "hyphen-sk",
+    "summary": "Slovak hyphenation rules"
+  },
+  {
+    "name": "hyphen-sl",
+    "summary": "Slovenian hyphenation rules"
+  },
+  {
+    "name": "hyphen-sr",
+    "summary": "Serbian hyphenation rules"
+  },
+  {
+    "name": "hyphen-sv",
+    "summary": "Swedish hyphenation rules"
+  },
+  {
+    "name": "hyphen-ta",
+    "summary": "Tamil hyphenation rules"
+  },
+  {
+    "name": "hyphen-te",
+    "summary": "Telugu hyphenation rules"
+  },
+  {
+    "name": "hyphen-uk",
+    "summary": "Ukrainian hyphenation rules"
+  },
+  {
+    "name": "hyphen-zu",
+    "summary": "Zulu hyphenation rules"
+  },
+  {
+    "name": "i2c-tools",
+    "summary": "A heterogeneous set of I2C tools for Linux"
+  },
+  {
+    "name": "i2c-tools-perl",
+    "summary": "i2c tools written in Perl"
+  },
+  {
+    "name": "ibus",
+    "summary": "Intelligent Input Bus for Linux OS"
+  },
+  {
+    "name": "ibus-anthy",
+    "summary": "The Anthy engine for IBus input platform"
+  },
+  {
+    "name": "ibus-anthy-python",
+    "summary": "Anthy Python files for IBus"
+  },
+  {
+    "name": "ibus-gtk2",
+    "summary": "IBus IM module for GTK2"
+  },
+  {
+    "name": "ibus-gtk3",
+    "summary": "IBus IM module for GTK3"
+  },
+  {
+    "name": "ibus-hangul",
+    "summary": "The Hangul engine for IBus input platform"
+  },
+  {
+    "name": "ibus-libpinyin",
+    "summary": "Intelligent Pinyin engine based on libpinyin for IBus"
+  },
+  {
+    "name": "ibus-libs",
+    "summary": "IBus libraries"
+  },
+  {
+    "name": "ibus-libzhuyin",
+    "summary": "New Zhuyin engine based on libzhuyin for IBus"
+  },
+  {
+    "name": "ibus-m17n",
+    "summary": "The M17N engine for IBus platform"
+  },
+  {
+    "name": "ibus-setup",
+    "summary": "IBus setup utility"
+  },
+  {
+    "name": "ibus-table",
+    "summary": "The Table engine for IBus platform"
+  },
+  {
+    "name": "ibus-table-chinese",
+    "summary": "Chinese input tables for IBus"
+  },
+  {
+    "name": "ibus-table-chinese-array",
+    "summary": "Array input methods"
+  },
+  {
+    "name": "ibus-table-chinese-cangjie",
+    "summary": "Cangjie based input methods"
+  },
+  {
+    "name": "ibus-table-chinese-cantonese",
+    "summary": "Cantonese input methods"
+  },
+  {
+    "name": "ibus-table-chinese-easy",
+    "summary": "Easy input method"
+  },
+  {
+    "name": "ibus-table-chinese-erbi",
+    "summary": "Erbi input method"
+  },
+  {
+    "name": "ibus-table-chinese-quick",
+    "summary": "Quick-to-learn input methods"
+  },
+  {
+    "name": "ibus-table-chinese-scj",
+    "summary": "Smart Cangjie"
+  },
+  {
+    "name": "ibus-table-chinese-stroke5",
+    "summary": "Stroke 5 input method"
+  },
+  {
+    "name": "ibus-table-chinese-wu",
+    "summary": "Wu pronunciation input method"
+  },
+  {
+    "name": "ibus-table-chinese-wubi-haifeng",
+    "summary": "Haifeng Wubi input method"
+  },
+  {
+    "name": "ibus-table-chinese-wubi-jidian",
+    "summary": "Jidian Wubi 86 input method, JiShuang 6.0"
+  },
+  {
+    "name": "ibus-table-chinese-yong",
+    "summary": "YongMa input method"
+  },
+  {
+    "name": "ibus-typing-booster",
+    "summary": "A completion input method"
+  },
+  {
+    "name": "ibus-wayland",
+    "summary": "IBus IM module for Wayland"
+  },
+  {
+    "name": "icoutils",
+    "summary": "Utility for extracting and converting Microsoft icon and cursor files"
+  },
+  {
+    "name": "icu",
+    "summary": "International Components for Unicode"
+  },
+  {
+    "name": "idm-jss",
+    "summary": "Java Security Services (JSS)"
+  },
+  {
+    "name": "idm-jss-tomcat",
+    "summary": "Java Security Services (JSS) Connector for Tomcat"
+  },
+  {
+    "name": "idm-ldapjdk",
+    "summary": "LDAP SDK"
+  },
+  {
+    "name": "idm-pki-acme",
+    "summary": "IDM PKI ACME Package"
+  },
+  {
+    "name": "idm-pki-base",
+    "summary": "IDM PKI Base Package"
+  },
+  {
+    "name": "idm-pki-ca",
+    "summary": "IDM PKI CA Package"
+  },
+  {
+    "name": "idm-pki-est",
+    "summary": "IDM PKI EST Package"
+  },
+  {
+    "name": "idm-pki-java",
+    "summary": "IDM PKI Base Java Package"
+  },
+  {
+    "name": "idm-pki-kra",
+    "summary": "IDM PKI KRA Package"
+  },
+  {
+    "name": "idm-pki-server",
+    "summary": "IDM PKI Server Package"
+  },
+  {
+    "name": "idm-pki-tools",
+    "summary": "IDM PKI Tools Package"
+  },
+  {
+    "name": "idm-tomcatjss",
+    "summary": "JSS Connector for Apache Tomcat"
+  },
+  {
+    "name": "idn2",
+    "summary": "IDNA2008 internationalized domain names conversion tool"
+  },
+  {
+    "name": "ignition",
+    "summary": "First boot installer and configuration tool"
+  },
+  {
+    "name": "ignition-edge",
+    "summary": "Enablement glue for Ignition on IoT/Edge systems"
+  },
+  {
+    "name": "ignition-grub",
+    "summary": "Enablement glue for bootupd's grub2 config"
+  },
+  {
+    "name": "ignition-validate",
+    "summary": "Validation tool for Ignition configs"
+  },
+  {
+    "name": "iio-sensor-proxy",
+    "summary": "IIO accelerometer sensor to input device proxy"
+  },
+  {
+    "name": "imath",
+    "summary": "Library of 2D and 3D vector, matrix, and math operations for computer graphics"
+  },
+  {
+    "name": "infiniband-diags",
+    "summary": "InfiniBand Diagnostic Tools"
+  },
+  {
+    "name": "initial-setup",
+    "summary": "Initial system configuration utility"
+  },
+  {
+    "name": "initial-setup-gui",
+    "summary": "Graphical user interface for the initial-setup utility"
+  },
+  {
+    "name": "inkscape",
+    "summary": "Vector-based drawing program using SVG"
+  },
+  {
+    "name": "inkscape-docs",
+    "summary": "Documentation for Inkscape"
+  },
+  {
+    "name": "inkscape-view",
+    "summary": "Viewing program for SVG files"
+  },
+  {
+    "name": "insights-client",
+    "summary": "Uploads Insights information to Red Hat on a periodic basis"
+  },
+  {
+    "name": "insights-client-ros",
+    "summary": "The subpackage for Insights resource optimization service"
+  },
+  {
+    "name": "intltool",
+    "summary": "Utility for internationalizing various kinds of data files"
+  },
+  {
+    "name": "iowatcher",
+    "summary": "Utility for visualizing block layer IO patterns and performance"
+  },
+  {
+    "name": "ipa-client",
+    "summary": "IPA authentication for use on clients"
+  },
+  {
+    "name": "ipa-client-common",
+    "summary": "Common files used by IPA client"
+  },
+  {
+    "name": "ipa-client-encrypted-dns",
+    "summary": "Enable encrypted DNS support for clients"
+  },
+  {
+    "name": "ipa-client-epn",
+    "summary": "Tools to configure Expiring Password Notification in IPA"
+  },
+  {
+    "name": "ipa-client-samba",
+    "summary": "Tools to configure Samba on IPA client"
+  },
+  {
+    "name": "ipa-common",
+    "summary": "Common files used by IPA"
+  },
+  {
+    "name": "ipa-healthcheck",
+    "summary": "Health check tool for IPA"
+  },
+  {
+    "name": "ipa-healthcheck-core",
+    "summary": "Core plugin system for healthcheck"
+  },
+  {
+    "name": "ipa-selinux",
+    "summary": "FreeIPA SELinux policy"
+  },
+  {
+    "name": "ipa-selinux-luna",
+    "summary": "FreeIPA SELinux policy for Thales Luna HSMs"
+  },
+  {
+    "name": "ipa-selinux-nfast",
+    "summary": "FreeIPA SELinux policy for nCipher nfast HSMs"
+  },
+  {
+    "name": "ipa-server",
+    "summary": "The IPA authentication server"
+  },
+  {
+    "name": "ipa-server-common",
+    "summary": "Common files used by IPA server"
+  },
+  {
+    "name": "ipa-server-dns",
+    "summary": "IPA integrated DNS server with support for automatic DNSSEC signing"
+  },
+  {
+    "name": "ipa-server-encrypted-dns",
+    "summary": "support for encrypted DNS in IPA integrated DNS server"
+  },
+  {
+    "name": "ipa-server-trust-ad",
+    "summary": "Virtual package to install packages required for Active Directory trusts"
+  },
+  {
+    "name": "iperf3",
+    "summary": "Measurement tool for TCP/UDP bandwidth performance"
+  },
+  {
+    "name": "ipmievd",
+    "summary": "IPMI event daemon for sending events to syslog"
+  },
+  {
+    "name": "ipmitool",
+    "summary": "Utility for IPMI control"
+  },
+  {
+    "name": "ipset-service",
+    "summary": "ipset service for ipsets"
+  },
+  {
+    "name": "iptables-devel",
+    "summary": "Development package for iptables"
+  },
+  {
+    "name": "iptables-nft-services",
+    "summary": "Services for nft-variants of iptables, ebtables and arptables"
+  },
+  {
+    "name": "iputils-ninfod",
+    "summary": "Node Information Query Daemon"
+  },
+  {
+    "name": "ipvsadm",
+    "summary": "Utility to administer the Linux Virtual Server"
+  },
+  {
+    "name": "ipxe-bootimgs-aarch64",
+    "summary": "AArch64 Network boot loader images in bootable USB and GRUB formats"
+  },
+  {
+    "name": "ipxe-bootimgs-x86",
+    "summary": "X86 Network boot loader images in bootable USB, CD, floppy and GRUB formats"
+  },
+  {
+    "name": "ipxe-roms",
+    "summary": "Network boot loader roms in .rom format"
+  },
+  {
+    "name": "ipxe-roms-qemu",
+    "summary": "Network boot loader roms supported by QEMU, .rom format"
+  },
+  {
+    "name": "irssi",
+    "summary": "Modular text mode IRC client with Perl scripting"
+  },
+  {
+    "name": "iso-codes",
+    "summary": "ISO code lists and translations"
+  },
+  {
+    "name": "iso-codes-devel",
+    "summary": "Files for development using iso-codes"
+  },
+  {
+    "name": "isomd5sum",
+    "summary": "Utilities for working with md5sum implanted in ISO images"
+  },
+  {
+    "name": "itstool",
+    "summary": "ITS-based XML translation tool"
+  },
+  {
+    "name": "jakarta-activation",
+    "summary": "Jakarta Activation Specification and Implementation"
+  },
+  {
+    "name": "jakarta-activation2",
+    "summary": "Jakarta Activation API"
+  },
+  {
+    "name": "jakarta-annotations",
+    "summary": "Jakarta Annotations"
+  },
+  {
+    "name": "jakarta-mail",
+    "summary": "Jakarta Mail API"
+  },
+  {
+    "name": "jakarta-oro",
+    "summary": "Full regular expressions API"
+  },
+  {
+    "name": "jansi",
+    "summary": "Generate and interpret ANSI escape sequences in Java"
+  },
+  {
+    "name": "jasper",
+    "summary": "Implementation of the JPEG-2000 standard, Part 1"
+  },
+  {
+    "name": "jasper-libs",
+    "summary": "Runtime libraries for jasper"
+  },
+  {
+    "name": "jasper-utils",
+    "summary": "Nonessential utilities for jasper"
+  },
+  {
+    "name": "java-1.8.0-openjdk",
+    "summary": "OpenJDK 8 Runtime Environment"
+  },
+  {
+    "name": "java-1.8.0-openjdk-demo",
+    "summary": "OpenJDK 8 Demos"
+  },
+  {
+    "name": "java-1.8.0-openjdk-devel",
+    "summary": "OpenJDK 8 Development Environment"
+  },
+  {
+    "name": "java-1.8.0-openjdk-headless",
+    "summary": "OpenJDK 8 Headless Runtime Environment"
+  },
+  {
+    "name": "java-1.8.0-openjdk-javadoc",
+    "summary": "OpenJDK 8 API documentation"
+  },
+  {
+    "name": "java-1.8.0-openjdk-javadoc-zip",
+    "summary": "OpenJDK 8 API documentation compressed in a single archive"
+  },
+  {
+    "name": "java-1.8.0-openjdk-src",
+    "summary": "OpenJDK 8 Source Bundle"
+  },
+  {
+    "name": "java-11-openjdk",
+    "summary": "OpenJDK 11 Runtime Environment"
+  },
+  {
+    "name": "java-11-openjdk-demo",
+    "summary": "OpenJDK 11 Demos"
+  },
+  {
+    "name": "java-11-openjdk-devel",
+    "summary": "OpenJDK 11 Development Environment"
+  },
+  {
+    "name": "java-11-openjdk-headless",
+    "summary": "OpenJDK 11 Headless Runtime Environment"
+  },
+  {
+    "name": "java-11-openjdk-javadoc",
+    "summary": "OpenJDK 11 API documentation"
+  },
+  {
+    "name": "java-11-openjdk-javadoc-zip",
+    "summary": "OpenJDK 11 API documentation compressed in a single archive"
+  },
+  {
+    "name": "java-11-openjdk-jmods",
+    "summary": "JMods for OpenJDK 11"
+  },
+  {
+    "name": "java-11-openjdk-src",
+    "summary": "OpenJDK 11 Source Bundle"
+  },
+  {
+    "name": "java-11-openjdk-static-libs",
+    "summary": "OpenJDK 11 libraries for static linking"
+  },
+  {
+    "name": "java-17-openjdk",
+    "summary": "OpenJDK 17 Runtime Environment"
+  },
+  {
+    "name": "java-17-openjdk-demo",
+    "summary": "OpenJDK 17 Demos"
+  },
+  {
+    "name": "java-17-openjdk-devel",
+    "summary": "OpenJDK 17 Development Environment"
+  },
+  {
+    "name": "java-17-openjdk-headless",
+    "summary": "OpenJDK 17 Headless Runtime Environment"
+  },
+  {
+    "name": "java-17-openjdk-javadoc",
+    "summary": "OpenJDK 17 API documentation"
+  },
+  {
+    "name": "java-17-openjdk-javadoc-zip",
+    "summary": "OpenJDK 17 API documentation compressed in a single archive"
+  },
+  {
+    "name": "java-17-openjdk-jmods",
+    "summary": "JMods for OpenJDK 17"
+  },
+  {
+    "name": "java-17-openjdk-src",
+    "summary": "OpenJDK 17 Source Bundle"
+  },
+  {
+    "name": "java-17-openjdk-static-libs",
+    "summary": "OpenJDK 17 libraries for static linking"
+  },
+  {
+    "name": "java-21-openjdk",
+    "summary": "OpenJDK 21 Runtime Environment"
+  },
+  {
+    "name": "java-21-openjdk-demo",
+    "summary": "OpenJDK 21 Demos"
+  },
+  {
+    "name": "java-21-openjdk-devel",
+    "summary": "OpenJDK 21 Development Environment"
+  },
+  {
+    "name": "java-21-openjdk-headless",
+    "summary": "OpenJDK 21 Headless Runtime Environment"
+  },
+  {
+    "name": "java-21-openjdk-javadoc",
+    "summary": "OpenJDK 21 API documentation"
+  },
+  {
+    "name": "java-21-openjdk-javadoc-zip",
+    "summary": "OpenJDK 21 API documentation compressed in a single archive"
+  },
+  {
+    "name": "java-21-openjdk-jmods",
+    "summary": "JMods for OpenJDK 21"
+  },
+  {
+    "name": "java-21-openjdk-src",
+    "summary": "OpenJDK 21 Source Bundle"
+  },
+  {
+    "name": "java-21-openjdk-static-libs",
+    "summary": "OpenJDK 21 libraries for static linking"
+  },
+  {
+    "name": "javapackages-filesystem",
+    "summary": "Java packages filesystem layout"
+  },
+  {
+    "name": "javapackages-tools",
+    "summary": "Macros and scripts for Java packaging support"
+  },
+  {
+    "name": "jaxb-api",
+    "summary": "Jakarta XML Binding API"
+  },
+  {
+    "name": "jaxb-api4",
+    "summary": "Jakarta XML Binding API"
+  },
+  {
+    "name": "jaxb-codemodel",
+    "summary": "Codemodel Core"
+  },
+  {
+    "name": "jaxb-core",
+    "summary": "JAXB Core"
+  },
+  {
+    "name": "jaxb-dtd-parser",
+    "summary": "SAX-like API for parsing XML DTDs"
+  },
+  {
+    "name": "jaxb-istack-commons-runtime",
+    "summary": "istack-commons runtime"
+  },
+  {
+    "name": "jaxb-istack-commons-tools",
+    "summary": "istack-commons tools"
+  },
+  {
+    "name": "jaxb-relaxng-datatype",
+    "summary": "RelaxNG Datatype"
+  },
+  {
+    "name": "jaxb-rngom",
+    "summary": "RELAX NG Object Model/Parser"
+  },
+  {
+    "name": "jaxb-runtime",
+    "summary": "JAXB Runtime"
+  },
+  {
+    "name": "jaxb-txw2",
+    "summary": "TXW2 Runtime"
+  },
+  {
+    "name": "jaxb-xjc",
+    "summary": "JAXB XJC"
+  },
+  {
+    "name": "jaxb-xsom",
+    "summary": "XML Schema Object Model"
+  },
+  {
+    "name": "jbig2dec-libs",
+    "summary": "A decoder implementation of the JBIG2 image compression format"
+  },
+  {
+    "name": "jbigkit",
+    "summary": "JBIG1 lossless image compression tools"
+  },
+  {
+    "name": "jbigkit-libs",
+    "summary": "JBIG1 lossless image compression library"
+  },
+  {
+    "name": "jboss-jaxrs-2.0-api",
+    "summary": "JAX-RS 2.0: The Java API for RESTful Web Services"
+  },
+  {
+    "name": "jboss-logging",
+    "summary": "The JBoss Logging Framework"
+  },
+  {
+    "name": "jboss-logging-tools",
+    "summary": "JBoss Logging I18n Annotation Processor"
+  },
+  {
+    "name": "jcl-over-slf4j",
+    "summary": "JCL 1.1.1 implemented over SLF4J"
+  },
+  {
+    "name": "jctools",
+    "summary": "Java Concurrency Tools for the JVM"
+  },
+  {
+    "name": "jdeparser",
+    "summary": "Source generator library for Java"
+  },
+  {
+    "name": "jdepend",
+    "summary": "Java Design Quality Metrics"
+  },
+  {
+    "name": "jigawatts",
+    "summary": "Java CRIU helper"
+  },
+  {
+    "name": "jigawatts-javadoc",
+    "summary": "Javadoc for jigawatts"
+  },
+  {
+    "name": "jmc-core",
+    "summary": "Core API for JDK Mission Control"
+  },
+  {
+    "name": "jna",
+    "summary": "Pure Java access to native libraries"
+  },
+  {
+    "name": "jna-contrib",
+    "summary": "Contrib for jna"
+  },
+  {
+    "name": "jomolhari-fonts",
+    "summary": "Jomolhari a Bhutanese style font for Tibetan and Dzongkha"
+  },
+  {
+    "name": "jose",
+    "summary": "Tools for JSON Object Signing and Encryption (JOSE)"
+  },
+  {
+    "name": "jq",
+    "summary": "Command-line JSON processor"
+  },
+  {
+    "name": "js-d3-flame-graph",
+    "summary": "A D3.js plugin that produces flame graphs"
+  },
+  {
+    "name": "jsch",
+    "summary": "Pure Java implementation of SSH2"
+  },
+  {
+    "name": "json-glib-devel",
+    "summary": "Development files for json-glib"
+  },
+  {
+    "name": "jsoup",
+    "summary": "Java library for working with real-world HTML"
+  },
+  {
+    "name": "jsr-305",
+    "summary": "Correctness annotations for Java code"
+  },
+  {
+    "name": "jss",
+    "summary": "Java Security Services (JSS)"
+  },
+  {
+    "name": "Judy",
+    "summary": "General purpose dynamic array"
+  },
+  {
+    "name": "julietaula-montserrat-fonts",
+    "summary": "Sans-serif typeface inspired from Montserrat area"
+  },
+  {
+    "name": "junit",
+    "summary": "Java regression test package"
+  },
+  {
+    "name": "junit5",
+    "summary": "Java regression testing framework"
+  },
+  {
+    "name": "jzlib",
+    "summary": "Re-implementation of zlib in pure Java"
+  },
+  {
+    "name": "kabi-dw",
+    "summary": "Detect changes in the ABI between kernel builds"
+  },
+  {
+    "name": "kacst-art-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-book-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-decorative-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-digital-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-farsi-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-fonts-common",
+    "summary": "Common files for kacst-fonts"
+  },
+  {
+    "name": "kacst-letter-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-naskh-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-office-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-one-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-pen-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-poster-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-qurn-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-screen-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-title-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-titlel-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kasumi-common",
+    "summary": "Anthy dictionary management common files between kasumi and kasumi-unicode"
+  },
+  {
+    "name": "kasumi-unicode",
+    "summary": "An anthy-unicode dictionary management tool"
+  },
+  {
+    "name": "kbd-legacy",
+    "summary": "Legacy data for kbd package"
+  },
+  {
+    "name": "kdump-anaconda-addon",
+    "summary": "Kdump configuration anaconda addon"
+  },
+  {
+    "name": "keepalived",
+    "summary": "High Availability monitor built upon LVS, VRRP and service pollers"
+  },
+  {
+    "name": "kernel-64k-debug-devel",
+    "summary": "Development package for building kernel modules to match the kernel"
+  },
+  {
+    "name": "kernel-64k-debug-devel-matched",
+    "summary": "Meta package to install matching core and devel packages for a given kernel"
+  },
+  {
+    "name": "kernel-64k-devel",
+    "summary": "Development package for building kernel modules to match the kernel"
+  },
+  {
+    "name": "kernel-64k-devel-matched",
+    "summary": "Meta package to install matching core and devel packages for a given kernel"
+  },
+  {
+    "name": "kernel-debug-devel",
+    "summary": "Development package for building kernel modules to match the kernel"
+  },
+  {
+    "name": "kernel-debug-devel-matched",
+    "summary": "Meta package to install matching core and devel packages for a given kernel"
+  },
+  {
+    "name": "kernel-devel",
+    "summary": "Development package for building kernel modules to match the kernel"
+  },
+  {
+    "name": "kernel-devel-matched",
+    "summary": "Meta package to install matching core and devel packages for a given kernel"
+  },
+  {
+    "name": "kernel-doc",
+    "summary": "Various documentation bits found in the kernel source"
+  },
+  {
+    "name": "kernel-headers",
+    "summary": "Header files for the Linux kernel for use by glibc"
+  },
+  {
+    "name": "kernel-rpm-macros",
+    "summary": "Macros and scripts for building kernel module packages"
+  },
+  {
+    "name": "kernel-srpm-macros",
+    "summary": "RPM macros that list arches the full kernel is built on"
+  },
+  {
+    "name": "kernelshark",
+    "summary": "GUI analysis for Ftrace data captured by trace-cmd"
+  },
+  {
+    "name": "keybinder3",
+    "summary": "A library for registering global keyboard shortcuts"
+  },
+  {
+    "name": "keycloak-httpd-client-install",
+    "summary": "Tools to configure Apache HTTPD as Keycloak client"
+  },
+  {
+    "name": "keylime",
+    "summary": "Open source TPM software for Bootstrapping and Maintaining Trust"
+  },
+  {
+    "name": "keylime-agent-rust",
+    "summary": "Rust agent for Keylime"
+  },
+  {
+    "name": "keylime-base",
+    "summary": "The base package contains the default configuration"
+  },
+  {
+    "name": "keylime-registrar",
+    "summary": "The Keylime Registrar component"
+  },
+  {
+    "name": "keylime-selinux",
+    "summary": "keylime SELinux policy"
+  },
+  {
+    "name": "keylime-tenant",
+    "summary": "The Python Keylime Tenant"
+  },
+  {
+    "name": "keylime-verifier",
+    "summary": "The Python Keylime Verifier component"
+  },
+  {
+    "name": "keyutils-libs-devel",
+    "summary": "Development package for building Linux key management utilities"
+  },
+  {
+    "name": "khmer-os-battambang-fonts",
+    "summary": "Battambang font"
+  },
+  {
+    "name": "khmer-os-bokor-fonts",
+    "summary": "Bokor font"
+  },
+  {
+    "name": "khmer-os-content-fonts",
+    "summary": "Content font family"
+  },
+  {
+    "name": "khmer-os-fasthand-fonts",
+    "summary": "Fasthand font family"
+  },
+  {
+    "name": "khmer-os-freehand-fonts",
+    "summary": "Freehand font family"
+  },
+  {
+    "name": "khmer-os-handwritten-fonts",
+    "summary": "All the handwritten font family packages"
+  },
+  {
+    "name": "khmer-os-metal-chrieng-fonts",
+    "summary": "Metal Chrieng font"
+  },
+  {
+    "name": "khmer-os-muol-fonts",
+    "summary": "Muol normal and Muol Light font family"
+  },
+  {
+    "name": "khmer-os-muol-fonts-all",
+    "summary": "All the Muol font family packages"
+  },
+  {
+    "name": "khmer-os-muol-pali-fonts",
+    "summary": "Muol Pali font"
+  },
+  {
+    "name": "khmer-os-siemreap-fonts",
+    "summary": "Siemreap font"
+  },
+  {
+    "name": "khmer-os-system-fonts",
+    "summary": "System font"
+  },
+  {
+    "name": "krb5-devel",
+    "summary": "Development files needed to compile Kerberos 5 programs"
+  },
+  {
+    "name": "ksh",
+    "summary": "The Original ATT Korn Shell"
+  },
+  {
+    "name": "ksmtuned",
+    "summary": "Kernel Samepage Merging services"
+  },
+  {
+    "name": "ktls-utils",
+    "summary": "TLS handshake agent for kernel sockets"
+  },
+  {
+    "name": "lame",
+    "summary": "Free MP3 audio compressor"
+  },
+  {
+    "name": "lame-libs",
+    "summary": "LAME MP3 encoding library"
+  },
+  {
+    "name": "langpacks-af",
+    "summary": "Afrikaans langpacks meta-package"
+  },
+  {
+    "name": "langpacks-am",
+    "summary": "Amharic langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ar",
+    "summary": "Arabic langpacks meta-package"
+  },
+  {
+    "name": "langpacks-as",
+    "summary": "Assamese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ast",
+    "summary": "Asturian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-be",
+    "summary": "Belarusian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-bg",
+    "summary": "Bulgarian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-bn",
+    "summary": "Bengali langpacks meta-package"
+  },
+  {
+    "name": "langpacks-bo",
+    "summary": "Tibetan langpacks meta-package"
+  },
+  {
+    "name": "langpacks-br",
+    "summary": "Breton langpacks meta-package"
+  },
+  {
+    "name": "langpacks-bs",
+    "summary": "Bosnian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ca",
+    "summary": "Catalan langpacks meta-package"
+  },
+  {
+    "name": "langpacks-core-af",
+    "summary": "Afrikaans langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-am",
+    "summary": "Amharic langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ar",
+    "summary": "Arabic langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-as",
+    "summary": "Assamese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ast",
+    "summary": "Asturian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-be",
+    "summary": "Belarusian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-bg",
+    "summary": "Bulgarian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-bn",
+    "summary": "Bengali langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-bo",
+    "summary": "Tibetan langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-br",
+    "summary": "Breton langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-bs",
+    "summary": "Bosnian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ca",
+    "summary": "Catalan langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-cs",
+    "summary": "Czech langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-cy",
+    "summary": "Welsh langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-da",
+    "summary": "Danish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-de",
+    "summary": "German langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-dz",
+    "summary": "Bhutanese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-el",
+    "summary": "Greek langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-en",
+    "summary": "English langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-en_GB",
+    "summary": "English (United Kingdom) langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-eo",
+    "summary": "Esperanto langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-es",
+    "summary": "Spanish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-et",
+    "summary": "Estonian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-eu",
+    "summary": "Basque langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-fa",
+    "summary": "Persian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-fi",
+    "summary": "Finnish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-font-af",
+    "summary": "Afrikaans core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-am",
+    "summary": "Amharic core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ar",
+    "summary": "Arabic core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-as",
+    "summary": "Assamese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ast",
+    "summary": "Asturian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-be",
+    "summary": "Belarusian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-bg",
+    "summary": "Bulgarian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-bn",
+    "summary": "Bengali core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-bo",
+    "summary": "Tibetan core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-br",
+    "summary": "Breton core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-bs",
+    "summary": "Bosnian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ca",
+    "summary": "Catalan core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-cs",
+    "summary": "Czech core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-cy",
+    "summary": "Welsh core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-da",
+    "summary": "Danish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-de",
+    "summary": "German core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-dz",
+    "summary": "Bhutanese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-el",
+    "summary": "Greek core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-en",
+    "summary": "English core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-eo",
+    "summary": "Esperanto core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-es",
+    "summary": "Spanish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-et",
+    "summary": "Estonian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-eu",
+    "summary": "Basque core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-fa",
+    "summary": "Persian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-fi",
+    "summary": "Finnish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-fr",
+    "summary": "French core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ga",
+    "summary": "Irish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-gl",
+    "summary": "Galician core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-gu",
+    "summary": "Gujarati core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-he",
+    "summary": "Hebrew core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-hi",
+    "summary": "Hindi core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-hr",
+    "summary": "Croatian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-hu",
+    "summary": "Hungarian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ia",
+    "summary": "Interlingua core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-id",
+    "summary": "Indonesian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-is",
+    "summary": "Icelandic core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-it",
+    "summary": "Italian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ja",
+    "summary": "Japanese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ka",
+    "summary": "Georgian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-kk",
+    "summary": "Kazakh core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-km",
+    "summary": "Khmer core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-kn",
+    "summary": "Kannada core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ko",
+    "summary": "Korean core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ku",
+    "summary": "Kurdish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-lt",
+    "summary": "Lithuanian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-lv",
+    "summary": "Latvian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-mai",
+    "summary": "Maithili core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-mk",
+    "summary": "Macedonian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ml",
+    "summary": "Malayalam core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-mr",
+    "summary": "Marathi core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ms",
+    "summary": "Malay core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-my",
+    "summary": "Burmese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-nb",
+    "summary": "Norwegian Bokm\u00e5l core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ne",
+    "summary": "Nepali core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-nl",
+    "summary": "Dutch core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-nn",
+    "summary": "Nynorsk core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-nr",
+    "summary": "Southern Ndebele core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-nso",
+    "summary": "Northern Sotho core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-or",
+    "summary": "Odia core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-pa",
+    "summary": "Punjabi core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-pl",
+    "summary": "Polish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-pt",
+    "summary": "Portuguese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ro",
+    "summary": "Romanian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ru",
+    "summary": "Russian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-si",
+    "summary": "Sinhala core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-sk",
+    "summary": "Slovak core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-sl",
+    "summary": "Slovenian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-sq",
+    "summary": "Albanian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-sr",
+    "summary": "Serbian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ss",
+    "summary": "Swati core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-sv",
+    "summary": "Swedish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ta",
+    "summary": "Tamil core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-te",
+    "summary": "Telugu core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-th",
+    "summary": "Thai core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-tn",
+    "summary": "Tswana core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-tr",
+    "summary": "Turkish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ts",
+    "summary": "Tsonga core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-uk",
+    "summary": "Ukrainian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ur",
+    "summary": "Urdu core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ve",
+    "summary": "Venda core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-vi",
+    "summary": "Vietnamese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-xh",
+    "summary": "Xhosa core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-yi",
+    "summary": "Yiddish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-zh_CN",
+    "summary": "Simplified Chinese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-zh_HK",
+    "summary": "Hong Kong Traditional Chinese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-zh_TW",
+    "summary": "Taiwan Traditional Chinese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-zu",
+    "summary": "Zulu core font meta-package"
+  },
+  {
+    "name": "langpacks-core-fr",
+    "summary": "French langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ga",
+    "summary": "Irish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-gl",
+    "summary": "Galician langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-gu",
+    "summary": "Gujarati langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-he",
+    "summary": "Hebrew langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-hi",
+    "summary": "Hindi langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-hr",
+    "summary": "Croatian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-hu",
+    "summary": "Hungarian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ia",
+    "summary": "Interlingua langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-id",
+    "summary": "Indonesian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-is",
+    "summary": "Icelandic langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-it",
+    "summary": "Italian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ja",
+    "summary": "Japanese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ka",
+    "summary": "Georgian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-kk",
+    "summary": "Kazakh langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-km",
+    "summary": "Khmer langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-kn",
+    "summary": "Kannada langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ko",
+    "summary": "Korean langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ku",
+    "summary": "Kurdish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-lt",
+    "summary": "Lithuanian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-lv",
+    "summary": "Latvian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-mai",
+    "summary": "Maithili langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-mk",
+    "summary": "Macedonian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ml",
+    "summary": "Malayalam langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-mr",
+    "summary": "Marathi langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ms",
+    "summary": "Malay langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-my",
+    "summary": "Burmese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-nb",
+    "summary": "Norwegian Bokm\u00e5l langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ne",
+    "summary": "Nepali langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-nl",
+    "summary": "Dutch langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-nn",
+    "summary": "Nynorsk langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-nr",
+    "summary": "Southern Ndebele langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-nso",
+    "summary": "Northern Sotho langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-or",
+    "summary": "Odia langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-pa",
+    "summary": "Punjabi langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-pl",
+    "summary": "Polish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-pt",
+    "summary": "Portuguese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-pt_BR",
+    "summary": "Portuguese (Brazil) langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ro",
+    "summary": "Romanian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ru",
+    "summary": "Russian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-si",
+    "summary": "Sinhala langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-sk",
+    "summary": "Slovak langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-sl",
+    "summary": "Slovenian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-sq",
+    "summary": "Albanian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-sr",
+    "summary": "Serbian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ss",
+    "summary": "Swati langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-sv",
+    "summary": "Swedish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ta",
+    "summary": "Tamil langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-te",
+    "summary": "Telugu langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-th",
+    "summary": "Thai langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-tn",
+    "summary": "Tswana langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-tr",
+    "summary": "Turkish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ts",
+    "summary": "Tsonga langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-uk",
+    "summary": "Ukrainian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ur",
+    "summary": "Urdu langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ve",
+    "summary": "Venda langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-vi",
+    "summary": "Vietnamese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-xh",
+    "summary": "Xhosa langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-yi",
+    "summary": "Yiddish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-zh_CN",
+    "summary": "Simplified Chinese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-zh_HK",
+    "summary": "Hong Kong Traditional Chinese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-zh_TW",
+    "summary": "Taiwan Traditional Chinese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-zu",
+    "summary": "Zulu langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-cs",
+    "summary": "Czech langpacks meta-package"
+  },
+  {
+    "name": "langpacks-cy",
+    "summary": "Welsh langpacks meta-package"
+  },
+  {
+    "name": "langpacks-da",
+    "summary": "Danish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-de",
+    "summary": "German langpacks meta-package"
+  },
+  {
+    "name": "langpacks-dz",
+    "summary": "Bhutanese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-el",
+    "summary": "Greek langpacks meta-package"
+  },
+  {
+    "name": "langpacks-en",
+    "summary": "English langpacks meta-package"
+  },
+  {
+    "name": "langpacks-en_GB",
+    "summary": "English (United Kingdom) langpacks meta-package"
+  },
+  {
+    "name": "langpacks-eo",
+    "summary": "Esperanto langpacks meta-package"
+  },
+  {
+    "name": "langpacks-es",
+    "summary": "Spanish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-et",
+    "summary": "Estonian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-eu",
+    "summary": "Basque langpacks meta-package"
+  },
+  {
+    "name": "langpacks-fa",
+    "summary": "Persian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-fi",
+    "summary": "Finnish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-fr",
+    "summary": "French langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ga",
+    "summary": "Irish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-gl",
+    "summary": "Galician langpacks meta-package"
+  },
+  {
+    "name": "langpacks-gu",
+    "summary": "Gujarati langpacks meta-package"
+  },
+  {
+    "name": "langpacks-he",
+    "summary": "Hebrew langpacks meta-package"
+  },
+  {
+    "name": "langpacks-hi",
+    "summary": "Hindi langpacks meta-package"
+  },
+  {
+    "name": "langpacks-hr",
+    "summary": "Croatian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-hu",
+    "summary": "Hungarian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ia",
+    "summary": "Interlingua langpacks meta-package"
+  },
+  {
+    "name": "langpacks-id",
+    "summary": "Indonesian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-is",
+    "summary": "Icelandic langpacks meta-package"
+  },
+  {
+    "name": "langpacks-it",
+    "summary": "Italian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ja",
+    "summary": "Japanese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ka",
+    "summary": "Georgian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-kk",
+    "summary": "Kazakh langpacks meta-package"
+  },
+  {
+    "name": "langpacks-km",
+    "summary": "Khmer langpacks meta-package"
+  },
+  {
+    "name": "langpacks-kn",
+    "summary": "Kannada langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ko",
+    "summary": "Korean langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ku",
+    "summary": "Kurdish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-lt",
+    "summary": "Lithuanian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-lv",
+    "summary": "Latvian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-mai",
+    "summary": "Maithili langpacks meta-package"
+  },
+  {
+    "name": "langpacks-mk",
+    "summary": "Macedonian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ml",
+    "summary": "Malayalam langpacks meta-package"
+  },
+  {
+    "name": "langpacks-mr",
+    "summary": "Marathi langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ms",
+    "summary": "Malay langpacks meta-package"
+  },
+  {
+    "name": "langpacks-my",
+    "summary": "Burmese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-nb",
+    "summary": "Norwegian Bokm\u00e5l langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ne",
+    "summary": "Nepali langpacks meta-package"
+  },
+  {
+    "name": "langpacks-nl",
+    "summary": "Dutch langpacks meta-package"
+  },
+  {
+    "name": "langpacks-nn",
+    "summary": "Nynorsk langpacks meta-package"
+  },
+  {
+    "name": "langpacks-nr",
+    "summary": "Southern Ndebele langpacks meta-package"
+  },
+  {
+    "name": "langpacks-nso",
+    "summary": "Northern Sotho langpacks meta-package"
+  },
+  {
+    "name": "langpacks-or",
+    "summary": "Odia langpacks meta-package"
+  },
+  {
+    "name": "langpacks-pa",
+    "summary": "Punjabi langpacks meta-package"
+  },
+  {
+    "name": "langpacks-pl",
+    "summary": "Polish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-pt",
+    "summary": "Portuguese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-pt_BR",
+    "summary": "Portuguese (Brazil) langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ro",
+    "summary": "Romanian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ru",
+    "summary": "Russian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-si",
+    "summary": "Sinhala langpacks meta-package"
+  },
+  {
+    "name": "langpacks-sk",
+    "summary": "Slovak langpacks meta-package"
+  },
+  {
+    "name": "langpacks-sl",
+    "summary": "Slovenian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-sq",
+    "summary": "Albanian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-sr",
+    "summary": "Serbian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ss",
+    "summary": "Swati langpacks meta-package"
+  },
+  {
+    "name": "langpacks-sv",
+    "summary": "Swedish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ta",
+    "summary": "Tamil langpacks meta-package"
+  },
+  {
+    "name": "langpacks-te",
+    "summary": "Telugu langpacks meta-package"
+  },
+  {
+    "name": "langpacks-th",
+    "summary": "Thai langpacks meta-package"
+  },
+  {
+    "name": "langpacks-tn",
+    "summary": "Tswana langpacks meta-package"
+  },
+  {
+    "name": "langpacks-tr",
+    "summary": "Turkish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ts",
+    "summary": "Tsonga langpacks meta-package"
+  },
+  {
+    "name": "langpacks-uk",
+    "summary": "Ukrainian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ur",
+    "summary": "Urdu langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ve",
+    "summary": "Venda langpacks meta-package"
+  },
+  {
+    "name": "langpacks-vi",
+    "summary": "Vietnamese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-xh",
+    "summary": "Xhosa langpacks meta-package"
+  },
+  {
+    "name": "langpacks-yi",
+    "summary": "Yiddish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-zh_CN",
+    "summary": "Simplified Chinese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-zh_HK",
+    "summary": "Hong Kong Traditional Chinese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-zh_TW",
+    "summary": "Taiwan langpacks meta-package"
+  },
+  {
+    "name": "langpacks-zu",
+    "summary": "Zulu langpacks meta-package"
+  },
+  {
+    "name": "langtable",
+    "summary": "Guessing reasonable defaults for locale, keyboard layout, territory, and language."
+  },
+  {
+    "name": "lapack",
+    "summary": "Numerical linear algebra package libraries"
+  },
+  {
+    "name": "lasso",
+    "summary": "Liberty Alliance Single Sign On"
+  },
+  {
+    "name": "lato-fonts",
+    "summary": "A sanserif typeface family"
+  },
+  {
+    "name": "lcms2",
+    "summary": "Color Management Engine"
+  },
+  {
+    "name": "lcms2-devel",
+    "summary": "Development files for LittleCMS"
+  },
+  {
+    "name": "ldapjdk",
+    "summary": "LDAP SDK"
+  },
+  {
+    "name": "ldns",
+    "summary": "Low-level DNS(SEC) library with API"
+  },
+  {
+    "name": "leapp",
+    "summary": "OS & Application modernization framework"
+  },
+  {
+    "name": "leapp-deps",
+    "summary": "Meta-package with system dependencies of leapp package"
+  },
+  {
+    "name": "leapp-upgrade-el9toel10",
+    "summary": "Leapp repositories for the in-place upgrade"
+  },
+  {
+    "name": "leapp-upgrade-el9toel10-deps",
+    "summary": "Meta-package with system dependencies of leapp-upgrade-el9toel10 package"
+  },
+  {
+    "name": "leptonica",
+    "summary": "C library for efficient image processing and image analysis operations"
+  },
+  {
+    "name": "lftp",
+    "summary": "A sophisticated file transfer program"
+  },
+  {
+    "name": "liba52",
+    "summary": "A free ATSC A/52 stream decoder, also known as AC-3 or AC3"
+  },
+  {
+    "name": "libabw",
+    "summary": "A library for import of AbiWord files"
+  },
+  {
+    "name": "libacl-devel",
+    "summary": "Files needed for building programs with libacl"
+  },
+  {
+    "name": "libadwaita",
+    "summary": "Building blocks for modern GNOME applications"
+  },
+  {
+    "name": "libadwaita-qt5",
+    "summary": "Adwaita Qt5 library"
+  },
+  {
+    "name": "libaio-devel",
+    "summary": "Development files for Linux-native asynchronous I/O access"
+  },
+  {
+    "name": "libao",
+    "summary": "Cross Platform Audio Output Library"
+  },
+  {
+    "name": "libappstream-glib",
+    "summary": "Library for AppStream metadata"
+  },
+  {
+    "name": "libarchive-devel",
+    "summary": "Development files for libarchive"
+  },
+  {
+    "name": "libasan",
+    "summary": "The Address Sanitizer runtime library"
+  },
+  {
+    "name": "libasan8",
+    "summary": "The Address Sanitizer runtime library from GCC 12"
+  },
+  {
+    "name": "libasyncns",
+    "summary": "Asynchronous Name Service Library"
+  },
+  {
+    "name": "libatasmart",
+    "summary": "ATA S.M.A.R.T. Disk Health Monitoring Library"
+  },
+  {
+    "name": "libattr-devel",
+    "summary": "Files needed for building programs with libattr"
+  },
+  {
+    "name": "libbabeltrace",
+    "summary": "Common Trace Format Babel Tower"
+  },
+  {
+    "name": "libblkid-devel",
+    "summary": "Block device ID library"
+  },
+  {
+    "name": "libblkio",
+    "summary": "Block device I/O library"
+  },
+  {
+    "name": "libblockdev",
+    "summary": "A library for low-level manipulation with block devices"
+  },
+  {
+    "name": "libblockdev-crypto",
+    "summary": "The crypto plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-dm",
+    "summary": "The Device Mapper plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-fs",
+    "summary": "The FS plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-kbd",
+    "summary": "The KBD plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-loop",
+    "summary": "The loop plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-lvm",
+    "summary": "The LVM plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-lvm-dbus",
+    "summary": "The LVM plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-mdraid",
+    "summary": "The MD RAID plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-mpath",
+    "summary": "The multipath plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-nvdimm",
+    "summary": "The NVDIMM plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-nvme",
+    "summary": "The NVMe plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-part",
+    "summary": "The partitioning plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-plugins-all",
+    "summary": "Meta-package that pulls all the libblockdev plugins as dependencies"
+  },
+  {
+    "name": "libblockdev-swap",
+    "summary": "The swap plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-tools",
+    "summary": "Various nice tools based on libblockdev"
+  },
+  {
+    "name": "libblockdev-utils",
+    "summary": "A library with utility functions for the libblockdev library"
+  },
+  {
+    "name": "libbpf-tools",
+    "summary": "Command line libbpf tools for BPF Compiler Collection (BCC)"
+  },
+  {
+    "name": "libburn",
+    "summary": "Library for reading, mastering and writing optical discs"
+  },
+  {
+    "name": "libburn-doc",
+    "summary": "Documentation files for libburn"
+  },
+  {
+    "name": "libbytesize",
+    "summary": "A library for working with sizes in bytes"
+  },
+  {
+    "name": "libcanberra",
+    "summary": "Portable Sound Event Library"
+  },
+  {
+    "name": "libcanberra-devel",
+    "summary": "Development Files for libcanberra Client Development"
+  },
+  {
+    "name": "libcanberra-gtk2",
+    "summary": "Gtk+ 2.x Bindings for libcanberra"
+  },
+  {
+    "name": "libcanberra-gtk3",
+    "summary": "Gtk+ 3.x Bindings for libcanberra"
+  },
+  {
+    "name": "libcap-devel",
+    "summary": "Development files for libcap"
+  },
+  {
+    "name": "libcap-ng-devel",
+    "summary": "Header files for libcap-ng library"
+  },
+  {
+    "name": "libcap-ng-python3",
+    "summary": "Python3 bindings for libcap-ng library"
+  },
+  {
+    "name": "libcdio",
+    "summary": "CD-ROM input and control library"
+  },
+  {
+    "name": "libcdio-paranoia",
+    "summary": "CD paranoia on top of libcdio"
+  },
+  {
+    "name": "libcdr",
+    "summary": "A library for import of CorelDRAW drawings"
+  },
+  {
+    "name": "libcmis",
+    "summary": "A C/C++ client library for CM interfaces"
+  },
+  {
+    "name": "libcmpiCppImpl0",
+    "summary": "CMPI C++ wrapper library"
+  },
+  {
+    "name": "libcom_err-devel",
+    "summary": "Common error description library"
+  },
+  {
+    "name": "libcurl-devel",
+    "summary": "Files needed for building applications with libcurl"
+  },
+  {
+    "name": "libdatrie",
+    "summary": "Implementation of Double-Array structure for representing trie"
+  },
+  {
+    "name": "libdatrie-devel",
+    "summary": "Development files for libdatrie"
+  },
+  {
+    "name": "libdazzle",
+    "summary": "Experimental new features for GTK+ and GLib"
+  },
+  {
+    "name": "libdb-devel",
+    "summary": "C development files for the Berkeley DB library"
+  },
+  {
+    "name": "libdb-utils",
+    "summary": "Command line tools for managing Berkeley DB databases"
+  },
+  {
+    "name": "libdecor",
+    "summary": "Wayland client side decoration library"
+  },
+  {
+    "name": "libdmx",
+    "summary": "X.Org X11 DMX runtime library"
+  },
+  {
+    "name": "libdrm",
+    "summary": "Direct Rendering Manager runtime library"
+  },
+  {
+    "name": "libdrm-devel",
+    "summary": "Direct Rendering Manager development package"
+  },
+  {
+    "name": "libdvdnav",
+    "summary": "A library for reading DVD video discs based on Ogle code"
+  },
+  {
+    "name": "libdvdread",
+    "summary": "A library for reading DVD video discs based on Ogle code"
+  },
+  {
+    "name": "libdwarves1",
+    "summary": "Debugging information  processing library"
+  },
+  {
+    "name": "libecap",
+    "summary": "Squid interface for embedded adaptation modules"
+  },
+  {
+    "name": "libecap-devel",
+    "summary": "Libraries and header files for the libecap library"
+  },
+  {
+    "name": "libecpg",
+    "summary": "ECPG - Embedded SQL in C"
+  },
+  {
+    "name": "libedit-devel",
+    "summary": "Development files for libedit"
+  },
+  {
+    "name": "libell",
+    "summary": "Embedded Linux library"
+  },
+  {
+    "name": "libepoxy",
+    "summary": "epoxy runtime library"
+  },
+  {
+    "name": "libepoxy-devel",
+    "summary": "Development files for libepoxy"
+  },
+  {
+    "name": "libepubgen",
+    "summary": "An EPUB generator library"
+  },
+  {
+    "name": "liberation-fonts",
+    "summary": "Fonts to replace commonly used Microsoft Windows fonts"
+  },
+  {
+    "name": "liberation-fonts-common",
+    "summary": "Shared common files of Liberation font families"
+  },
+  {
+    "name": "liberation-mono-fonts",
+    "summary": "Monospace fonts to replace commonly used Microsoft Courier New"
+  },
+  {
+    "name": "liberation-narrow-fonts",
+    "summary": "Sans-serif Narrow fonts to replace commonly used Microsoft Arial Narrow"
+  },
+  {
+    "name": "liberation-sans-fonts",
+    "summary": "Sans-serif fonts to replace commonly used Microsoft Arial"
+  },
+  {
+    "name": "liberation-serif-fonts",
+    "summary": "Serif fonts to replace commonly used Microsoft Times New Roman"
+  },
+  {
+    "name": "libestr",
+    "summary": "String handling essentials library"
+  },
+  {
+    "name": "libetonyek",
+    "summary": "A library for import of Apple iWork documents"
+  },
+  {
+    "name": "libevdev",
+    "summary": "Kernel Evdev Device Wrapper Library"
+  },
+  {
+    "name": "libevent-devel",
+    "summary": "Development files for libevent"
+  },
+  {
+    "name": "libevent-doc",
+    "summary": "Development documentation for libevent"
+  },
+  {
+    "name": "libexif",
+    "summary": "Library for extracting extra information from image files"
+  },
+  {
+    "name": "libexttextcat",
+    "summary": "Text categorization library"
+  },
+  {
+    "name": "libfabric",
+    "summary": "Open Fabric Interfaces"
+  },
+  {
+    "name": "libfastjson",
+    "summary": "A JSON implementation in C"
+  },
+  {
+    "name": "libfdt",
+    "summary": "Device tree library"
+  },
+  {
+    "name": "libffi-devel",
+    "summary": "Development files for libffi"
+  },
+  {
+    "name": "libfontenc",
+    "summary": "X.Org X11 libfontenc runtime library"
+  },
+  {
+    "name": "libfreehand",
+    "summary": "A library for import of Macromedia/Adobe FreeHand documents"
+  },
+  {
+    "name": "libgccjit",
+    "summary": "Library for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "libgccjit-devel",
+    "summary": "Support for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "libgcrypt-devel",
+    "summary": "Development files for the libgcrypt package"
+  },
+  {
+    "name": "libgdata",
+    "summary": "Library for the GData protocol"
+  },
+  {
+    "name": "libgdata-devel",
+    "summary": "Development files for libgdata"
+  },
+  {
+    "name": "libgee",
+    "summary": "GObject collection library"
+  },
+  {
+    "name": "libgexiv2",
+    "summary": "Gexiv2 is a GObject-based wrapper around the Exiv2 library"
+  },
+  {
+    "name": "libglvnd",
+    "summary": "The GL Vendor-Neutral Dispatch library"
+  },
+  {
+    "name": "libglvnd-core-devel",
+    "summary": "Core development files for libglvnd"
+  },
+  {
+    "name": "libglvnd-devel",
+    "summary": "Development files for libglvnd"
+  },
+  {
+    "name": "libglvnd-egl",
+    "summary": "EGL support for libglvnd"
+  },
+  {
+    "name": "libglvnd-gles",
+    "summary": "GLES support for libglvnd"
+  },
+  {
+    "name": "libglvnd-glx",
+    "summary": "GLX support for libglvnd"
+  },
+  {
+    "name": "libglvnd-opengl",
+    "summary": "OpenGL support for libglvnd"
+  },
+  {
+    "name": "libgnomekbd",
+    "summary": "A keyboard configuration library"
+  },
+  {
+    "name": "libgpg-error-devel",
+    "summary": "Development files for the libgpg-error package"
+  },
+  {
+    "name": "libgphoto2",
+    "summary": "Library for accessing digital cameras"
+  },
+  {
+    "name": "libgpiod",
+    "summary": "C library and tools for interacting with linux GPIO char device"
+  },
+  {
+    "name": "libgpiod-c++",
+    "summary": "C++ bindings for libgpiod"
+  },
+  {
+    "name": "libgpiod-devel",
+    "summary": "Development package for libgpiod"
+  },
+  {
+    "name": "libgpiod-utils",
+    "summary": "Utilities for GPIO"
+  },
+  {
+    "name": "libgs",
+    "summary": "Library providing Ghostcript's core functionality"
+  },
+  {
+    "name": "libgsf",
+    "summary": "GNOME Structured File library"
+  },
+  {
+    "name": "libgtop2",
+    "summary": "LibGTop library (version 2)"
+  },
+  {
+    "name": "libgudev-devel",
+    "summary": "Header files for libgudev"
+  },
+  {
+    "name": "libguestfs",
+    "summary": "Access and modify virtual machine disk images"
+  },
+  {
+    "name": "libguestfs-appliance",
+    "summary": "Appliance for libguestfs"
+  },
+  {
+    "name": "libguestfs-bash-completion",
+    "summary": "Bash tab-completion scripts for libguestfs tools"
+  },
+  {
+    "name": "libguestfs-inspect-icons",
+    "summary": "Additional dependencies for inspecting guest icons"
+  },
+  {
+    "name": "libguestfs-rescue",
+    "summary": "virt-rescue shell"
+  },
+  {
+    "name": "libguestfs-rsync",
+    "summary": "rsync support for libguestfs"
+  },
+  {
+    "name": "libguestfs-winsupport",
+    "summary": "Add support for Windows guests to virt-v2v and virt-p2v"
+  },
+  {
+    "name": "libguestfs-xfs",
+    "summary": "XFS support for libguestfs"
+  },
+  {
+    "name": "libgweather",
+    "summary": "A library for weather information"
+  },
+  {
+    "name": "libgweather-devel",
+    "summary": "Development files for libgweather"
+  },
+  {
+    "name": "libgxps",
+    "summary": "GObject based library for handling and rendering XPS documents"
+  },
+  {
+    "name": "libhandy",
+    "summary": "Building blocks for modern adaptive GNOME apps"
+  },
+  {
+    "name": "libhangul",
+    "summary": "Hangul input library"
+  },
+  {
+    "name": "libi2c",
+    "summary": "I2C/SMBus bus access library"
+  },
+  {
+    "name": "libi2cd",
+    "summary": "C library for interacting with linux I2C devices"
+  },
+  {
+    "name": "libi2cd-devel",
+    "summary": "Development package for libi2cd"
+  },
+  {
+    "name": "libical",
+    "summary": "Reference implementation of the iCalendar data type and serialization format"
+  },
+  {
+    "name": "libical-devel",
+    "summary": "Development files for libical"
+  },
+  {
+    "name": "libical-glib",
+    "summary": "GObject wrapper for libical library"
+  },
+  {
+    "name": "libical-glib-devel",
+    "summary": "Development files for building against libical-glib"
+  },
+  {
+    "name": "libICE",
+    "summary": "X.Org X11 ICE runtime library"
+  },
+  {
+    "name": "libICE-devel",
+    "summary": "X.Org X11 ICE development package"
+  },
+  {
+    "name": "libicu-devel",
+    "summary": "Development files for International Components for Unicode"
+  },
+  {
+    "name": "libidn2-devel",
+    "summary": "Development files for libidn2"
+  },
+  {
+    "name": "libieee1284",
+    "summary": "A library for interfacing IEEE 1284-compatible devices"
+  },
+  {
+    "name": "libieee1284-devel",
+    "summary": "Files for developing applications that use libieee1284"
+  },
+  {
+    "name": "libijs",
+    "summary": "IJS Raster Image Transport Protocol Library"
+  },
+  {
+    "name": "libinput",
+    "summary": "Input device library"
+  },
+  {
+    "name": "libinput-utils",
+    "summary": "Utilities and tools for debugging libinput"
+  },
+  {
+    "name": "libiptcdata",
+    "summary": "IPTC tag library"
+  },
+  {
+    "name": "libiscsi",
+    "summary": "iSCSI client library"
+  },
+  {
+    "name": "libiscsi-utils",
+    "summary": "iSCSI Client Utilities"
+  },
+  {
+    "name": "libisoburn",
+    "summary": "Library to enable creation and expansion of ISO-9660 filesystems"
+  },
+  {
+    "name": "libisoburn-doc",
+    "summary": "Documentation files for libisoburn"
+  },
+  {
+    "name": "libisofs",
+    "summary": "Library to create ISO 9660 disk images"
+  },
+  {
+    "name": "libisofs-doc",
+    "summary": "Documentation files for libisofs"
+  },
+  {
+    "name": "libitm",
+    "summary": "The GNU Transactional Memory library"
+  },
+  {
+    "name": "libitm-devel",
+    "summary": "The GNU Transactional Memory support"
+  },
+  {
+    "name": "libjose",
+    "summary": "Library implementing JSON Object Signing and Encryption"
+  },
+  {
+    "name": "libjpeg-turbo",
+    "summary": "A MMX/SSE2/SIMD accelerated library for manipulating JPEG image files"
+  },
+  {
+    "name": "libjpeg-turbo-devel",
+    "summary": "Headers for the libjpeg-turbo library"
+  },
+  {
+    "name": "libjpeg-turbo-utils",
+    "summary": "Utilities for manipulating JPEG images"
+  },
+  {
+    "name": "libkdumpfile",
+    "summary": "Kernel coredump file access"
+  },
+  {
+    "name": "libkdumpfile-devel",
+    "summary": "Development files for libkdumpfile"
+  },
+  {
+    "name": "libkeepalive",
+    "summary": "Enable TCP keepalive in dynamic binaries"
+  },
+  {
+    "name": "liblangtag",
+    "summary": "An interface library to access tags for identifying languages"
+  },
+  {
+    "name": "liblangtag-data",
+    "summary": "liblangtag data files"
+  },
+  {
+    "name": "libldac",
+    "summary": "A lossy audio codec for Bluetooth connections"
+  },
+  {
+    "name": "liblockfile",
+    "summary": "This implements a number of functions found in -lmail on SysV systems"
+  },
+  {
+    "name": "liblognorm",
+    "summary": "Fast samples-based log normalization library"
+  },
+  {
+    "name": "liblognorm-doc",
+    "summary": "HTML documentation for liblognorm"
+  },
+  {
+    "name": "liblouis",
+    "summary": "Braille translation and back-translation library"
+  },
+  {
+    "name": "liblsan",
+    "summary": "The Leak Sanitizer runtime library"
+  },
+  {
+    "name": "libluksmeta",
+    "summary": "Library for storing small metadata in the LUKSv1 header"
+  },
+  {
+    "name": "libmatchbox",
+    "summary": "Libraries for the Matchbox Desktop"
+  },
+  {
+    "name": "libmaxminddb",
+    "summary": "C library for the MaxMind DB file format"
+  },
+  {
+    "name": "libmicrohttpd",
+    "summary": "Lightweight library for embedding a webserver in applications"
+  },
+  {
+    "name": "libmng",
+    "summary": "Library for Multiple-image Network Graphics support"
+  },
+  {
+    "name": "libmount-devel",
+    "summary": "Device mounting library"
+  },
+  {
+    "name": "libmpc",
+    "summary": "C library for multiple precision complex arithmetic"
+  },
+  {
+    "name": "libmpc-devel",
+    "summary": "Headers and shared development libraries for MPC"
+  },
+  {
+    "name": "libmpeg2",
+    "summary": "MPEG-2 decoder libraries"
+  },
+  {
+    "name": "libmspack",
+    "summary": "Library for CAB and related files compression and decompression"
+  },
+  {
+    "name": "libmspub",
+    "summary": "A library for import of Microsoft Publisher documents"
+  },
+  {
+    "name": "libmtp",
+    "summary": "Software library for MTP media players"
+  },
+  {
+    "name": "libmwaw",
+    "summary": "A library for import of many old Mac document formats"
+  },
+  {
+    "name": "libmypaint",
+    "summary": "Library for making brush strokes"
+  },
+  {
+    "name": "libnbd",
+    "summary": "NBD client library in userspace"
+  },
+  {
+    "name": "libnbd-bash-completion",
+    "summary": "Bash tab-completion for libnbd"
+  },
+  {
+    "name": "libnet",
+    "summary": "C library for portable packet creation and injection"
+  },
+  {
+    "name": "libnetfilter_cthelper",
+    "summary": "User-space infrastructure for connection tracking helpers"
+  },
+  {
+    "name": "libnetfilter_cttimeout",
+    "summary": "Timeout policy tuning for Netfilter/conntrack"
+  },
+  {
+    "name": "libnetfilter_queue",
+    "summary": "Netfilter queue userspace library"
+  },
+  {
+    "name": "libnl3-devel",
+    "summary": "Libraries and headers for using libnl3"
+  },
+  {
+    "name": "libnma",
+    "summary": "NetworkManager GUI library"
+  },
+  {
+    "name": "libnotify",
+    "summary": "Desktop notification library"
+  },
+  {
+    "name": "libnotify-devel",
+    "summary": "Development files for libnotify"
+  },
+  {
+    "name": "libnsl2",
+    "summary": "Public client interface library for NIS(YP) and NIS+"
+  },
+  {
+    "name": "libnumbertext",
+    "summary": "Number to number name and money text conversion library"
+  },
+  {
+    "name": "libodfgen",
+    "summary": "An ODF generator library"
+  },
+  {
+    "name": "libogg",
+    "summary": "The Ogg bitstream file format library"
+  },
+  {
+    "name": "libomp",
+    "summary": "OpenMP runtime for clang"
+  },
+  {
+    "name": "libomp-devel",
+    "summary": "OpenMP header files"
+  },
+  {
+    "name": "libomp-test",
+    "summary": "OpenMP regression tests"
+  },
+  {
+    "name": "libopenraw",
+    "summary": "Decode camera RAW files"
+  },
+  {
+    "name": "liborcus",
+    "summary": "Standalone file import filter library for spreadsheet documents"
+  },
+  {
+    "name": "libosinfo",
+    "summary": "A library for managing OS information for virtualization"
+  },
+  {
+    "name": "libotf",
+    "summary": "A Library for handling OpenType Font"
+  },
+  {
+    "name": "libotr",
+    "summary": "Off-The-Record Messaging library and toolkit"
+  },
+  {
+    "name": "libpagemaker",
+    "summary": "A library for import of Adobe PageMaker documents"
+  },
+  {
+    "name": "libpaper",
+    "summary": "Library and tools for handling papersize"
+  },
+  {
+    "name": "libpeas-gtk",
+    "summary": "GTK+ plug-ins support for libpeas"
+  },
+  {
+    "name": "libpeas-loader-python3",
+    "summary": "Python 3 loader for libpeas"
+  },
+  {
+    "name": "libpfm",
+    "summary": "Library to encode performance events for use by perf tool"
+  },
+  {
+    "name": "libpfm-devel",
+    "summary": "Development library to encode performance events for perf_events based tools"
+  },
+  {
+    "name": "libpgtypes",
+    "summary": "Map PostgreSQL database types to C equivalents"
+  },
+  {
+    "name": "libpinyin",
+    "summary": "Library to deal with pinyin"
+  },
+  {
+    "name": "libpinyin-data",
+    "summary": "Data files for libpinyin"
+  },
+  {
+    "name": "libpng-devel",
+    "summary": "Development tools for programs to manipulate PNG image format files"
+  },
+  {
+    "name": "libpng15",
+    "summary": "Old version of libpng, needed to run old binaries"
+  },
+  {
+    "name": "libpq",
+    "summary": "PostgreSQL client library"
+  },
+  {
+    "name": "libpq-devel",
+    "summary": "Development files for building PostgreSQL client tools"
+  },
+  {
+    "name": "libproxy-bin",
+    "summary": "Binary to test libproxy"
+  },
+  {
+    "name": "libproxy-gnome",
+    "summary": "Plugin for libproxy and gnome"
+  },
+  {
+    "name": "libproxy-webkitgtk4",
+    "summary": "Plugin for libproxy and webkitgtk3"
+  },
+  {
+    "name": "libpsl-devel",
+    "summary": "Development files for libpsl"
+  },
+  {
+    "name": "libpst-libs",
+    "summary": "Shared library used by the pst utilities"
+  },
+  {
+    "name": "libqb",
+    "summary": "Library providing high performance logging, tracing, ipc, and poll"
+  },
+  {
+    "name": "libqxp",
+    "summary": "Library for import of QuarkXPress documents"
+  },
+  {
+    "name": "librabbitmq",
+    "summary": "Client library for AMQP"
+  },
+  {
+    "name": "librabbitmq-tools",
+    "summary": "Example tools built using the librabbitmq package"
+  },
+  {
+    "name": "librados2",
+    "summary": "RADOS distributed object store client library"
+  },
+  {
+    "name": "LibRaw",
+    "summary": "Library for reading RAW files obtained from digital photo cameras"
+  },
+  {
+    "name": "librbd1",
+    "summary": "RADOS block device client library"
+  },
+  {
+    "name": "librdkafka",
+    "summary": "The Apache Kafka C library"
+  },
+  {
+    "name": "librelp",
+    "summary": "The Reliable Event Logging Protocol library"
+  },
+  {
+    "name": "libreoffice-calc",
+    "summary": "LibreOffice Spreadsheet Application"
+  },
+  {
+    "name": "libreoffice-core",
+    "summary": "Core modules for LibreOffice"
+  },
+  {
+    "name": "libreoffice-data",
+    "summary": "LibreOffice data files"
+  },
+  {
+    "name": "libreoffice-graphicfilter",
+    "summary": "LibreOffice Extra Graphic filters"
+  },
+  {
+    "name": "libreoffice-help-en",
+    "summary": "English help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-impress",
+    "summary": "LibreOffice Presentation Application"
+  },
+  {
+    "name": "libreoffice-langpack-en",
+    "summary": "English language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-ogltrans",
+    "summary": "3D OpenGL slide transitions for LibreOffice"
+  },
+  {
+    "name": "libreoffice-opensymbol-fonts",
+    "summary": "LibreOffice dingbats font"
+  },
+  {
+    "name": "libreoffice-pdfimport",
+    "summary": "PDF Importer for LibreOffice Draw"
+  },
+  {
+    "name": "libreoffice-pyuno",
+    "summary": "Python support for LibreOffice"
+  },
+  {
+    "name": "libreoffice-ure",
+    "summary": "UNO Runtime Environment"
+  },
+  {
+    "name": "libreoffice-ure-common",
+    "summary": "Common UNO Runtime Environment"
+  },
+  {
+    "name": "libreoffice-writer",
+    "summary": "LibreOffice Word Processor Application"
+  },
+  {
+    "name": "libreport",
+    "summary": "Generic library for reporting various problems"
+  },
+  {
+    "name": "libreport-anaconda",
+    "summary": "Default configuration for reporting anaconda bugs"
+  },
+  {
+    "name": "libreport-cli",
+    "summary": "libreport's command line interface"
+  },
+  {
+    "name": "libreport-gtk",
+    "summary": "GTK front-end for libreport"
+  },
+  {
+    "name": "libreport-plugin-bugzilla",
+    "summary": "libreport's bugzilla plugin"
+  },
+  {
+    "name": "libreport-plugin-reportuploader",
+    "summary": "libreport's reportuploader plugin"
+  },
+  {
+    "name": "libreport-rhel-anaconda-bugzilla",
+    "summary": "Default configuration for reporting anaconda bugs to Red Hat Bugzilla"
+  },
+  {
+    "name": "libreport-web",
+    "summary": "Library providing network API for libreport"
+  },
+  {
+    "name": "libreswan",
+    "summary": "Internet Key Exchange (IKEv1 and IKEv2) implementation for IPsec"
+  },
+  {
+    "name": "librevenge",
+    "summary": "A base library for writing document import filters"
+  },
+  {
+    "name": "librevenge-gdb",
+    "summary": "gdb pretty printers for librevenge"
+  },
+  {
+    "name": "librsvg2",
+    "summary": "An SVG library based on cairo"
+  },
+  {
+    "name": "librsvg2-devel",
+    "summary": "Libraries and include files for developing with librsvg"
+  },
+  {
+    "name": "librsvg2-tools",
+    "summary": "Extra tools for librsvg"
+  },
+  {
+    "name": "libsamplerate",
+    "summary": "Sample rate conversion library for audio data"
+  },
+  {
+    "name": "libsane-airscan",
+    "summary": "SANE backend for eSCL or WSD"
+  },
+  {
+    "name": "libsane-hpaio",
+    "summary": "SANE driver for scanners in HP's multi-function devices"
+  },
+  {
+    "name": "libsbc",
+    "summary": "Library for the SBC (Sub Band Codec)"
+  },
+  {
+    "name": "libseccomp-devel",
+    "summary": "Development files used to build applications with libseccomp support"
+  },
+  {
+    "name": "libsecret",
+    "summary": "Library for storing and retrieving passwords and other secrets"
+  },
+  {
+    "name": "libsecret-devel",
+    "summary": "Development files for libsecret"
+  },
+  {
+    "name": "libselinux-devel",
+    "summary": "Header files and libraries used to build SELinux"
+  },
+  {
+    "name": "libselinux-ruby",
+    "summary": "SELinux ruby bindings for libselinux"
+  },
+  {
+    "name": "libsepol-devel",
+    "summary": "Header files and libraries used to build policy manipulation tools"
+  },
+  {
+    "name": "libsepol-utils",
+    "summary": "SELinux libsepol utilities"
+  },
+  {
+    "name": "libserf",
+    "summary": "High-Performance Asynchronous HTTP Client Library"
+  },
+  {
+    "name": "libshaderc",
+    "summary": "A library for compiling shader strings into SPIR-V"
+  },
+  {
+    "name": "libshout",
+    "summary": "Icecast source streaming library"
+  },
+  {
+    "name": "libsigc++20",
+    "summary": "Typesafe signal framework for C++"
+  },
+  {
+    "name": "libslirp",
+    "summary": "A general purpose TCP-IP emulator"
+  },
+  {
+    "name": "libSM",
+    "summary": "X.Org X11 SM runtime library"
+  },
+  {
+    "name": "libSM-devel",
+    "summary": "X.Org X11 SM development package"
+  },
+  {
+    "name": "libsmi",
+    "summary": "A library to access SMI MIB information"
+  },
+  {
+    "name": "libsndfile",
+    "summary": "Library for reading and writing sound files"
+  },
+  {
+    "name": "libsndfile-utils",
+    "summary": "Command Line Utilities for libsndfile"
+  },
+  {
+    "name": "libsoup",
+    "summary": "Soup, an HTTP library implementation"
+  },
+  {
+    "name": "libsoup-devel",
+    "summary": "Header files for the Soup library"
+  },
+  {
+    "name": "libspectre",
+    "summary": "A library for rendering PostScript(TM) documents"
+  },
+  {
+    "name": "libspiro",
+    "summary": "Library to simplify the drawing of beautiful curves"
+  },
+  {
+    "name": "libsrtp",
+    "summary": "An implementation of the Secure Real-time Transport Protocol (SRTP)"
+  },
+  {
+    "name": "libssh-devel",
+    "summary": "Development files for libssh"
+  },
+  {
+    "name": "libstaroffice",
+    "summary": "A library for import of binary StarOffice documents"
+  },
+  {
+    "name": "libstdc++-devel",
+    "summary": "Header files and libraries for C++ development"
+  },
+  {
+    "name": "libstdc++-docs",
+    "summary": "Documentation for the GNU standard C++ library"
+  },
+  {
+    "name": "libstemmer",
+    "summary": "C stemming algorithm library"
+  },
+  {
+    "name": "libstoragemgmt",
+    "summary": "Storage array management library"
+  },
+  {
+    "name": "libstoragemgmt-arcconf-plugin",
+    "summary": "Files for Microsemi Adaptec and Smart Family support for libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-hpsa-plugin",
+    "summary": "Files for HP SmartArray support for libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-local-plugin",
+    "summary": "Files for local pseudo plugin of libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-megaraid-plugin",
+    "summary": "Files for LSI MegaRAID support for libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-nfs-plugin",
+    "summary": "Files for NFS local filesystem support for libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-smis-plugin",
+    "summary": "Files for SMI-S generic array support for libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-targetd-plugin",
+    "summary": "Files for targetd array support for libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-udev",
+    "summary": "Udev files for libstoragemgmt"
+  },
+  {
+    "name": "libtasn1-devel",
+    "summary": "Files for development of applications which will use libtasn1"
+  },
+  {
+    "name": "libtasn1-tools",
+    "summary": "Some ASN.1 tools"
+  },
+  {
+    "name": "libthai",
+    "summary": "Thai language support routines"
+  },
+  {
+    "name": "libthai-devel",
+    "summary": "Thai language support routines"
+  },
+  {
+    "name": "libtheora",
+    "summary": "Theora Video Compression Codec"
+  },
+  {
+    "name": "libtiff",
+    "summary": "Library of functions for manipulating TIFF format image files"
+  },
+  {
+    "name": "libtiff-devel",
+    "summary": "Development tools for programs which will use the libtiff library"
+  },
+  {
+    "name": "libtimezonemap",
+    "summary": "Time zone map widget for Gtk+"
+  },
+  {
+    "name": "libtool",
+    "summary": "The GNU Portable Library Tool"
+  },
+  {
+    "name": "libtool-ltdl",
+    "summary": "Runtime libraries for GNU Libtool Dynamic Module Loader"
+  },
+  {
+    "name": "libtpms",
+    "summary": "Library providing Trusted Platform Module (TPM) functionality"
+  },
+  {
+    "name": "libtracker-sparql",
+    "summary": "Tracker SPARQL library"
+  },
+  {
+    "name": "libtsan",
+    "summary": "The Thread Sanitizer runtime library"
+  },
+  {
+    "name": "libtsan2",
+    "summary": "The Thread Sanitizer runtime library"
+  },
+  {
+    "name": "libubsan",
+    "summary": "The Undefined Behavior Sanitizer runtime library"
+  },
+  {
+    "name": "libudisks2",
+    "summary": "Dynamic library to access the udisksd daemon"
+  },
+  {
+    "name": "liburing",
+    "summary": "Linux-native io_uring I/O access library"
+  },
+  {
+    "name": "libusb",
+    "summary": "Compatibility shim around libusb-1.0 offering the old 0.1 API"
+  },
+  {
+    "name": "libusbx-devel",
+    "summary": "Development files for libusbx"
+  },
+  {
+    "name": "libuuid-devel",
+    "summary": "Universally unique ID library"
+  },
+  {
+    "name": "libuv",
+    "summary": "Platform layer for node.js"
+  },
+  {
+    "name": "libv4l",
+    "summary": "Collection of video4linux support libraries"
+  },
+  {
+    "name": "libva",
+    "summary": "Video Acceleration (VA) API for Linux"
+  },
+  {
+    "name": "libva-devel",
+    "summary": "Development files for libva"
+  },
+  {
+    "name": "libvdpau",
+    "summary": "Wrapper library for the Video Decode and Presentation API"
+  },
+  {
+    "name": "libvdpau-trace",
+    "summary": "Trace library for libvdpau"
+  },
+  {
+    "name": "libverto-devel",
+    "summary": "Development files for libverto"
+  },
+  {
+    "name": "libvirt",
+    "summary": "Library providing a simple virtualization API"
+  },
+  {
+    "name": "libvirt-client",
+    "summary": "Client side utilities of the libvirt library"
+  },
+  {
+    "name": "libvirt-client-qemu",
+    "summary": "Additional client side utilities for QEMU"
+  },
+  {
+    "name": "libvirt-daemon",
+    "summary": "Server side daemon and supporting files for libvirt library"
+  },
+  {
+    "name": "libvirt-daemon-common",
+    "summary": "Files and utilities used by daemons"
+  },
+  {
+    "name": "libvirt-daemon-config-network",
+    "summary": "Default configuration files for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-config-nwfilter",
+    "summary": "Network filter configuration files for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-interface",
+    "summary": "Interface driver plugin for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-network",
+    "summary": "Network driver plugin for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-nodedev",
+    "summary": "Nodedev driver plugin for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-nwfilter",
+    "summary": "Nwfilter driver plugin for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-qemu",
+    "summary": "QEMU driver plugin for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-secret",
+    "summary": "Secret driver plugin for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage",
+    "summary": "Storage driver plugin including all backends for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-core",
+    "summary": "Storage driver plugin including base backends for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-disk",
+    "summary": "Storage driver plugin for disk"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-iscsi",
+    "summary": "Storage driver plugin for iscsi"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-logical",
+    "summary": "Storage driver plugin for lvm volumes"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-mpath",
+    "summary": "Storage driver plugin for multipath volumes"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-rbd",
+    "summary": "Storage driver plugin for rbd"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-scsi",
+    "summary": "Storage driver plugin for local scsi devices"
+  },
+  {
+    "name": "libvirt-daemon-kvm",
+    "summary": "Server side daemon & driver required to run KVM guests"
+  },
+  {
+    "name": "libvirt-daemon-lock",
+    "summary": "Server side daemon for managing locks"
+  },
+  {
+    "name": "libvirt-daemon-log",
+    "summary": "Server side daemon for managing logs"
+  },
+  {
+    "name": "libvirt-daemon-plugin-lockd",
+    "summary": "lockd client plugin for virtlockd"
+  },
+  {
+    "name": "libvirt-daemon-proxy",
+    "summary": "Server side daemon providing libvirtd proxy"
+  },
+  {
+    "name": "libvirt-dbus",
+    "summary": "libvirt D-Bus API binding"
+  },
+  {
+    "name": "libvirt-glib",
+    "summary": "libvirt glib integration for events"
+  },
+  {
+    "name": "libvirt-libs",
+    "summary": "Client side libraries"
+  },
+  {
+    "name": "libvirt-nss",
+    "summary": "Libvirt plugin for Name Service Switch"
+  },
+  {
+    "name": "libvirt-ssh-proxy",
+    "summary": "Libvirt SSH proxy"
+  },
+  {
+    "name": "libvisio",
+    "summary": "A library for import of Microsoft Visio diagrams"
+  },
+  {
+    "name": "libvisual",
+    "summary": "Abstraction library for audio visualisation plugins"
+  },
+  {
+    "name": "libvma",
+    "summary": "A library for boosting TCP and UDP traffic (over RDMA hardware)"
+  },
+  {
+    "name": "libvma-utils",
+    "summary": "Utilities used with libvma"
+  },
+  {
+    "name": "libvoikko",
+    "summary": "Voikko is a library for spellcheckers and hyphenators"
+  },
+  {
+    "name": "libvorbis",
+    "summary": "The Vorbis General Audio Compression Codec"
+  },
+  {
+    "name": "libvpx",
+    "summary": "VP8/VP9 Video Codec SDK"
+  },
+  {
+    "name": "libwacom",
+    "summary": "Tablet Information Client Library"
+  },
+  {
+    "name": "libwacom-data",
+    "summary": "Tablet Information Client Library Data Files"
+  },
+  {
+    "name": "libwayland-client",
+    "summary": "Wayland client library"
+  },
+  {
+    "name": "libwayland-cursor",
+    "summary": "Wayland cursor library"
+  },
+  {
+    "name": "libwayland-egl",
+    "summary": "Wayland egl library"
+  },
+  {
+    "name": "libwayland-server",
+    "summary": "Wayland server library"
+  },
+  {
+    "name": "libwebp",
+    "summary": "Library and tools for the WebP graphics format"
+  },
+  {
+    "name": "libwebp-devel",
+    "summary": "Development files for libwebp, a library for the WebP format"
+  },
+  {
+    "name": "libwinpr",
+    "summary": "Windows Portable Runtime"
+  },
+  {
+    "name": "libwmf",
+    "summary": "Windows MetaFile Library"
+  },
+  {
+    "name": "libwmf-lite",
+    "summary": "Windows Metafile parser library"
+  },
+  {
+    "name": "libwnck3",
+    "summary": "Window Navigator Construction Kit"
+  },
+  {
+    "name": "libwpd",
+    "summary": "A library for import of WordPerfect documents"
+  },
+  {
+    "name": "libwpe",
+    "summary": "General-purpose library for the WPE-flavored port of WebKit"
+  },
+  {
+    "name": "libwpg",
+    "summary": "A library for import of WordPerfect Graphics images"
+  },
+  {
+    "name": "libwps",
+    "summary": "A library for import of Microsoft Works documents"
+  },
+  {
+    "name": "libwsman1",
+    "summary": "Open source Implementation of WS-Management"
+  },
+  {
+    "name": "libX11",
+    "summary": "Core X11 protocol client library"
+  },
+  {
+    "name": "libX11-common",
+    "summary": "Common data for libX11"
+  },
+  {
+    "name": "libX11-devel",
+    "summary": "Development files for libX11"
+  },
+  {
+    "name": "libX11-xcb",
+    "summary": "XCB interop for libX11"
+  },
+  {
+    "name": "libXau",
+    "summary": "Sample Authorization Protocol for X"
+  },
+  {
+    "name": "libXau-devel",
+    "summary": "Development files for libXau"
+  },
+  {
+    "name": "libXaw",
+    "summary": "X Athena Widget Set"
+  },
+  {
+    "name": "libXaw-devel",
+    "summary": "Development files for libXaw"
+  },
+  {
+    "name": "libxcb",
+    "summary": "A C binding to the X11 protocol"
+  },
+  {
+    "name": "libxcb-devel",
+    "summary": "Development files for libxcb"
+  },
+  {
+    "name": "libXcomposite",
+    "summary": "X Composite Extension library"
+  },
+  {
+    "name": "libXcomposite-devel",
+    "summary": "Development files for libXcomposite"
+  },
+  {
+    "name": "libxcrypt-compat",
+    "summary": "Compatibility library providing legacy API functions"
+  },
+  {
+    "name": "libxcrypt-devel",
+    "summary": "Development files for libxcrypt"
+  },
+  {
+    "name": "libXcursor",
+    "summary": "Cursor management library"
+  },
+  {
+    "name": "libXcursor-devel",
+    "summary": "Development files for libXcursor"
+  },
+  {
+    "name": "libxcvt",
+    "summary": "VESA CVT standard timing modelines generator"
+  },
+  {
+    "name": "libXdamage",
+    "summary": "X Damage extension library"
+  },
+  {
+    "name": "libXdamage-devel",
+    "summary": "Development files for libXdamage"
+  },
+  {
+    "name": "libXdmcp",
+    "summary": "X Display Manager Control Protocol library"
+  },
+  {
+    "name": "libxdp",
+    "summary": "XDP helper library"
+  },
+  {
+    "name": "libXext",
+    "summary": "X.Org X11 libXext runtime library"
+  },
+  {
+    "name": "libXext-devel",
+    "summary": "X.Org X11 libXext development package"
+  },
+  {
+    "name": "libXfixes",
+    "summary": "X Fixes library"
+  },
+  {
+    "name": "libXfixes-devel",
+    "summary": "Development files for libXfixes"
+  },
+  {
+    "name": "libXfont2",
+    "summary": "X.Org X11 libXfont2 runtime library"
+  },
+  {
+    "name": "libXft",
+    "summary": "X.Org X11 libXft runtime library"
+  },
+  {
+    "name": "libXft-devel",
+    "summary": "X.Org X11 libXft development package"
+  },
+  {
+    "name": "libXi",
+    "summary": "X.Org X11 libXi runtime library"
+  },
+  {
+    "name": "libXi-devel",
+    "summary": "X.Org X11 libXi development package"
+  },
+  {
+    "name": "libXinerama",
+    "summary": "X.Org X11 libXinerama runtime library"
+  },
+  {
+    "name": "libXinerama-devel",
+    "summary": "X.Org X11 libXinerama development package"
+  },
+  {
+    "name": "libxkbcommon",
+    "summary": "X.Org X11 XKB parsing library"
+  },
+  {
+    "name": "libxkbcommon-devel",
+    "summary": "X.Org X11 XKB parsing development package"
+  },
+  {
+    "name": "libxkbcommon-x11",
+    "summary": "X.Org X11 XKB keymap creation library"
+  },
+  {
+    "name": "libxkbfile",
+    "summary": "X.Org X11 libxkbfile runtime library"
+  },
+  {
+    "name": "libxklavier",
+    "summary": "High-level API for X Keyboard Extension"
+  },
+  {
+    "name": "libxml2-devel",
+    "summary": "Libraries, includes, etc. to develop XML and HTML applications"
+  },
+  {
+    "name": "libXmu",
+    "summary": "X.Org X11 libXmu/libXmuu runtime libraries"
+  },
+  {
+    "name": "libXmu-devel",
+    "summary": "X.Org X11 libXmu development package"
+  },
+  {
+    "name": "libXp",
+    "summary": "X.Org X11 libXp runtime library"
+  },
+  {
+    "name": "libXp-devel",
+    "summary": "X.Org X11 libXp development package"
+  },
+  {
+    "name": "libXpm",
+    "summary": "X.Org X11 libXpm runtime library"
+  },
+  {
+    "name": "libXpm-devel",
+    "summary": "X.Org X11 libXpm development package"
+  },
+  {
+    "name": "libXrandr",
+    "summary": "X.Org X11 libXrandr runtime library"
+  },
+  {
+    "name": "libXrandr-devel",
+    "summary": "X.Org X11 libXrandr development package"
+  },
+  {
+    "name": "libXrender",
+    "summary": "X.Org X11 libXrender runtime library"
+  },
+  {
+    "name": "libXrender-devel",
+    "summary": "X.Org X11 libXrender development package"
+  },
+  {
+    "name": "libXres",
+    "summary": "X-Resource extension client library"
+  },
+  {
+    "name": "libXScrnSaver",
+    "summary": "X.Org X11 libXss runtime library"
+  },
+  {
+    "name": "libXScrnSaver-devel",
+    "summary": "X.Org X11 libXScrnSaver development package"
+  },
+  {
+    "name": "libxshmfence",
+    "summary": "X11 shared memory fences"
+  },
+  {
+    "name": "libxshmfence-devel",
+    "summary": "Development files for libxshmfence"
+  },
+  {
+    "name": "libxslt",
+    "summary": "Library providing the Gnome XSLT engine"
+  },
+  {
+    "name": "libxslt-devel",
+    "summary": "Development libraries and header files for libxslt"
+  },
+  {
+    "name": "libXt",
+    "summary": "X.Org X11 libXt runtime library"
+  },
+  {
+    "name": "libXt-devel",
+    "summary": "X.Org X11 libXt development package"
+  },
+  {
+    "name": "libXtst",
+    "summary": "X.Org X11 libXtst runtime library"
+  },
+  {
+    "name": "libXtst-devel",
+    "summary": "X.Org X11 libXtst development package"
+  },
+  {
+    "name": "libXv",
+    "summary": "X.Org X11 libXv runtime library"
+  },
+  {
+    "name": "libXv-devel",
+    "summary": "X.Org X11 libXv development package"
+  },
+  {
+    "name": "libXxf86dga",
+    "summary": "X.Org X11 libXxf86dga runtime library"
+  },
+  {
+    "name": "libXxf86dga-devel",
+    "summary": "X.Org X11 libXxf86dga development package"
+  },
+  {
+    "name": "libXxf86vm",
+    "summary": "X.Org X11 libXxf86vm runtime library"
+  },
+  {
+    "name": "libyang",
+    "summary": "YANG data modeling language library"
+  },
+  {
+    "name": "libzhuyin",
+    "summary": "Library to deal with zhuyin"
+  },
+  {
+    "name": "libzip",
+    "summary": "C library for reading, creating, and modifying zip archives"
+  },
+  {
+    "name": "libzip-tools",
+    "summary": "Command line tools from libzip"
+  },
+  {
+    "name": "libzmf",
+    "summary": "A library for import of Zoner document formats"
+  },
+  {
+    "name": "libzstd-devel",
+    "summary": "Header files for Zstd library"
+  },
+  {
+    "name": "linuxconsoletools",
+    "summary": "Tools for connecting joysticks & legacy devices to the kernel's input subsystem"
+  },
+  {
+    "name": "linuxptp",
+    "summary": "PTP implementation for Linux"
+  },
+  {
+    "name": "lklug-fonts",
+    "summary": "Fonts for Sinhala language"
+  },
+  {
+    "name": "lksctp-tools-devel",
+    "summary": "Development files for lksctp-tools"
+  },
+  {
+    "name": "lksctp-tools-doc",
+    "summary": "Documents pertaining to SCTP"
+  },
+  {
+    "name": "lld",
+    "summary": "The LLVM Linker"
+  },
+  {
+    "name": "lld-devel",
+    "summary": "Libraries and header files for LLD"
+  },
+  {
+    "name": "lld-libs",
+    "summary": "LLD shared libraries"
+  },
+  {
+    "name": "lld-test",
+    "summary": "LLD regression tests"
+  },
+  {
+    "name": "lldb",
+    "summary": "Next generation high-performance debugger"
+  },
+  {
+    "name": "lldb-devel",
+    "summary": "Development header files for LLDB"
+  },
+  {
+    "name": "lldpd",
+    "summary": "ISC-licensed implementation of LLDP"
+  },
+  {
+    "name": "lldpd-devel",
+    "summary": "ISC-licensed implementation of LLDP"
+  },
+  {
+    "name": "llvm",
+    "summary": "The Low Level Virtual Machine"
+  },
+  {
+    "name": "llvm-devel",
+    "summary": "Libraries and header files for LLVM"
+  },
+  {
+    "name": "llvm-doc",
+    "summary": "Documentation for LLVM"
+  },
+  {
+    "name": "llvm-googletest",
+    "summary": "LLVM's modified googletest sources"
+  },
+  {
+    "name": "llvm-libs",
+    "summary": "LLVM shared libraries"
+  },
+  {
+    "name": "llvm-static",
+    "summary": "LLVM static libraries"
+  },
+  {
+    "name": "llvm-test",
+    "summary": "LLVM regression tests"
+  },
+  {
+    "name": "llvm-toolset",
+    "summary": "Package that installs llvm-toolset"
+  },
+  {
+    "name": "lm_sensors",
+    "summary": "Hardware monitoring tools"
+  },
+  {
+    "name": "lm_sensors-devel",
+    "summary": "Development files for programs which will use lm_sensors"
+  },
+  {
+    "name": "lm_sensors-libs",
+    "summary": "Lm_sensors core libraries"
+  },
+  {
+    "name": "lm_sensors-sensord",
+    "summary": "Daemon that periodically logs sensor readings"
+  },
+  {
+    "name": "log4j",
+    "summary": "Java logging package"
+  },
+  {
+    "name": "log4j-jcl",
+    "summary": "Apache Log4j Commons Logging Bridge"
+  },
+  {
+    "name": "log4j-slf4j",
+    "summary": "Binding between LOG4J 2 API and SLF4J"
+  },
+  {
+    "name": "logwatch",
+    "summary": "A log file analysis program"
+  },
+  {
+    "name": "lohit-assamese-fonts",
+    "summary": "Free Assamese font"
+  },
+  {
+    "name": "lohit-bengali-fonts",
+    "summary": "Free Bengali script font"
+  },
+  {
+    "name": "lohit-devanagari-fonts",
+    "summary": "Free Devanagari Script Font"
+  },
+  {
+    "name": "lohit-gujarati-fonts",
+    "summary": "Free Gujarati font"
+  },
+  {
+    "name": "lohit-gurmukhi-fonts",
+    "summary": "Free Gurmukhi truetype font for Punjabi language"
+  },
+  {
+    "name": "lohit-kannada-fonts",
+    "summary": "Free Kannada font"
+  },
+  {
+    "name": "lohit-marathi-fonts",
+    "summary": "Free truetype font for Marathi language"
+  },
+  {
+    "name": "lohit-odia-fonts",
+    "summary": "Free truetype font for Odia language"
+  },
+  {
+    "name": "lohit-tamil-fonts",
+    "summary": "Free truetype font for Tamil language"
+  },
+  {
+    "name": "lohit-telugu-fonts",
+    "summary": "Free Telugu font"
+  },
+  {
+    "name": "lorax",
+    "summary": "Tool for creating the anaconda install images"
+  },
+  {
+    "name": "lorax-docs",
+    "summary": "Lorax html documentation"
+  },
+  {
+    "name": "lorax-lmc-novirt",
+    "summary": "livemedia-creator no-virt dependencies"
+  },
+  {
+    "name": "lorax-lmc-virt",
+    "summary": "livemedia-creator libvirt dependencies"
+  },
+  {
+    "name": "lorax-templates-generic",
+    "summary": "Generic build templates for lorax and livemedia-creator"
+  },
+  {
+    "name": "lorax-templates-rhel",
+    "summary": "RHEL8 build templates for lorax and livemedia-creator"
+  },
+  {
+    "name": "low-memory-monitor",
+    "summary": "Monitors low-memory conditions"
+  },
+  {
+    "name": "lpsolve",
+    "summary": "A Mixed Integer Linear Programming (MILP) solver"
+  },
+  {
+    "name": "lshw-gui",
+    "summary": "Graphical hardware lister"
+  },
+  {
+    "name": "ltrace",
+    "summary": "Tracks runtime library calls from dynamically linked executables"
+  },
+  {
+    "name": "lttng-ust",
+    "summary": "LTTng Userspace Tracer library"
+  },
+  {
+    "name": "lua",
+    "summary": "Powerful light-weight programming language"
+  },
+  {
+    "name": "lua-posix",
+    "summary": "A POSIX library for Lua"
+  },
+  {
+    "name": "lua-rpm-macros",
+    "summary": "The common Lua RPM macros"
+  },
+  {
+    "name": "lua-srpm-macros",
+    "summary": "RPM macros for building Lua source packages"
+  },
+  {
+    "name": "luksmeta",
+    "summary": "Utility for storing small metadata in the LUKSv1 header"
+  },
+  {
+    "name": "lvm2-dbusd",
+    "summary": "LVM2 D-Bus daemon"
+  },
+  {
+    "name": "lvm2-lockd",
+    "summary": "LVM locking daemon"
+  },
+  {
+    "name": "lynx",
+    "summary": "A text-based Web browser"
+  },
+  {
+    "name": "lz4-devel",
+    "summary": "Development files for lz4"
+  },
+  {
+    "name": "lzo-devel",
+    "summary": "Development files for the lzo library"
+  },
+  {
+    "name": "lzo-minilzo",
+    "summary": "Mini version of lzo for apps which don't need the full version"
+  },
+  {
+    "name": "m17n-db",
+    "summary": "Multilingualization datafiles for m17n-lib"
+  },
+  {
+    "name": "m17n-lib",
+    "summary": "Multilingual text library"
+  },
+  {
+    "name": "m4",
+    "summary": "GNU macro processor"
+  },
+  {
+    "name": "madan-fonts",
+    "summary": "Font for Nepali language"
+  },
+  {
+    "name": "make-latest",
+    "summary": "Meta package to include latest version of make"
+  },
+  {
+    "name": "make441",
+    "summary": "A GNU tool which simplifies the build process for users"
+  },
+  {
+    "name": "mallard-rng",
+    "summary": "RELAX NG schemas for all Mallard versions"
+  },
+  {
+    "name": "man-db-cron",
+    "summary": "Periodic update of man-db cache"
+  },
+  {
+    "name": "man-pages-overrides",
+    "summary": "Complementary and updated manual pages"
+  },
+  {
+    "name": "mariadb",
+    "summary": "A very fast and robust SQL database server"
+  },
+  {
+    "name": "mariadb-backup",
+    "summary": "The mariabackup tool for physical online backups"
+  },
+  {
+    "name": "mariadb-common",
+    "summary": "The shared files required by server and client"
+  },
+  {
+    "name": "mariadb-connector-c",
+    "summary": "The MariaDB Native Client library (C driver)"
+  },
+  {
+    "name": "mariadb-connector-c-config",
+    "summary": "Configuration files for packages that use /etc/my.cnf as a configuration file"
+  },
+  {
+    "name": "mariadb-connector-c-devel",
+    "summary": "Development files for mariadb-connector-c"
+  },
+  {
+    "name": "mariadb-connector-odbc",
+    "summary": "The MariaDB Native Client library (ODBC driver)"
+  },
+  {
+    "name": "mariadb-embedded",
+    "summary": "MariaDB as an embeddable library"
+  },
+  {
+    "name": "mariadb-errmsg",
+    "summary": "The error messages files required by server and embedded"
+  },
+  {
+    "name": "mariadb-gssapi-server",
+    "summary": "GSSAPI authentication plugin for server"
+  },
+  {
+    "name": "mariadb-java-client",
+    "summary": "Connects applications developed in Java to MariaDB and MySQL databases"
+  },
+  {
+    "name": "mariadb-oqgraph-engine",
+    "summary": "The Open Query GRAPH engine for MariaDB"
+  },
+  {
+    "name": "mariadb-pam",
+    "summary": "PAM authentication plugin for the MariaDB server"
+  },
+  {
+    "name": "mariadb-server",
+    "summary": "The MariaDB server and related files"
+  },
+  {
+    "name": "mariadb-server-galera",
+    "summary": "The configuration files and scripts for galera replication"
+  },
+  {
+    "name": "mariadb-server-utils",
+    "summary": "Non-essential server utilities for MariaDB/MySQL applications"
+  },
+  {
+    "name": "matchbox-window-manager",
+    "summary": "Window manager for the Matchbox Desktop"
+  },
+  {
+    "name": "maven",
+    "summary": "Java project management and project comprehension tool"
+  },
+  {
+    "name": "maven-lib",
+    "summary": "Core part of Maven"
+  },
+  {
+    "name": "maven-openjdk11",
+    "summary": "OpenJDK 11 binding for Maven"
+  },
+  {
+    "name": "maven-openjdk17",
+    "summary": "OpenJDK 17 binding for Maven"
+  },
+  {
+    "name": "maven-openjdk21",
+    "summary": "OpenJDK 21 binding for Maven"
+  },
+  {
+    "name": "maven-openjdk8",
+    "summary": "OpenJDK 8 binding for Maven"
+  },
+  {
+    "name": "maven-resolver",
+    "summary": "Apache Maven Artifact Resolver library"
+  },
+  {
+    "name": "maven-shared-utils",
+    "summary": "Maven shared utility classes"
+  },
+  {
+    "name": "maven-wagon",
+    "summary": "Tools to manage artifacts and deployment"
+  },
+  {
+    "name": "mc",
+    "summary": "User-friendly text console file manager and visual shell"
+  },
+  {
+    "name": "mdevctl",
+    "summary": "Mediated device management and persistence utility"
+  },
+  {
+    "name": "mecab",
+    "summary": "Yet Another Part-of-Speech and Morphological Analyzer"
+  },
+  {
+    "name": "mecab-ipadic",
+    "summary": "IPA dictionary for MeCab"
+  },
+  {
+    "name": "mecab-ipadic-EUCJP",
+    "summary": "IPA dictionary for Mecab with encoded by EUC-JP"
+  },
+  {
+    "name": "memcached",
+    "summary": "High Performance, Distributed Memory Object Cache"
+  },
+  {
+    "name": "memcached-selinux",
+    "summary": "Selinux policy module"
+  },
+  {
+    "name": "memkind",
+    "summary": "User Extensible Heap Manager"
+  },
+  {
+    "name": "memstrack",
+    "summary": "A memory allocation tracer, like a hot spot analyzer for memory allocation"
+  },
+  {
+    "name": "mesa-demos",
+    "summary": "Mesa demos"
+  },
+  {
+    "name": "mesa-dri-drivers",
+    "summary": "Mesa-based DRI drivers"
+  },
+  {
+    "name": "mesa-filesystem",
+    "summary": "Mesa driver filesystem"
+  },
+  {
+    "name": "mesa-libEGL",
+    "summary": "Mesa libEGL runtime libraries"
+  },
+  {
+    "name": "mesa-libEGL-devel",
+    "summary": "Mesa libEGL development package"
+  },
+  {
+    "name": "mesa-libgbm",
+    "summary": "Mesa gbm runtime library"
+  },
+  {
+    "name": "mesa-libgbm-devel",
+    "summary": "Mesa libgbm development package"
+  },
+  {
+    "name": "mesa-libGL",
+    "summary": "Mesa libGL runtime libraries"
+  },
+  {
+    "name": "mesa-libGL-devel",
+    "summary": "Mesa libGL development package"
+  },
+  {
+    "name": "mesa-libglapi",
+    "summary": "Mesa shared glapi"
+  },
+  {
+    "name": "mesa-libGLU",
+    "summary": "Mesa libGLU library"
+  },
+  {
+    "name": "mesa-libGLU-devel",
+    "summary": "Development files for mesa-libGLU"
+  },
+  {
+    "name": "mesa-libGLw",
+    "summary": "Xt / Motif OpenGL widgets"
+  },
+  {
+    "name": "mesa-libGLw-devel",
+    "summary": "Mesa libGLw development package"
+  },
+  {
+    "name": "micropipenv",
+    "summary": "A simple wrapper around pip to support Pipenv and Poetry files"
+  },
+  {
+    "name": "mingw-qemu-ga-win",
+    "summary": "Qemus Guest agent for Windows"
+  },
+  {
+    "name": "mkfontscale",
+    "summary": "Tool to generate legacy X11 font system index files"
+  },
+  {
+    "name": "mkpasswd",
+    "summary": "Encrypt a password with crypt(3) function using a salt"
+  },
+  {
+    "name": "mobile-broadband-provider-info",
+    "summary": "Mobile broadband provider database"
+  },
+  {
+    "name": "mod_auth_gssapi",
+    "summary": "A GSSAPI Authentication module for Apache"
+  },
+  {
+    "name": "mod_auth_mellon",
+    "summary": "A SAML 2.0 authentication module for the Apache Httpd Server"
+  },
+  {
+    "name": "mod_auth_openidc",
+    "summary": "OpenID Connect auth module for Apache HTTP Server"
+  },
+  {
+    "name": "mod_authnz_pam",
+    "summary": "PAM authorization checker and PAM Basic Authentication provider"
+  },
+  {
+    "name": "mod_dav_svn",
+    "summary": "Apache httpd module for Subversion server"
+  },
+  {
+    "name": "mod_fcgid",
+    "summary": "FastCGI interface module for Apache 2"
+  },
+  {
+    "name": "mod_http2",
+    "summary": "module implementing HTTP/2 for Apache 2"
+  },
+  {
+    "name": "mod_intercept_form_submit",
+    "summary": "Apache module to intercept login form submission and run PAM authentication"
+  },
+  {
+    "name": "mod_jk",
+    "summary": "Tomcat mod_jk connector for Apache"
+  },
+  {
+    "name": "mod_ldap",
+    "summary": "LDAP authentication modules for the Apache HTTP Server"
+  },
+  {
+    "name": "mod_lookup_identity",
+    "summary": "Apache module to retrieve additional information about the authenticated user"
+  },
+  {
+    "name": "mod_lua",
+    "summary": "Lua scripting support for the Apache HTTP Server"
+  },
+  {
+    "name": "mod_md",
+    "summary": "Certificate provisioning using ACME for the Apache HTTP Server"
+  },
+  {
+    "name": "mod_proxy_cluster",
+    "summary": "JBoss mod_proxy_cluster for Apache httpd"
+  },
+  {
+    "name": "mod_proxy_html",
+    "summary": "HTML and XML content filters for the Apache HTTP Server"
+  },
+  {
+    "name": "mod_security",
+    "summary": "Security module for the Apache HTTP Server"
+  },
+  {
+    "name": "mod_security-mlogc",
+    "summary": "ModSecurity Audit Log Collector"
+  },
+  {
+    "name": "mod_security_crs",
+    "summary": "ModSecurity Rules"
+  },
+  {
+    "name": "mod_session",
+    "summary": "Session interface for the Apache HTTP Server"
+  },
+  {
+    "name": "mod_ssl",
+    "summary": "SSL/TLS module for the Apache HTTP Server"
+  },
+  {
+    "name": "modulemd-tools",
+    "summary": "Collection of tools for parsing and generating modulemd YAML files"
+  },
+  {
+    "name": "motif",
+    "summary": "Run-time libraries and programs"
+  },
+  {
+    "name": "motif-devel",
+    "summary": "Development libraries and header files"
+  },
+  {
+    "name": "mozilla-filesystem",
+    "summary": "Mozilla filesytem layout"
+  },
+  {
+    "name": "mpdecimal",
+    "summary": "Library for general decimal arithmetic"
+  },
+  {
+    "name": "mpfr-devel",
+    "summary": "Development files for the MPFR library"
+  },
+  {
+    "name": "mpg123",
+    "summary": "Real time MPEG 1.0/2.0/2.5 audio player/decoder for layers 1, 2 and 3"
+  },
+  {
+    "name": "mpg123-libs",
+    "summary": "Real time MPEG 1.0/2.0/2.5 audio player/decoder for layers 1, 2 and 3"
+  },
+  {
+    "name": "mpg123-plugins-pulseaudio",
+    "summary": "Pulseaudio output plug-in for mpg123"
+  },
+  {
+    "name": "mpich",
+    "summary": "A high-performance implementation of MPI"
+  },
+  {
+    "name": "mpich-autoload",
+    "summary": "Load mpich automatically into profile"
+  },
+  {
+    "name": "mpich-devel",
+    "summary": "Development files for mpich"
+  },
+  {
+    "name": "mpich-doc",
+    "summary": "Documentations and examples for mpich"
+  },
+  {
+    "name": "mpitests-mpich",
+    "summary": "MPI tests package compiled against mpich"
+  },
+  {
+    "name": "mpitests-mvapich2",
+    "summary": "MPI tests package compiled against mvapich2"
+  },
+  {
+    "name": "mpitests-openmpi",
+    "summary": "MPI tests package compiled against openmpi"
+  },
+  {
+    "name": "mptcpd",
+    "summary": "Multipath TCP daemon"
+  },
+  {
+    "name": "mrtg",
+    "summary": "Multi Router Traffic Grapher"
+  },
+  {
+    "name": "mstflint",
+    "summary": "Mellanox firmware burning tool"
+  },
+  {
+    "name": "mt-st",
+    "summary": "Tool for controlling tape drives"
+  },
+  {
+    "name": "mtdev",
+    "summary": "Multitouch Protocol Translation Library"
+  },
+  {
+    "name": "mtr-gtk",
+    "summary": "GTK interface for MTR"
+  },
+  {
+    "name": "mtx",
+    "summary": "SCSI media changer control program"
+  },
+  {
+    "name": "munge",
+    "summary": "Enables uid & gid authentication across a host cluster"
+  },
+  {
+    "name": "munge-libs",
+    "summary": "Runtime libs for uid * gid authentication across a host cluster"
+  },
+  {
+    "name": "mutt",
+    "summary": "A text mode mail user agent"
+  },
+  {
+    "name": "mutter",
+    "summary": "Window and compositing manager based on Clutter"
+  },
+  {
+    "name": "mvapich2",
+    "summary": "OSU MVAPICH2 MPI package"
+  },
+  {
+    "name": "mvapich2-devel",
+    "summary": "Development files for mvapich2"
+  },
+  {
+    "name": "mvapich2-doc",
+    "summary": "Documentation files for mvapich2"
+  },
+  {
+    "name": "mypaint-brushes",
+    "summary": "Brushes to be used with the MyPaint library"
+  },
+  {
+    "name": "mysql",
+    "summary": "MySQL client programs and shared libraries"
+  },
+  {
+    "name": "mysql-common",
+    "summary": "The shared files required for MySQL server and client"
+  },
+  {
+    "name": "mysql-errmsg",
+    "summary": "The error messages files required by MySQL server"
+  },
+  {
+    "name": "mysql-selinux",
+    "summary": "SELinux policy modules for MySQL and MariaDB packages"
+  },
+  {
+    "name": "mysql-server",
+    "summary": "The MySQL server and related files"
+  },
+  {
+    "name": "mythes",
+    "summary": "A thesaurus library"
+  },
+  {
+    "name": "mythes-en",
+    "summary": "English thesaurus"
+  },
+  {
+    "name": "nautilus",
+    "summary": "File manager for GNOME"
+  },
+  {
+    "name": "nautilus-extensions",
+    "summary": "Nautilus extensions library"
+  },
+  {
+    "name": "navilu-fonts",
+    "summary": "Free Kannada opentype sans-serif font"
+  },
+  {
+    "name": "nbdfuse",
+    "summary": "FUSE support for libnbd"
+  },
+  {
+    "name": "nbdkit",
+    "summary": "NBD server"
+  },
+  {
+    "name": "nbdkit-bash-completion",
+    "summary": "Bash tab-completion for nbdkit"
+  },
+  {
+    "name": "nbdkit-basic-filters",
+    "summary": "Basic filters for nbdkit"
+  },
+  {
+    "name": "nbdkit-basic-plugins",
+    "summary": "Basic plugins for nbdkit"
+  },
+  {
+    "name": "nbdkit-curl-plugin",
+    "summary": "HTTP/FTP (cURL) plugin for nbdkit"
+  },
+  {
+    "name": "nbdkit-gzip-filter",
+    "summary": "GZip filter for nbdkit"
+  },
+  {
+    "name": "nbdkit-linuxdisk-plugin",
+    "summary": "Virtual Linux disk plugin for nbdkit"
+  },
+  {
+    "name": "nbdkit-nbd-plugin",
+    "summary": "NBD proxy / forward plugin for nbdkit"
+  },
+  {
+    "name": "nbdkit-python-plugin",
+    "summary": "Python 3 plugin for nbdkit"
+  },
+  {
+    "name": "nbdkit-selinux",
+    "summary": "nbdkit SELinux policy"
+  },
+  {
+    "name": "nbdkit-server",
+    "summary": "The nbdkit server"
+  },
+  {
+    "name": "nbdkit-ssh-plugin",
+    "summary": "SSH plugin for nbdkit"
+  },
+  {
+    "name": "nbdkit-tar-filter",
+    "summary": "Tar archive filter for nbdkit"
+  },
+  {
+    "name": "nbdkit-tmpdisk-plugin",
+    "summary": "Remote temporary filesystem disk plugin for nbdkit"
+  },
+  {
+    "name": "nbdkit-xz-filter",
+    "summary": "XZ filter for nbdkit"
+  },
+  {
+    "name": "ncurses-c++-libs",
+    "summary": "Ncurses C++ bindings"
+  },
+  {
+    "name": "ncurses-devel",
+    "summary": "Development files for the ncurses library"
+  },
+  {
+    "name": "ncurses-term",
+    "summary": "Terminal descriptions"
+  },
+  {
+    "name": "neon",
+    "summary": "An HTTP and WebDAV client library"
+  },
+  {
+    "name": "net-snmp",
+    "summary": "A collection of SNMP protocol tools and libraries"
+  },
+  {
+    "name": "net-snmp-agent-libs",
+    "summary": "The NET-SNMP runtime agent libraries"
+  },
+  {
+    "name": "net-snmp-devel",
+    "summary": "The development environment for the NET-SNMP project"
+  },
+  {
+    "name": "net-snmp-libs",
+    "summary": "The NET-SNMP runtime client libraries"
+  },
+  {
+    "name": "net-snmp-perl",
+    "summary": "The perl NET-SNMP module and the mib2c tool"
+  },
+  {
+    "name": "net-snmp-utils",
+    "summary": "Network management utilities using SNMP, from the NET-SNMP project"
+  },
+  {
+    "name": "netavark",
+    "summary": "OCI network stack"
+  },
+  {
+    "name": "netpbm",
+    "summary": "A library for handling different graphics file formats"
+  },
+  {
+    "name": "netpbm-progs",
+    "summary": "Tools for manipulating graphics files in netpbm supported formats"
+  },
+  {
+    "name": "netstandard-targeting-pack-2.1",
+    "summary": "Targeting Pack for NETStandard.Library 2.1"
+  },
+  {
+    "name": "nettle-devel",
+    "summary": "Development headers for a low-level cryptographic library"
+  },
+  {
+    "name": "network-manager-applet",
+    "summary": "A network control and status applet for NetworkManager"
+  },
+  {
+    "name": "NetworkManager-cloud-setup",
+    "summary": "Automatically configure NetworkManager in cloud"
+  },
+  {
+    "name": "NetworkManager-config-connectivity-redhat",
+    "summary": "NetworkManager config file for connectivity checking via Red Hat servers"
+  },
+  {
+    "name": "NetworkManager-dispatcher-routing-rules",
+    "summary": "NetworkManager dispatcher file for advanced routing rules"
+  },
+  {
+    "name": "NetworkManager-libreswan",
+    "summary": "NetworkManager VPN plug-in for IPsec VPN"
+  },
+  {
+    "name": "NetworkManager-libreswan-gnome",
+    "summary": "NetworkManager VPN plugin for libreswan - GNOME files"
+  },
+  {
+    "name": "NetworkManager-ovs",
+    "summary": "Open vSwitch device plugin for NetworkManager"
+  },
+  {
+    "name": "NetworkManager-ppp",
+    "summary": "PPP plugin for NetworkManager"
+  },
+  {
+    "name": "newt-devel",
+    "summary": "Newt windowing toolkit development files"
+  },
+  {
+    "name": "nfs-utils-coreos",
+    "summary": "Minimal NFS utilities for supporting clients"
+  },
+  {
+    "name": "nfsv4-client-utils",
+    "summary": "NFSv4 utilities for supporting client"
+  },
+  {
+    "name": "nginx",
+    "summary": "A high performance web server and reverse proxy server"
+  },
+  {
+    "name": "nginx-all-modules",
+    "summary": "A meta package that installs all available Nginx modules"
+  },
+  {
+    "name": "nginx-core",
+    "summary": "nginx minimal core"
+  },
+  {
+    "name": "nginx-filesystem",
+    "summary": "The basic directory layout for the Nginx server"
+  },
+  {
+    "name": "nginx-mod-http-image-filter",
+    "summary": "Nginx HTTP image filter module"
+  },
+  {
+    "name": "nginx-mod-http-perl",
+    "summary": "Nginx HTTP perl module"
+  },
+  {
+    "name": "nginx-mod-http-xslt-filter",
+    "summary": "Nginx XSLT module"
+  },
+  {
+    "name": "nginx-mod-mail",
+    "summary": "Nginx mail modules"
+  },
+  {
+    "name": "nginx-mod-stream",
+    "summary": "Nginx stream modules"
+  },
+  {
+    "name": "nispor",
+    "summary": "API for network status querying"
+  },
+  {
+    "name": "nm-connection-editor",
+    "summary": "A network connection configuration editor for NetworkManager"
+  },
+  {
+    "name": "nmap",
+    "summary": "Network exploration tool and security scanner"
+  },
+  {
+    "name": "nmap-ncat",
+    "summary": "Nmap's Netcat replacement"
+  },
+  {
+    "name": "nmstate",
+    "summary": "Declarative network manager API"
+  },
+  {
+    "name": "nmstate-libs",
+    "summary": "C binding of nmstate"
+  },
+  {
+    "name": "nmstate-plugin-ovsdb",
+    "summary": "nmstate plugin for OVS database manipulation"
+  },
+  {
+    "name": "nodejs",
+    "summary": "JavaScript runtime"
+  },
+  {
+    "name": "nodejs-docs",
+    "summary": "Node.js API documentation"
+  },
+  {
+    "name": "nodejs-full-i18n",
+    "summary": "Non-English locale data for Node.js"
+  },
+  {
+    "name": "nodejs-libs",
+    "summary": "Node.js and v8 libraries"
+  },
+  {
+    "name": "nodejs-nodemon",
+    "summary": "Simple monitor script for use during development of a node.js app"
+  },
+  {
+    "name": "npm",
+    "summary": "Node.js Package Manager"
+  },
+  {
+    "name": "nspr",
+    "summary": "Netscape Portable Runtime"
+  },
+  {
+    "name": "nspr-devel",
+    "summary": "Development libraries for the Netscape Portable Runtime"
+  },
+  {
+    "name": "nss",
+    "summary": "Network Security Services"
+  },
+  {
+    "name": "nss-altfiles",
+    "summary": "NSS module to look up users in /usr/lib/passwd too"
+  },
+  {
+    "name": "nss-devel",
+    "summary": "Development libraries for Network Security Services"
+  },
+  {
+    "name": "nss-softokn",
+    "summary": "Network Security Services Softoken Module"
+  },
+  {
+    "name": "nss-softokn-devel",
+    "summary": "Development libraries for Network Security Services"
+  },
+  {
+    "name": "nss-softokn-freebl",
+    "summary": "Freebl library for the Network Security Services"
+  },
+  {
+    "name": "nss-softokn-freebl-devel",
+    "summary": "Header and Library files for doing development with the Freebl library for NSS"
+  },
+  {
+    "name": "nss-sysinit",
+    "summary": "System NSS Initialization"
+  },
+  {
+    "name": "nss-tools",
+    "summary": "Tools for the Network Security Services"
+  },
+  {
+    "name": "nss-util",
+    "summary": "Network Security Services Utilities Library"
+  },
+  {
+    "name": "nss-util-devel",
+    "summary": "Development libraries for Network Security Services Utilities"
+  },
+  {
+    "name": "nss_wrapper",
+    "summary": "A wrapper for the user, group and hosts NSS API"
+  },
+  {
+    "name": "nss_wrapper-libs",
+    "summary": "nss_library shared library only"
+  },
+  {
+    "name": "ntpstat",
+    "summary": "Utility to print NTP synchronization status"
+  },
+  {
+    "name": "ntsysv",
+    "summary": "A tool to set the stop/start of system services in a runlevel"
+  },
+  {
+    "name": "numactl-devel",
+    "summary": "Development package for building Applications that use numa"
+  },
+  {
+    "name": "nvme-stas",
+    "summary": "NVMe STorage Appliance Services"
+  },
+  {
+    "name": "objectweb-asm",
+    "summary": "Java bytecode manipulation and analysis framework"
+  },
+  {
+    "name": "ocaml-srpm-macros",
+    "summary": "OCaml architecture macros"
+  },
+  {
+    "name": "oci-seccomp-bpf-hook",
+    "summary": "OCI Hook to generate seccomp json files based on EBF syscalls used by container"
+  },
+  {
+    "name": "ocl-icd",
+    "summary": "OpenCL Library (Installable Client Library) Bindings"
+  },
+  {
+    "name": "oddjob",
+    "summary": "A D-Bus service which runs odd jobs on behalf of client applications"
+  },
+  {
+    "name": "oddjob-mkhomedir",
+    "summary": "An oddjob helper which creates and populates home directories"
+  },
+  {
+    "name": "omping",
+    "summary": "Utility to test IP multicast functionality"
+  },
+  {
+    "name": "ongres-scram",
+    "summary": "Salted Challenge Response Authentication Mechanism (SCRAM) - Java Implementation"
+  },
+  {
+    "name": "ongres-scram-client",
+    "summary": "Client for ongres-scram"
+  },
+  {
+    "name": "oniguruma",
+    "summary": "Regular expressions library"
+  },
+  {
+    "name": "open-sans-fonts",
+    "summary": "Open Sans is a humanist sans-serif typeface designed by Steve Matteson"
+  },
+  {
+    "name": "open-vm-tools",
+    "summary": "Open Virtual Machine Tools for virtual machines hosted on VMware"
+  },
+  {
+    "name": "open-vm-tools-desktop",
+    "summary": "User experience components for Open Virtual Machine Tools"
+  },
+  {
+    "name": "open-vm-tools-test",
+    "summary": "Test utilities for Open Virtual Machine Tools"
+  },
+  {
+    "name": "openal-soft",
+    "summary": "Open Audio Library"
+  },
+  {
+    "name": "openblas",
+    "summary": "An optimized BLAS library based on GotoBLAS2"
+  },
+  {
+    "name": "openblas-openmp",
+    "summary": "An optimized BLAS library based on GotoBLAS2, OpenMP version"
+  },
+  {
+    "name": "openblas-openmp64",
+    "summary": "An optimized BLAS library based on GotoBLAS2, OpenMP version"
+  },
+  {
+    "name": "openblas-serial",
+    "summary": "An optimized BLAS library based on GotoBLAS2, serial version"
+  },
+  {
+    "name": "openblas-srpm-macros",
+    "summary": "OpenBLAS architecture macros"
+  },
+  {
+    "name": "openchange",
+    "summary": "Provides access to Microsoft Exchange servers using native protocols"
+  },
+  {
+    "name": "opencl-filesystem",
+    "summary": "OpenCL filesystem layout"
+  },
+  {
+    "name": "opencl-headers",
+    "summary": "OpenCL (Open Computing Language) header files"
+  },
+  {
+    "name": "opencsd",
+    "summary": "An open source CoreSight(tm) Trace Decode library"
+  },
+  {
+    "name": "opendnssec",
+    "summary": "DNSSEC key and zone management software"
+  },
+  {
+    "name": "openexr",
+    "summary": "Provides the specification and reference implementation of the EXR file format"
+  },
+  {
+    "name": "openexr-libs",
+    "summary": "OpenEXR Libraries"
+  },
+  {
+    "name": "OpenIPMI",
+    "summary": "IPMI (Intelligent Platform Management Interface) library and tools"
+  },
+  {
+    "name": "OpenIPMI-lanserv",
+    "summary": "Emulates an IPMI network listener"
+  },
+  {
+    "name": "OpenIPMI-libs",
+    "summary": "The OpenIPMI runtime libraries"
+  },
+  {
+    "name": "openjpeg2",
+    "summary": "C-Library for JPEG 2000"
+  },
+  {
+    "name": "openldap-devel",
+    "summary": "LDAP development libraries and header files"
+  },
+  {
+    "name": "openmpi",
+    "summary": "Open Message Passing Interface"
+  },
+  {
+    "name": "openmpi-devel",
+    "summary": "Development files for openmpi"
+  },
+  {
+    "name": "openmpi-java",
+    "summary": "Java library"
+  },
+  {
+    "name": "openscap",
+    "summary": "Set of open source libraries enabling integration of the SCAP line of standards"
+  },
+  {
+    "name": "openscap-devel",
+    "summary": "Development files for openscap"
+  },
+  {
+    "name": "openscap-engine-sce",
+    "summary": "Script Check Engine plug-in for OpenSCAP"
+  },
+  {
+    "name": "openscap-python3",
+    "summary": "Python 3 bindings for openscap"
+  },
+  {
+    "name": "openscap-scanner",
+    "summary": "OpenSCAP Scanner Tool (oscap)"
+  },
+  {
+    "name": "openscap-utils",
+    "summary": "OpenSCAP Utilities"
+  },
+  {
+    "name": "openslp",
+    "summary": "Open implementation of Service Location Protocol V2"
+  },
+  {
+    "name": "openslp-server",
+    "summary": "OpenSLP server daemon"
+  },
+  {
+    "name": "openssh-askpass",
+    "summary": "A passphrase dialog for OpenSSH and X"
+  },
+  {
+    "name": "openssl-devel",
+    "summary": "Files for development of applications which will use OpenSSL"
+  },
+  {
+    "name": "openssl-perl",
+    "summary": "Perl scripts provided with OpenSSL"
+  },
+  {
+    "name": "opentelemetry-collector",
+    "summary": "Red Hat build of OpenTelemetry"
+  },
+  {
+    "name": "opentest4j",
+    "summary": "Open Test Alliance for the JVM"
+  },
+  {
+    "name": "openwsman-python3",
+    "summary": "Python bindings for openwsman client API"
+  },
+  {
+    "name": "openwsman-server",
+    "summary": "Openwsman Server and service libraries"
+  },
+  {
+    "name": "opus",
+    "summary": "An audio codec for use in low-delay speech and audio communication"
+  },
+  {
+    "name": "orc",
+    "summary": "The Oil Run-time Compiler"
+  },
+  {
+    "name": "orc-compiler",
+    "summary": "Orc compiler"
+  },
+  {
+    "name": "orc-devel",
+    "summary": "Development files and libraries for Orc"
+  },
+  {
+    "name": "orca",
+    "summary": "Assistive technology for people with visual impairments"
+  },
+  {
+    "name": "osbuild",
+    "summary": "A build system for OS images"
+  },
+  {
+    "name": "osbuild-composer",
+    "summary": "An image building service based on osbuild"
+  },
+  {
+    "name": "osbuild-composer-core",
+    "summary": "The core osbuild-composer binary"
+  },
+  {
+    "name": "osbuild-composer-dnf-json",
+    "summary": "The dnf-json binary used by osbuild-composer and the workers"
+  },
+  {
+    "name": "osbuild-composer-worker",
+    "summary": "The worker for osbuild-composer"
+  },
+  {
+    "name": "osbuild-depsolve-dnf",
+    "summary": "Dependency solving support for DNF"
+  },
+  {
+    "name": "osbuild-luks2",
+    "summary": "LUKS2 support"
+  },
+  {
+    "name": "osbuild-lvm2",
+    "summary": "LVM2 support"
+  },
+  {
+    "name": "osbuild-ostree",
+    "summary": "OSTree support"
+  },
+  {
+    "name": "osbuild-selinux",
+    "summary": "SELinux policies"
+  },
+  {
+    "name": "oscap-anaconda-addon",
+    "summary": "Anaconda addon integrating OpenSCAP to the installation process"
+  },
+  {
+    "name": "osinfo-db",
+    "summary": "osinfo database files"
+  },
+  {
+    "name": "osinfo-db-tools",
+    "summary": "Tools for managing the osinfo database"
+  },
+  {
+    "name": "ostree",
+    "summary": "Tool for managing bootable, immutable filesystem trees"
+  },
+  {
+    "name": "ostree-grub2",
+    "summary": "GRUB2 integration for OSTree"
+  },
+  {
+    "name": "ostree-libs",
+    "summary": "Development headers for ostree"
+  },
+  {
+    "name": "overpass-fonts",
+    "summary": "Typeface based on the U.S. interstate highway road signage type system"
+  },
+  {
+    "name": "owasp-java-encoder",
+    "summary": "Collection of high-performance low-overhead contextual encoders"
+  },
+  {
+    "name": "p11-kit-devel",
+    "summary": "Development files for p11-kit"
+  },
+  {
+    "name": "p11-kit-server",
+    "summary": "Server and client commands for p11-kit"
+  },
+  {
+    "name": "pacemaker-cluster-libs",
+    "summary": "Cluster Libraries used by Pacemaker"
+  },
+  {
+    "name": "pacemaker-libs",
+    "summary": "Core Pacemaker libraries"
+  },
+  {
+    "name": "pacemaker-schemas",
+    "summary": "Schemas and upgrade stylesheets for Pacemaker"
+  },
+  {
+    "name": "PackageKit",
+    "summary": "Package management service"
+  },
+  {
+    "name": "PackageKit-command-not-found",
+    "summary": "Ask the user to install command line programs automatically"
+  },
+  {
+    "name": "PackageKit-glib",
+    "summary": "GLib libraries for accessing PackageKit"
+  },
+  {
+    "name": "PackageKit-gstreamer-plugin",
+    "summary": "Install GStreamer codecs using PackageKit"
+  },
+  {
+    "name": "PackageKit-gtk3-module",
+    "summary": "Install fonts automatically using PackageKit"
+  },
+  {
+    "name": "paktype-naqsh-fonts",
+    "summary": "Fonts for Arabic from PakType"
+  },
+  {
+    "name": "paktype-naskh-basic-fonts",
+    "summary": "Fonts for Arabic, Farsi, Urdu and Sindhi from PakType"
+  },
+  {
+    "name": "paktype-tehreer-fonts",
+    "summary": "Fonts for Arabic from PakType"
+  },
+  {
+    "name": "pam-devel",
+    "summary": "Files needed for developing PAM-aware applications and modules for PAM"
+  },
+  {
+    "name": "pam-docs",
+    "summary": "Extra documentation for PAM."
+  },
+  {
+    "name": "pam_cifscreds",
+    "summary": "PAM module to manage NTLM credentials in kernel keyring"
+  },
+  {
+    "name": "pam_ssh_agent_auth",
+    "summary": "PAM module for authentication with ssh-agent"
+  },
+  {
+    "name": "pango",
+    "summary": "System for layout and rendering of internationalized text"
+  },
+  {
+    "name": "pango-devel",
+    "summary": "Development files for pango"
+  },
+  {
+    "name": "pangomm",
+    "summary": "C++ interface for Pango"
+  },
+  {
+    "name": "papi",
+    "summary": "Performance Application Programming Interface"
+  },
+  {
+    "name": "papi-devel",
+    "summary": "Header files for the compiling programs with PAPI"
+  },
+  {
+    "name": "papi-libs",
+    "summary": "Libraries for PAPI clients"
+  },
+  {
+    "name": "paps",
+    "summary": "Plain Text to PostScript converter"
+  },
+  {
+    "name": "passt",
+    "summary": "User-mode networking daemons for virtual machines and namespaces"
+  },
+  {
+    "name": "passt-selinux",
+    "summary": "SELinux support for passt and pasta"
+  },
+  {
+    "name": "patch",
+    "summary": "Utility for modifying/upgrading files"
+  },
+  {
+    "name": "patchutils",
+    "summary": "A collection of programs for manipulating patch files"
+  },
+  {
+    "name": "pavucontrol",
+    "summary": "Volume control for PulseAudio"
+  },
+  {
+    "name": "pbzip2",
+    "summary": "Parallel implementation of bzip2"
+  },
+  {
+    "name": "pcaudiolib",
+    "summary": "Portable C Audio Library"
+  },
+  {
+    "name": "pciutils-devel",
+    "summary": "Linux PCI development library"
+  },
+  {
+    "name": "pcp",
+    "summary": "System-level performance monitoring and performance management"
+  },
+  {
+    "name": "pcp-conf",
+    "summary": "Performance Co-Pilot run-time configuration"
+  },
+  {
+    "name": "pcp-devel",
+    "summary": "Performance Co-Pilot (PCP) development tools and documentation"
+  },
+  {
+    "name": "pcp-doc",
+    "summary": "Documentation and tutorial for the Performance Co-Pilot"
+  },
+  {
+    "name": "pcp-export-pcp2elasticsearch",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics to ElasticSearch"
+  },
+  {
+    "name": "pcp-export-pcp2graphite",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics to Graphite"
+  },
+  {
+    "name": "pcp-export-pcp2influxdb",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics to InfluxDB"
+  },
+  {
+    "name": "pcp-export-pcp2json",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics in JSON format"
+  },
+  {
+    "name": "pcp-export-pcp2openmetrics",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics in OpenMetrics format"
+  },
+  {
+    "name": "pcp-export-pcp2spark",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics to Apache Spark"
+  },
+  {
+    "name": "pcp-export-pcp2xml",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics in XML format"
+  },
+  {
+    "name": "pcp-export-pcp2zabbix",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics to Zabbix"
+  },
+  {
+    "name": "pcp-export-zabbix-agent",
+    "summary": "Module for exporting PCP metrics to Zabbix agent"
+  },
+  {
+    "name": "pcp-geolocate",
+    "summary": "Performance Co-Pilot geographical location metric labels"
+  },
+  {
+    "name": "pcp-gui",
+    "summary": "Visualization tools for the Performance Co-Pilot toolkit"
+  },
+  {
+    "name": "pcp-import-collectl2pcp",
+    "summary": "Performance Co-Pilot tools for importing collectl log files into PCP archive logs"
+  },
+  {
+    "name": "pcp-import-ganglia2pcp",
+    "summary": "Performance Co-Pilot tools for importing ganglia data into PCP archive logs"
+  },
+  {
+    "name": "pcp-import-iostat2pcp",
+    "summary": "Performance Co-Pilot tools for importing iostat data into PCP archive logs"
+  },
+  {
+    "name": "pcp-import-mrtg2pcp",
+    "summary": "Performance Co-Pilot tools for importing MTRG data into PCP archive logs"
+  },
+  {
+    "name": "pcp-import-sar2pcp",
+    "summary": "Performance Co-Pilot tools for importing sar data into PCP archive logs"
+  },
+  {
+    "name": "pcp-libs",
+    "summary": "Performance Co-Pilot run-time libraries"
+  },
+  {
+    "name": "pcp-libs-devel",
+    "summary": "Performance Co-Pilot (PCP) development headers"
+  },
+  {
+    "name": "pcp-pmda-activemq",
+    "summary": "Performance Co-Pilot (PCP) metrics for ActiveMQ"
+  },
+  {
+    "name": "pcp-pmda-apache",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Apache webserver"
+  },
+  {
+    "name": "pcp-pmda-bash",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Bash shell"
+  },
+  {
+    "name": "pcp-pmda-bcc",
+    "summary": "Performance Co-Pilot (PCP) metrics from eBPF/BCC modules"
+  },
+  {
+    "name": "pcp-pmda-bind2",
+    "summary": "Performance Co-Pilot (PCP) metrics for BIND servers"
+  },
+  {
+    "name": "pcp-pmda-bonding",
+    "summary": "Performance Co-Pilot (PCP) metrics for Bonded network interfaces"
+  },
+  {
+    "name": "pcp-pmda-bpf",
+    "summary": "Performance Co-Pilot (PCP) metrics from eBPF ELF modules"
+  },
+  {
+    "name": "pcp-pmda-bpftrace",
+    "summary": "Performance Co-Pilot (PCP) metrics from bpftrace scripts"
+  },
+  {
+    "name": "pcp-pmda-cifs",
+    "summary": "Performance Co-Pilot (PCP) metrics for the CIFS protocol"
+  },
+  {
+    "name": "pcp-pmda-cisco",
+    "summary": "Performance Co-Pilot (PCP) metrics for Cisco routers"
+  },
+  {
+    "name": "pcp-pmda-dbping",
+    "summary": "Performance Co-Pilot (PCP) metrics for Database response times and Availablility"
+  },
+  {
+    "name": "pcp-pmda-denki",
+    "summary": "Performance Co-Pilot (PCP) metrics dealing with electrical power"
+  },
+  {
+    "name": "pcp-pmda-dm",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Device Mapper Cache and Thin Client"
+  },
+  {
+    "name": "pcp-pmda-docker",
+    "summary": "Performance Co-Pilot (PCP) metrics from the Docker daemon"
+  },
+  {
+    "name": "pcp-pmda-ds389",
+    "summary": "Performance Co-Pilot (PCP) metrics for 389 Directory Servers"
+  },
+  {
+    "name": "pcp-pmda-ds389log",
+    "summary": "Performance Co-Pilot (PCP) metrics for 389 Directory Server Loggers"
+  },
+  {
+    "name": "pcp-pmda-elasticsearch",
+    "summary": "Performance Co-Pilot (PCP) metrics for Elasticsearch"
+  },
+  {
+    "name": "pcp-pmda-farm",
+    "summary": "Performance Co-Pilot (PCP) metrics for Seagate FARM Log metrics"
+  },
+  {
+    "name": "pcp-pmda-gfs2",
+    "summary": "Performance Co-Pilot (PCP) metrics for the GFS2 filesystem"
+  },
+  {
+    "name": "pcp-pmda-gluster",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Gluster filesystem"
+  },
+  {
+    "name": "pcp-pmda-gpfs",
+    "summary": "Performance Co-Pilot (PCP) metrics for GPFS Filesystem"
+  },
+  {
+    "name": "pcp-pmda-gpsd",
+    "summary": "Performance Co-Pilot (PCP) metrics for a GPS Daemon"
+  },
+  {
+    "name": "pcp-pmda-hacluster",
+    "summary": "Performance Co-Pilot (PCP) metrics for High Availability Clusters"
+  },
+  {
+    "name": "pcp-pmda-haproxy",
+    "summary": "Performance Co-Pilot (PCP) metrics for HAProxy"
+  },
+  {
+    "name": "pcp-pmda-infiniband",
+    "summary": "Performance Co-Pilot (PCP) metrics for Infiniband HCAs and switches"
+  },
+  {
+    "name": "pcp-pmda-json",
+    "summary": "Performance Co-Pilot (PCP) metrics for JSON data"
+  },
+  {
+    "name": "pcp-pmda-libvirt",
+    "summary": "Performance Co-Pilot (PCP) metrics from virtual machines"
+  },
+  {
+    "name": "pcp-pmda-lio",
+    "summary": "Performance Co-Pilot (PCP) metrics for the LIO subsystem"
+  },
+  {
+    "name": "pcp-pmda-lmsensors",
+    "summary": "Performance Co-Pilot (PCP) metrics for hardware sensors"
+  },
+  {
+    "name": "pcp-pmda-logger",
+    "summary": "Performance Co-Pilot (PCP) metrics from arbitrary log files"
+  },
+  {
+    "name": "pcp-pmda-lustre",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Lustre Filesytem"
+  },
+  {
+    "name": "pcp-pmda-lustrecomm",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Lustre Filesytem Comms"
+  },
+  {
+    "name": "pcp-pmda-mailq",
+    "summary": "Performance Co-Pilot (PCP) metrics for the sendmail queue"
+  },
+  {
+    "name": "pcp-pmda-memcache",
+    "summary": "Performance Co-Pilot (PCP) metrics for Memcached"
+  },
+  {
+    "name": "pcp-pmda-mic",
+    "summary": "Performance Co-Pilot (PCP) metrics for Intel MIC cards"
+  },
+  {
+    "name": "pcp-pmda-mongodb",
+    "summary": "Performance Co-Pilot (PCP) metrics for MongoDB"
+  },
+  {
+    "name": "pcp-pmda-mounts",
+    "summary": "Performance Co-Pilot (PCP) metrics for filesystem mounts"
+  },
+  {
+    "name": "pcp-pmda-mysql",
+    "summary": "Performance Co-Pilot (PCP) metrics for MySQL"
+  },
+  {
+    "name": "pcp-pmda-named",
+    "summary": "Performance Co-Pilot (PCP) metrics for Named"
+  },
+  {
+    "name": "pcp-pmda-netcheck",
+    "summary": "Performance Co-Pilot (PCP) metrics for simple network checks"
+  },
+  {
+    "name": "pcp-pmda-netfilter",
+    "summary": "Performance Co-Pilot (PCP) metrics for Netfilter framework"
+  },
+  {
+    "name": "pcp-pmda-news",
+    "summary": "Performance Co-Pilot (PCP) metrics for Usenet News"
+  },
+  {
+    "name": "pcp-pmda-nfsclient",
+    "summary": "Performance Co-Pilot (PCP) metrics for NFS Clients"
+  },
+  {
+    "name": "pcp-pmda-nginx",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Nginx Webserver"
+  },
+  {
+    "name": "pcp-pmda-nvidia-gpu",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Nvidia GPU"
+  },
+  {
+    "name": "pcp-pmda-openmetrics",
+    "summary": "Performance Co-Pilot (PCP) metrics from OpenMetrics endpoints"
+  },
+  {
+    "name": "pcp-pmda-openvswitch",
+    "summary": "Performance Co-Pilot (PCP) metrics for Open vSwitch"
+  },
+  {
+    "name": "pcp-pmda-oracle",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Oracle database"
+  },
+  {
+    "name": "pcp-pmda-pdns",
+    "summary": "Performance Co-Pilot (PCP) metrics for PowerDNS"
+  },
+  {
+    "name": "pcp-pmda-perfevent",
+    "summary": "Performance Co-Pilot (PCP) metrics for hardware counters"
+  },
+  {
+    "name": "pcp-pmda-podman",
+    "summary": "Performance Co-Pilot (PCP) metrics for podman containers"
+  },
+  {
+    "name": "pcp-pmda-postfix",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Postfix (MTA)"
+  },
+  {
+    "name": "pcp-pmda-postgresql",
+    "summary": "Performance Co-Pilot (PCP) metrics for PostgreSQL"
+  },
+  {
+    "name": "pcp-pmda-rabbitmq",
+    "summary": "Performance Co-Pilot (PCP) metrics for RabbitMQ queues"
+  },
+  {
+    "name": "pcp-pmda-redis",
+    "summary": "Performance Co-Pilot (PCP) metrics for Redis"
+  },
+  {
+    "name": "pcp-pmda-roomtemp",
+    "summary": "Performance Co-Pilot (PCP) metrics for the room temperature"
+  },
+  {
+    "name": "pcp-pmda-rsyslog",
+    "summary": "Performance Co-Pilot (PCP) metrics for Rsyslog"
+  },
+  {
+    "name": "pcp-pmda-samba",
+    "summary": "Performance Co-Pilot (PCP) metrics for Samba"
+  },
+  {
+    "name": "pcp-pmda-sendmail",
+    "summary": "Performance Co-Pilot (PCP) metrics for Sendmail"
+  },
+  {
+    "name": "pcp-pmda-shping",
+    "summary": "Performance Co-Pilot (PCP) metrics for shell command responses"
+  },
+  {
+    "name": "pcp-pmda-slurm",
+    "summary": "Performance Co-Pilot (PCP) metrics for the SLURM Workload Manager"
+  },
+  {
+    "name": "pcp-pmda-smart",
+    "summary": "Performance Co-Pilot (PCP) metrics for S.M.A.R.T values"
+  },
+  {
+    "name": "pcp-pmda-snmp",
+    "summary": "Performance Co-Pilot (PCP) metrics for Simple Network Management Protocol"
+  },
+  {
+    "name": "pcp-pmda-sockets",
+    "summary": "Performance Co-Pilot (PCP) per-socket metrics"
+  },
+  {
+    "name": "pcp-pmda-statsd",
+    "summary": "Performance Co-Pilot (PCP) metrics from statsd"
+  },
+  {
+    "name": "pcp-pmda-summary",
+    "summary": "Performance Co-Pilot (PCP) summary metrics from pmie"
+  },
+  {
+    "name": "pcp-pmda-systemd",
+    "summary": "Performance Co-Pilot (PCP) metrics from the Systemd journal"
+  },
+  {
+    "name": "pcp-pmda-trace",
+    "summary": "Performance Co-Pilot (PCP) metrics for application tracing"
+  },
+  {
+    "name": "pcp-pmda-unbound",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Unbound DNS Resolver"
+  },
+  {
+    "name": "pcp-pmda-uwsgi",
+    "summary": "Performance Co-Pilot (PCP) metrics from uWSGI servers"
+  },
+  {
+    "name": "pcp-pmda-weblog",
+    "summary": "Performance Co-Pilot (PCP) metrics from web server logs"
+  },
+  {
+    "name": "pcp-pmda-zimbra",
+    "summary": "Performance Co-Pilot (PCP) metrics for Zimbra"
+  },
+  {
+    "name": "pcp-pmda-zswap",
+    "summary": "Performance Co-Pilot (PCP) metrics for compressed swap"
+  },
+  {
+    "name": "pcp-selinux",
+    "summary": "Selinux policy package"
+  },
+  {
+    "name": "pcp-system-tools",
+    "summary": "Performance Co-Pilot (PCP) System and Monitoring Tools"
+  },
+  {
+    "name": "pcp-testsuite",
+    "summary": "Performance Co-Pilot (PCP) test suite"
+  },
+  {
+    "name": "pcp-zeroconf",
+    "summary": "Performance Co-Pilot (PCP) Zeroconf Package"
+  },
+  {
+    "name": "pcre-cpp",
+    "summary": "C++ bindings for PCRE"
+  },
+  {
+    "name": "pcre-devel",
+    "summary": "Development files for pcre"
+  },
+  {
+    "name": "pcre-utf16",
+    "summary": "UTF-16 variant of PCRE"
+  },
+  {
+    "name": "pcre-utf32",
+    "summary": "UTF-32 variant of PCRE"
+  },
+  {
+    "name": "pcre2-devel",
+    "summary": "Development files for pcre2"
+  },
+  {
+    "name": "pcre2-utf16",
+    "summary": "UTF-16 variant of PCRE2"
+  },
+  {
+    "name": "pcre2-utf32",
+    "summary": "UTF-32 variant of PCRE2"
+  },
+  {
+    "name": "perf",
+    "summary": "Performance monitoring for the Linux kernel"
+  },
+  {
+    "name": "perl",
+    "summary": "Practical Extraction and Report Language"
+  },
+  {
+    "name": "perl-Algorithm-Diff",
+    "summary": "Compute 'intelligent' differences between two files/lists"
+  },
+  {
+    "name": "perl-App-cpanminus",
+    "summary": "Get, unpack, build and install CPAN modules"
+  },
+  {
+    "name": "perl-Archive-Tar",
+    "summary": "A module for Perl manipulation of .tar files"
+  },
+  {
+    "name": "perl-Archive-Zip",
+    "summary": "Perl library for accessing Zip archives"
+  },
+  {
+    "name": "perl-Attribute-Handlers",
+    "summary": "Simpler definition of attribute handlers"
+  },
+  {
+    "name": "perl-Authen-SASL",
+    "summary": "SASL Authentication framework for Perl"
+  },
+  {
+    "name": "perl-autodie",
+    "summary": "Replace functions with ones that succeed or die"
+  },
+  {
+    "name": "perl-AutoLoader",
+    "summary": "Load subroutines only on demand"
+  },
+  {
+    "name": "perl-AutoSplit",
+    "summary": "Split a package for automatic loading"
+  },
+  {
+    "name": "perl-autouse",
+    "summary": "Postpone load of modules until a function is used"
+  },
+  {
+    "name": "perl-B",
+    "summary": "Perl compiler backend"
+  },
+  {
+    "name": "perl-base",
+    "summary": "Establish an ISA relationship with base classes at compile time"
+  },
+  {
+    "name": "perl-Benchmark",
+    "summary": "Benchmark running times of Perl code"
+  },
+  {
+    "name": "perl-bignum",
+    "summary": "Transparent big number support for Perl"
+  },
+  {
+    "name": "perl-Bit-Vector",
+    "summary": "Efficient bit vector, set of integers and \"big int\" math library"
+  },
+  {
+    "name": "perl-blib",
+    "summary": "Use uninstalled version of a package"
+  },
+  {
+    "name": "perl-BSD-Resource",
+    "summary": "BSD process resource limit and priority functions"
+  },
+  {
+    "name": "perl-Carp",
+    "summary": "Alternative warn and die for modules"
+  },
+  {
+    "name": "perl-Carp-Clan",
+    "summary": "Perl module to print improved warning messages"
+  },
+  {
+    "name": "perl-CGI",
+    "summary": "Handle Common Gateway Interface requests and responses"
+  },
+  {
+    "name": "perl-Class-Inspector",
+    "summary": "Get information about a class and its structure"
+  },
+  {
+    "name": "perl-Class-Struct",
+    "summary": "Declare struct-like data types as Perl classes"
+  },
+  {
+    "name": "perl-Clone",
+    "summary": "Recursively copy perl data types"
+  },
+  {
+    "name": "perl-Compress-Bzip2",
+    "summary": "Interface to Bzip2 compression library"
+  },
+  {
+    "name": "perl-Compress-Raw-Bzip2",
+    "summary": "Low-level interface to bzip2 compression library"
+  },
+  {
+    "name": "perl-Compress-Raw-Lzma",
+    "summary": "Low-level interface to lzma compression library"
+  },
+  {
+    "name": "perl-Compress-Raw-Zlib",
+    "summary": "Low-level interface to the zlib compression library"
+  },
+  {
+    "name": "perl-Config-Extensions",
+    "summary": "Hash lookup of which Perl core extensions were built"
+  },
+  {
+    "name": "perl-Config-Perl-V",
+    "summary": "Structured data retrieval of perl -V output"
+  },
+  {
+    "name": "perl-constant",
+    "summary": "Perl pragma to declare constants"
+  },
+  {
+    "name": "perl-Convert-ASN1",
+    "summary": "ASN.1 encode/decode library"
+  },
+  {
+    "name": "perl-CPAN",
+    "summary": "Query, download and build perl modules from CPAN sites"
+  },
+  {
+    "name": "perl-CPAN-DistnameInfo",
+    "summary": "Extract distribution name and version from a distribution filename"
+  },
+  {
+    "name": "perl-CPAN-Meta",
+    "summary": "Distribution metadata for a CPAN dist"
+  },
+  {
+    "name": "perl-CPAN-Meta-Check",
+    "summary": "Verify requirements in a CPAN::Meta object"
+  },
+  {
+    "name": "perl-CPAN-Meta-Requirements",
+    "summary": "Set of version requirements for a CPAN dist"
+  },
+  {
+    "name": "perl-CPAN-Meta-YAML",
+    "summary": "Read and write a subset of YAML for CPAN Meta files"
+  },
+  {
+    "name": "perl-Crypt-OpenSSL-Bignum",
+    "summary": "Perl interface to OpenSSL for Bignum"
+  },
+  {
+    "name": "perl-Crypt-OpenSSL-Random",
+    "summary": "OpenSSL/LibreSSL pseudo-random number generator access"
+  },
+  {
+    "name": "perl-Crypt-OpenSSL-RSA",
+    "summary": "Perl interface to OpenSSL for RSA"
+  },
+  {
+    "name": "perl-Cyrus",
+    "summary": "Perl libraries for interfacing with Cyrus IMAPd"
+  },
+  {
+    "name": "perl-Data-Dump",
+    "summary": "Pretty printing of data structures"
+  },
+  {
+    "name": "perl-Data-Dumper",
+    "summary": "Stringify perl data structures, suitable for printing and eval"
+  },
+  {
+    "name": "perl-Data-OptList",
+    "summary": "Parse and validate simple name/value option pairs"
+  },
+  {
+    "name": "perl-Data-Section",
+    "summary": "Read multiple hunks of data out of your DATA section"
+  },
+  {
+    "name": "perl-Date-Calc",
+    "summary": "Gregorian calendar date calculations"
+  },
+  {
+    "name": "perl-Date-Manip",
+    "summary": "Date manipulation routines"
+  },
+  {
+    "name": "perl-DB_File",
+    "summary": "Perl5 access to Berkeley DB version 1.x"
+  },
+  {
+    "name": "perl-DBD-MariaDB",
+    "summary": "MariaDB and MySQL driver for the Perl5 Database Interface (DBI)"
+  },
+  {
+    "name": "perl-DBD-MySQL",
+    "summary": "A MySQL interface for Perl"
+  },
+  {
+    "name": "perl-DBD-Pg",
+    "summary": "A PostgreSQL interface for Perl"
+  },
+  {
+    "name": "perl-DBD-SQLite",
+    "summary": "SQLite DBI Driver"
+  },
+  {
+    "name": "perl-DBI",
+    "summary": "A database access API for perl"
+  },
+  {
+    "name": "perl-DBM_Filter",
+    "summary": "Filter DBM keys and values"
+  },
+  {
+    "name": "perl-debugger",
+    "summary": "Perl debugger"
+  },
+  {
+    "name": "perl-deprecate",
+    "summary": "Perl pragma for deprecating the inclusion of a module in core"
+  },
+  {
+    "name": "perl-devel",
+    "summary": "Header files for use in perl development"
+  },
+  {
+    "name": "perl-Devel-Peek",
+    "summary": "A data debugging tool for the XS programmer"
+  },
+  {
+    "name": "perl-Devel-PPPort",
+    "summary": "Perl Pollution Portability header generator"
+  },
+  {
+    "name": "perl-Devel-SelfStubber",
+    "summary": "Generate stubs for a SelfLoading module"
+  },
+  {
+    "name": "perl-Devel-Size",
+    "summary": "Perl extension for finding the memory usage of Perl variables"
+  },
+  {
+    "name": "perl-diagnostics",
+    "summary": "Produce verbose warning diagnostics"
+  },
+  {
+    "name": "perl-Digest",
+    "summary": "Modules that calculate message digests"
+  },
+  {
+    "name": "perl-Digest-HMAC",
+    "summary": "Keyed-Hashing for Message Authentication"
+  },
+  {
+    "name": "perl-Digest-MD5",
+    "summary": "Perl interface to the MD5 algorithm"
+  },
+  {
+    "name": "perl-Digest-SHA",
+    "summary": "Perl extension for SHA-1/224/256/384/512"
+  },
+  {
+    "name": "perl-Digest-SHA1",
+    "summary": "Digest-SHA1 Perl module"
+  },
+  {
+    "name": "perl-DirHandle",
+    "summary": "Supply object methods for directory handles"
+  },
+  {
+    "name": "perl-doc",
+    "summary": "Perl language documentation"
+  },
+  {
+    "name": "perl-Dumpvalue",
+    "summary": "Screen dump of Perl data"
+  },
+  {
+    "name": "perl-DynaLoader",
+    "summary": "Dynamically load C libraries into Perl code"
+  },
+  {
+    "name": "perl-Encode",
+    "summary": "Character encodings in Perl"
+  },
+  {
+    "name": "perl-Encode-Detect",
+    "summary": "Encode::Encoding subclass that detects the encoding of data"
+  },
+  {
+    "name": "perl-Encode-devel",
+    "summary": "Perl Encode Module Generator"
+  },
+  {
+    "name": "perl-Encode-Locale",
+    "summary": "Determine the locale encoding"
+  },
+  {
+    "name": "perl-encoding",
+    "summary": "Write your Perl script in non-ASCII or non-UTF-8"
+  },
+  {
+    "name": "perl-encoding-warnings",
+    "summary": "Warn on implicit encoding conversions"
+  },
+  {
+    "name": "perl-English",
+    "summary": "Nice English or awk names for ugly punctuation variables"
+  },
+  {
+    "name": "perl-Env",
+    "summary": "Perl module that imports environment variables as scalars or arrays"
+  },
+  {
+    "name": "perl-Errno",
+    "summary": "System errno constants"
+  },
+  {
+    "name": "perl-Error",
+    "summary": "Error/exception handling in an OO-ish way"
+  },
+  {
+    "name": "perl-experimental",
+    "summary": "Experimental features made easy"
+  },
+  {
+    "name": "perl-Exporter",
+    "summary": "Implements default import method for modules"
+  },
+  {
+    "name": "perl-Exporter-Tiny",
+    "summary": "An exporter with the features of Sub::Exporter but only core dependencies"
+  },
+  {
+    "name": "perl-ExtUtils-CBuilder",
+    "summary": "Compile and link C code for Perl modules"
+  },
+  {
+    "name": "perl-ExtUtils-Command",
+    "summary": "Perl routines to replace common UNIX commands in Makefiles"
+  },
+  {
+    "name": "perl-ExtUtils-Constant",
+    "summary": "Generate XS code to import C header constants"
+  },
+  {
+    "name": "perl-ExtUtils-Embed",
+    "summary": "Utilities for embedding Perl in C/C++ applications"
+  },
+  {
+    "name": "perl-ExtUtils-Install",
+    "summary": "Install Perl files from here to there"
+  },
+  {
+    "name": "perl-ExtUtils-MakeMaker",
+    "summary": "Create a module Makefile"
+  },
+  {
+    "name": "perl-ExtUtils-Manifest",
+    "summary": "Utilities to write and check a MANIFEST file"
+  },
+  {
+    "name": "perl-ExtUtils-Miniperl",
+    "summary": "Write the C code for perlmain.c"
+  },
+  {
+    "name": "perl-ExtUtils-MM-Utils",
+    "summary": "ExtUtils::MM methods without dependency on ExtUtils::MakeMaker"
+  },
+  {
+    "name": "perl-ExtUtils-ParseXS",
+    "summary": "Module and a script for converting Perl XS code into C code"
+  },
+  {
+    "name": "perl-FCGI",
+    "summary": "FastCGI Perl bindings"
+  },
+  {
+    "name": "perl-Fcntl",
+    "summary": "File operation options"
+  },
+  {
+    "name": "perl-Fedora-VSP",
+    "summary": "Perl version normalization for RPM"
+  },
+  {
+    "name": "perl-fields",
+    "summary": "Compile-time class fields"
+  },
+  {
+    "name": "perl-File-Basename",
+    "summary": "Parse file paths into directory, file name, and suffix"
+  },
+  {
+    "name": "perl-File-Compare",
+    "summary": "Compare files or file handles"
+  },
+  {
+    "name": "perl-File-Copy",
+    "summary": "Copy files or file handles"
+  },
+  {
+    "name": "perl-File-DosGlob",
+    "summary": "DOS-like globbing"
+  },
+  {
+    "name": "perl-File-Fetch",
+    "summary": "Generic file fetching mechanism"
+  },
+  {
+    "name": "perl-File-Find",
+    "summary": "Traverse a directory tree"
+  },
+  {
+    "name": "perl-File-HomeDir",
+    "summary": "Find your home and other directories on any platform"
+  },
+  {
+    "name": "perl-File-Listing",
+    "summary": "Parse directory listing"
+  },
+  {
+    "name": "perl-File-Path",
+    "summary": "Create or remove directory trees"
+  },
+  {
+    "name": "perl-File-pushd",
+    "summary": "Change directory temporarily for a limited scope"
+  },
+  {
+    "name": "perl-File-ShareDir",
+    "summary": "Locate per-dist and per-module shared files"
+  },
+  {
+    "name": "perl-File-Slurp",
+    "summary": "Efficient Reading/Writing of Complete Files"
+  },
+  {
+    "name": "perl-File-stat",
+    "summary": "By-name interface to Perl built-in stat functions"
+  },
+  {
+    "name": "perl-File-Temp",
+    "summary": "Return name and handle of a temporary file safely"
+  },
+  {
+    "name": "perl-File-Which",
+    "summary": "Portable implementation of the 'which' utility"
+  },
+  {
+    "name": "perl-FileCache",
+    "summary": "Keep more files open than the system permits"
+  },
+  {
+    "name": "perl-FileHandle",
+    "summary": "Object methods for file handles"
+  },
+  {
+    "name": "perl-filetest",
+    "summary": "Perl pragma to control the filetest permission operators"
+  },
+  {
+    "name": "perl-Filter",
+    "summary": "Perl source filters"
+  },
+  {
+    "name": "perl-Filter-Simple",
+    "summary": "Simplified Perl source filtering"
+  },
+  {
+    "name": "perl-FindBin",
+    "summary": "Locate a directory of an original Perl script"
+  },
+  {
+    "name": "perl-GDBM_File",
+    "summary": "Perl5 access to the gdbm library"
+  },
+  {
+    "name": "perl-generators",
+    "summary": "RPM Perl dependencies generators"
+  },
+  {
+    "name": "perl-Getopt-Long",
+    "summary": "Extended processing of command line options"
+  },
+  {
+    "name": "perl-Getopt-Std",
+    "summary": "Process single-character switches with switch clustering"
+  },
+  {
+    "name": "perl-Git",
+    "summary": "Perl interface to Git"
+  },
+  {
+    "name": "perl-Git-SVN",
+    "summary": "Perl interface to Git::SVN"
+  },
+  {
+    "name": "perl-GSSAPI",
+    "summary": "Perl extension providing access to the GSSAPIv2 library"
+  },
+  {
+    "name": "perl-Hash-Util",
+    "summary": "General-utility hash subroutines"
+  },
+  {
+    "name": "perl-Hash-Util-FieldHash",
+    "summary": "Support for inside-out classes"
+  },
+  {
+    "name": "perl-hivex",
+    "summary": "Perl bindings for hivex"
+  },
+  {
+    "name": "perl-HTML-Parser",
+    "summary": "Perl module for parsing HTML"
+  },
+  {
+    "name": "perl-HTML-Tagset",
+    "summary": "HTML::Tagset - data tables useful in parsing HTML"
+  },
+  {
+    "name": "perl-HTTP-Cookies",
+    "summary": "HTTP cookie jars"
+  },
+  {
+    "name": "perl-HTTP-Date",
+    "summary": "Date conversion routines"
+  },
+  {
+    "name": "perl-HTTP-Message",
+    "summary": "HTTP style message"
+  },
+  {
+    "name": "perl-HTTP-Negotiate",
+    "summary": "Choose a variant to serve"
+  },
+  {
+    "name": "perl-HTTP-Tiny",
+    "summary": "Small, simple, correct HTTP/1.1 client"
+  },
+  {
+    "name": "perl-I18N-Collate",
+    "summary": "Compare 8-bit scalar data according to the current locale"
+  },
+  {
+    "name": "perl-I18N-Langinfo",
+    "summary": "Query locale information"
+  },
+  {
+    "name": "perl-I18N-LangTags",
+    "summary": "Functions for dealing with RFC 3066 language tags"
+  },
+  {
+    "name": "perl-if",
+    "summary": "Use a Perl module if a condition holds"
+  },
+  {
+    "name": "perl-Importer",
+    "summary": "Alternative interface to modules that export symbols"
+  },
+  {
+    "name": "perl-inc-latest",
+    "summary": "Use modules bundled in inc/ if they are newer than installed ones"
+  },
+  {
+    "name": "perl-interpreter",
+    "summary": "Standalone executable Perl interpreter"
+  },
+  {
+    "name": "perl-IO",
+    "summary": "Perl input/output modules"
+  },
+  {
+    "name": "perl-IO-Compress",
+    "summary": "Read and write compressed data"
+  },
+  {
+    "name": "perl-IO-Compress-Lzma",
+    "summary": "Read and write lzma compressed data"
+  },
+  {
+    "name": "perl-IO-HTML",
+    "summary": "Open an HTML file with automatic character set detection"
+  },
+  {
+    "name": "perl-IO-Multiplex",
+    "summary": "Manage IO on many file handles"
+  },
+  {
+    "name": "perl-IO-Socket-INET6",
+    "summary": "Perl Object interface for AF_INET|AF_INET6 domain sockets"
+  },
+  {
+    "name": "perl-IO-Socket-IP",
+    "summary": "Drop-in replacement for IO::Socket::INET supporting both IPv4 and IPv6"
+  },
+  {
+    "name": "perl-IO-Socket-SSL",
+    "summary": "Perl library for transparent SSL"
+  },
+  {
+    "name": "perl-IO-Zlib",
+    "summary": "Perl IO:: style interface to Compress::Zlib"
+  },
+  {
+    "name": "perl-IPC-Cmd",
+    "summary": "Finding and running system commands made easy"
+  },
+  {
+    "name": "perl-IPC-Open3",
+    "summary": "Open a process for reading, writing, and error handling"
+  },
+  {
+    "name": "perl-IPC-System-Simple",
+    "summary": "Run commands simply, with detailed diagnostics"
+  },
+  {
+    "name": "perl-IPC-SysV",
+    "summary": "Object interface to System V IPC"
+  },
+  {
+    "name": "perl-JSON",
+    "summary": "Parse and convert to JSON (JavaScript Object Notation)"
+  },
+  {
+    "name": "perl-JSON-PP",
+    "summary": "JSON::XS compatible pure-Perl module"
+  },
+  {
+    "name": "perl-LDAP",
+    "summary": "LDAP Perl module"
+  },
+  {
+    "name": "perl-less",
+    "summary": "Perl pragma to request less of something"
+  },
+  {
+    "name": "perl-lib",
+    "summary": "Manipulate @INC at compile time"
+  },
+  {
+    "name": "perl-libintl-perl",
+    "summary": "Internationalization library for Perl, compatible with gettext"
+  },
+  {
+    "name": "perl-libnet",
+    "summary": "Perl clients for various network protocols"
+  },
+  {
+    "name": "perl-libnetcfg",
+    "summary": "Configure libnet"
+  },
+  {
+    "name": "perl-libs",
+    "summary": "The libraries for the perl run-time"
+  },
+  {
+    "name": "perl-libwww-perl",
+    "summary": "A Perl interface to the World-Wide Web"
+  },
+  {
+    "name": "perl-List-MoreUtils",
+    "summary": "Provide the stuff missing in List::Util"
+  },
+  {
+    "name": "perl-List-MoreUtils-XS",
+    "summary": "Provide compiled List::MoreUtils functions"
+  },
+  {
+    "name": "perl-local-lib",
+    "summary": "Create and use a local lib/ for perl modules"
+  },
+  {
+    "name": "perl-locale",
+    "summary": "Pragma to use or avoid POSIX locales for built-in operations"
+  },
+  {
+    "name": "perl-Locale-Maketext",
+    "summary": "Framework for localization"
+  },
+  {
+    "name": "perl-Locale-Maketext-Simple",
+    "summary": "Simple interface to Locale::Maketext::Lexicon"
+  },
+  {
+    "name": "perl-LWP-MediaTypes",
+    "summary": "Guess media type for a file or a URL"
+  },
+  {
+    "name": "perl-LWP-Protocol-https",
+    "summary": "Provide HTTPS support for LWP::UserAgent"
+  },
+  {
+    "name": "perl-macros",
+    "summary": "Macros for rpmbuild"
+  },
+  {
+    "name": "perl-Mail-AuthenticationResults",
+    "summary": "Object Oriented Authentication-Results Headers"
+  },
+  {
+    "name": "perl-Mail-DKIM",
+    "summary": "Sign and verify Internet mail with DKIM/DomainKey signatures"
+  },
+  {
+    "name": "perl-Mail-Sender",
+    "summary": "Module for sending mails with attachments through an SMTP server"
+  },
+  {
+    "name": "perl-Mail-SPF",
+    "summary": "Object-oriented implementation of Sender Policy Framework"
+  },
+  {
+    "name": "perl-MailTools",
+    "summary": "Various ancient mail-related perl modules"
+  },
+  {
+    "name": "perl-Math-BigInt",
+    "summary": "Arbitrary-size integer and float mathematics"
+  },
+  {
+    "name": "perl-Math-BigInt-FastCalc",
+    "summary": "Math::BigInt::Calc with some XS for more speed"
+  },
+  {
+    "name": "perl-Math-BigRat",
+    "summary": "Arbitrary big rational numbers"
+  },
+  {
+    "name": "perl-Math-Complex",
+    "summary": "Complex numbers and trigonometric functions"
+  },
+  {
+    "name": "perl-Memoize",
+    "summary": "Transparently speed up functions by caching return values"
+  },
+  {
+    "name": "perl-meta-notation",
+    "summary": "Change nonprintable characters below 0x100 into printables"
+  },
+  {
+    "name": "perl-MIME-Base64",
+    "summary": "Encoding and decoding of Base64 and quoted-printable strings"
+  },
+  {
+    "name": "perl-MIME-Charset",
+    "summary": "Charset Informations for MIME"
+  },
+  {
+    "name": "perl-Module-Build",
+    "summary": "Build and install Perl modules"
+  },
+  {
+    "name": "perl-Module-CoreList",
+    "summary": "What modules are shipped with versions of perl"
+  },
+  {
+    "name": "perl-Module-CoreList-tools",
+    "summary": "Tool for listing modules shipped with perl"
+  },
+  {
+    "name": "perl-Module-CPANfile",
+    "summary": "Parse cpanfile"
+  },
+  {
+    "name": "perl-Module-Load",
+    "summary": "Run-time require of both modules and files"
+  },
+  {
+    "name": "perl-Module-Load-Conditional",
+    "summary": "Looking up module information / loading at run-time"
+  },
+  {
+    "name": "perl-Module-Loaded",
+    "summary": "Mark modules as loaded or unloaded"
+  },
+  {
+    "name": "perl-Module-Metadata",
+    "summary": "Gather package and POD information from perl module files"
+  },
+  {
+    "name": "perl-Module-Signature",
+    "summary": "CPAN signature management utilities and modules"
+  },
+  {
+    "name": "perl-Mozilla-CA",
+    "summary": "Mozilla's CA certificate bundle in PEM format"
+  },
+  {
+    "name": "perl-mro",
+    "summary": "Method resolution order"
+  },
+  {
+    "name": "perl-MRO-Compat",
+    "summary": "Mro::* interface compatibility for Perls < 5.9.5"
+  },
+  {
+    "name": "perl-NDBM_File",
+    "summary": "Tied access to ndbm files"
+  },
+  {
+    "name": "perl-Net",
+    "summary": "By-name interface to Perl built-in network resolver"
+  },
+  {
+    "name": "perl-Net-CIDR-Lite",
+    "summary": "Perl extension for merging IPv4 or IPv6 CIDR addresses"
+  },
+  {
+    "name": "perl-Net-DNS",
+    "summary": "DNS resolver modules for Perl"
+  },
+  {
+    "name": "perl-Net-HTTP",
+    "summary": "Low-level HTTP connection (client)"
+  },
+  {
+    "name": "perl-Net-Ping",
+    "summary": "Check a remote host for reachability"
+  },
+  {
+    "name": "perl-Net-Server",
+    "summary": "Extensible, general Perl server engine"
+  },
+  {
+    "name": "perl-Net-SMTP-SSL",
+    "summary": "SSL support for Net::SMTP"
+  },
+  {
+    "name": "perl-Net-SSLeay",
+    "summary": "Perl extension for using OpenSSL"
+  },
+  {
+    "name": "perl-NetAddr-IP",
+    "summary": "Manages IPv4 and IPv6 addresses and subnets"
+  },
+  {
+    "name": "perl-NEXT",
+    "summary": "Pseudo-class that allows method redispatch"
+  },
+  {
+    "name": "perl-NTLM",
+    "summary": "NTLM Perl module"
+  },
+  {
+    "name": "perl-Object-HashBase",
+    "summary": "Build hash-based classes"
+  },
+  {
+    "name": "perl-ODBM_File",
+    "summary": "Tied access to odbm files"
+  },
+  {
+    "name": "perl-Opcode",
+    "summary": "Disable named opcodes when compiling a perl code"
+  },
+  {
+    "name": "perl-open",
+    "summary": "Perl pragma to set default PerlIO layers for input and output"
+  },
+  {
+    "name": "perl-overload",
+    "summary": "Overloading Perl operations"
+  },
+  {
+    "name": "perl-overloading",
+    "summary": "Perl pragma to lexically control overloading"
+  },
+  {
+    "name": "perl-Package-Generator",
+    "summary": "Generate new packages quickly and easily"
+  },
+  {
+    "name": "perl-Params-Check",
+    "summary": "Generic input parsing/checking mechanism"
+  },
+  {
+    "name": "perl-Params-Util",
+    "summary": "Simple standalone parameter-checking functions"
+  },
+  {
+    "name": "perl-parent",
+    "summary": "Establish an ISA relationship with base classes at compile time"
+  },
+  {
+    "name": "perl-Parse-PMFile",
+    "summary": "Parses .pm file as PAUSE does"
+  },
+  {
+    "name": "perl-PathTools",
+    "summary": "PathTools Perl module (Cwd, File::Spec)"
+  },
+  {
+    "name": "perl-PCP-LogImport",
+    "summary": "Performance Co-Pilot (PCP) Perl bindings for importing external data into PCP archives"
+  },
+  {
+    "name": "perl-PCP-LogSummary",
+    "summary": "Performance Co-Pilot (PCP) Perl bindings for post-processing output of pmlogsummary"
+  },
+  {
+    "name": "perl-PCP-MMV",
+    "summary": "Performance Co-Pilot (PCP) Perl bindings for PCP Memory Mapped Values"
+  },
+  {
+    "name": "perl-PCP-PMDA",
+    "summary": "Performance Co-Pilot (PCP) Perl bindings and documentation"
+  },
+  {
+    "name": "perl-Perl-OSType",
+    "summary": "Map Perl operating system names to generic types"
+  },
+  {
+    "name": "perl-perlfaq",
+    "summary": "Frequently asked questions about Perl"
+  },
+  {
+    "name": "perl-PerlIO-via-QuotedPrint",
+    "summary": "PerlIO layer for quoted-printable strings"
+  },
+  {
+    "name": "perl-ph",
+    "summary": "Selected system header files converted to Perl headers"
+  },
+  {
+    "name": "perl-Pod-Checker",
+    "summary": "Check POD documents for syntax errors"
+  },
+  {
+    "name": "perl-Pod-Escapes",
+    "summary": "Resolve POD escape sequences"
+  },
+  {
+    "name": "perl-Pod-Functions",
+    "summary": "Group Perl functions as in perlfunc POD"
+  },
+  {
+    "name": "perl-Pod-Html",
+    "summary": "Convert POD files to HTML"
+  },
+  {
+    "name": "perl-Pod-Perldoc",
+    "summary": "Look up Perl documentation in Pod format"
+  },
+  {
+    "name": "perl-Pod-Simple",
+    "summary": "Framework for parsing POD documentation"
+  },
+  {
+    "name": "perl-Pod-Usage",
+    "summary": "Print a usage message from embedded POD documentation"
+  },
+  {
+    "name": "perl-podlators",
+    "summary": "Format POD source into various output formats"
+  },
+  {
+    "name": "perl-POSIX",
+    "summary": "Perl interface to IEEE Std 1003.1"
+  },
+  {
+    "name": "perl-Safe",
+    "summary": "Compile and execute code in restricted compartments"
+  },
+  {
+    "name": "perl-Scalar-List-Utils",
+    "summary": "A selection of general-utility scalar and list subroutines"
+  },
+  {
+    "name": "perl-Search-Dict",
+    "summary": "Search for a key in a dictionary file"
+  },
+  {
+    "name": "perl-SelectSaver",
+    "summary": "Save and restore selected file handle"
+  },
+  {
+    "name": "perl-SelfLoader",
+    "summary": "Load functions only on demand"
+  },
+  {
+    "name": "perl-sigtrap",
+    "summary": "Perl pragma to enable simple signal handling"
+  },
+  {
+    "name": "perl-SNMP_Session",
+    "summary": "SNMP support for Perl 5"
+  },
+  {
+    "name": "perl-Socket",
+    "summary": "Networking constants and support functions"
+  },
+  {
+    "name": "perl-Socket6",
+    "summary": "IPv6 related part of the C socket.h defines and structure manipulators"
+  },
+  {
+    "name": "perl-Software-License",
+    "summary": "Package that provides templated software licenses"
+  },
+  {
+    "name": "perl-sort",
+    "summary": "Perl pragma to control sort() behavior"
+  },
+  {
+    "name": "perl-srpm-macros",
+    "summary": "RPM macros for building Perl source package from source repository"
+  },
+  {
+    "name": "perl-Storable",
+    "summary": "Persistence for Perl data structures"
+  },
+  {
+    "name": "perl-String-ShellQuote",
+    "summary": "Perl module for quoting strings for passing through the shell"
+  },
+  {
+    "name": "perl-Sub-Exporter",
+    "summary": "Sophisticated exporter for custom-built routines"
+  },
+  {
+    "name": "perl-Sub-Install",
+    "summary": "Install subroutines into packages easily"
+  },
+  {
+    "name": "perl-subs",
+    "summary": "Perl pragma to predeclare subroutine names"
+  },
+  {
+    "name": "perl-Symbol",
+    "summary": "Manipulate Perl symbols and their names"
+  },
+  {
+    "name": "perl-Sys-CPU",
+    "summary": "Getting CPU information"
+  },
+  {
+    "name": "perl-Sys-Guestfs",
+    "summary": "Perl bindings for libguestfs (Sys::Guestfs)"
+  },
+  {
+    "name": "perl-Sys-Hostname",
+    "summary": "Try every conceivable way to get a hostname"
+  },
+  {
+    "name": "perl-Sys-MemInfo",
+    "summary": "Memory information as Perl module"
+  },
+  {
+    "name": "perl-Sys-Syslog",
+    "summary": "Perl interface to the UNIX syslog(3) calls"
+  },
+  {
+    "name": "perl-Term-ANSIColor",
+    "summary": "Color screen output using ANSI escape sequences"
+  },
+  {
+    "name": "perl-Term-Cap",
+    "summary": "Perl termcap interface"
+  },
+  {
+    "name": "perl-Term-Complete",
+    "summary": "Perl word completion"
+  },
+  {
+    "name": "perl-Term-ReadLine",
+    "summary": "Perl interface to various read-line packages"
+  },
+  {
+    "name": "perl-Term-Size-Any",
+    "summary": "Retrieve terminal size"
+  },
+  {
+    "name": "perl-Term-Size-Perl",
+    "summary": "Perl extension for retrieving terminal size (Perl version)"
+  },
+  {
+    "name": "perl-Term-Table",
+    "summary": "Format a header and rows into a table"
+  },
+  {
+    "name": "perl-TermReadKey",
+    "summary": "A perl module for simple terminal control"
+  },
+  {
+    "name": "perl-Test",
+    "summary": "Simple framework for writing test scripts"
+  },
+  {
+    "name": "perl-Test-Harness",
+    "summary": "Run Perl standard test scripts with statistics"
+  },
+  {
+    "name": "perl-Test-Simple",
+    "summary": "Basic utilities for writing tests"
+  },
+  {
+    "name": "perl-Text-Abbrev",
+    "summary": "Create an abbreviation table from a list"
+  },
+  {
+    "name": "perl-Text-Balanced",
+    "summary": "Extract delimited text sequences from strings"
+  },
+  {
+    "name": "perl-Text-Diff",
+    "summary": "Perform diffs on files and record sets"
+  },
+  {
+    "name": "perl-Text-Glob",
+    "summary": "Perl module to match globbing patterns against text"
+  },
+  {
+    "name": "perl-Text-ParseWords",
+    "summary": "Parse text into an array of tokens or array of arrays"
+  },
+  {
+    "name": "perl-Text-Soundex",
+    "summary": "Implementation of the soundex algorithm"
+  },
+  {
+    "name": "perl-Text-Tabs+Wrap",
+    "summary": "Expand tabs and do simple line wrapping"
+  },
+  {
+    "name": "perl-Text-Template",
+    "summary": "Expand template text with embedded Perl"
+  },
+  {
+    "name": "perl-Text-Unidecode",
+    "summary": "US-ASCII transliterations of Unicode text"
+  },
+  {
+    "name": "perl-Thread",
+    "summary": "Manipulate threads in Perl (for old code only)"
+  },
+  {
+    "name": "perl-Thread-Queue",
+    "summary": "Thread-safe queues"
+  },
+  {
+    "name": "perl-Thread-Semaphore",
+    "summary": "Thread-safe semaphores"
+  },
+  {
+    "name": "perl-threads",
+    "summary": "Perl interpreter-based threads"
+  },
+  {
+    "name": "perl-threads-shared",
+    "summary": "Perl extension for sharing data structures between threads"
+  },
+  {
+    "name": "perl-Tie",
+    "summary": "Base classes for tying variables"
+  },
+  {
+    "name": "perl-Tie-File",
+    "summary": "Access the lines of a disk file via a Perl array"
+  },
+  {
+    "name": "perl-Tie-Memoize",
+    "summary": "Add data to a hash when needed"
+  },
+  {
+    "name": "perl-Tie-RefHash",
+    "summary": "Use references as hash keys"
+  },
+  {
+    "name": "perl-Time",
+    "summary": "By-name interface to Perl built-in time functions"
+  },
+  {
+    "name": "perl-Time-HiRes",
+    "summary": "High resolution alarm, sleep, gettimeofday, interval timers"
+  },
+  {
+    "name": "perl-Time-Local",
+    "summary": "Efficiently compute time from local and GMT time"
+  },
+  {
+    "name": "perl-Time-Piece",
+    "summary": "Time objects from localtime and gmtime"
+  },
+  {
+    "name": "perl-TimeDate",
+    "summary": "A Perl module for time and date manipulation"
+  },
+  {
+    "name": "perl-Tk",
+    "summary": "Perl Graphical User Interface ToolKit"
+  },
+  {
+    "name": "perl-Try-Tiny",
+    "summary": "Minimal try/catch with proper localization of $@"
+  },
+  {
+    "name": "perl-Unicode-Collate",
+    "summary": "Unicode Collation Algorithm"
+  },
+  {
+    "name": "perl-Unicode-LineBreak",
+    "summary": "UAX #14 Unicode Line Breaking Algorithm"
+  },
+  {
+    "name": "perl-Unicode-Normalize",
+    "summary": "Unicode Normalization Forms"
+  },
+  {
+    "name": "perl-Unicode-UCD",
+    "summary": "Unicode character database"
+  },
+  {
+    "name": "perl-Unix-Syslog",
+    "summary": "Perl interface to the UNIX syslog(3) calls"
+  },
+  {
+    "name": "perl-URI",
+    "summary": "A Perl module implementing URI parsing and manipulation"
+  },
+  {
+    "name": "perl-User-pwent",
+    "summary": "By-name interface to Perl built-in user name resolver"
+  },
+  {
+    "name": "perl-utils",
+    "summary": "Utilities packaged with the Perl distribution"
+  },
+  {
+    "name": "perl-vars",
+    "summary": "Perl pragma to predeclare global variable names"
+  },
+  {
+    "name": "perl-version",
+    "summary": "Perl extension for Version Objects"
+  },
+  {
+    "name": "perl-vmsish",
+    "summary": "Perl pragma to control VMS-specific language features"
+  },
+  {
+    "name": "perl-WWW-RobotRules",
+    "summary": "Database of robots.txt-derived permissions"
+  },
+  {
+    "name": "perl-XML-Catalog",
+    "summary": "Resolve public identifiers and remap system identifiers"
+  },
+  {
+    "name": "perl-XML-LibXML",
+    "summary": "Perl interface to the libxml2 library"
+  },
+  {
+    "name": "perl-XML-NamespaceSupport",
+    "summary": "A simple generic name space support class"
+  },
+  {
+    "name": "perl-XML-Parser",
+    "summary": "Perl module for parsing XML documents"
+  },
+  {
+    "name": "perl-XML-SAX",
+    "summary": "SAX parser access API for Perl"
+  },
+  {
+    "name": "perl-XML-SAX-Base",
+    "summary": "Base class SAX drivers and filters"
+  },
+  {
+    "name": "perl-XML-Simple",
+    "summary": "Easy API to maintain XML in Perl"
+  },
+  {
+    "name": "perl-XML-TokeParser",
+    "summary": "Simplified interface to XML::Parser"
+  },
+  {
+    "name": "perl-XML-XPath",
+    "summary": "XPath parser and evaluator for Perl"
+  },
+  {
+    "name": "perl-YAML",
+    "summary": "YAML Ain't Markup Language (tm)"
+  },
+  {
+    "name": "pesign",
+    "summary": "Signing utility for UEFI binaries"
+  },
+  {
+    "name": "pf-bb-config",
+    "summary": "PF BBDEV (baseband device) Configuration Application"
+  },
+  {
+    "name": "pg_repack",
+    "summary": "Reorganize tables in PostgreSQL databases without any locks"
+  },
+  {
+    "name": "pgaudit",
+    "summary": "PostgreSQL Audit Extension"
+  },
+  {
+    "name": "php",
+    "summary": "PHP scripting language for creating dynamic web sites"
+  },
+  {
+    "name": "php-bcmath",
+    "summary": "A module for PHP applications for using the bcmath library"
+  },
+  {
+    "name": "php-cli",
+    "summary": "Command-line interface for PHP"
+  },
+  {
+    "name": "php-common",
+    "summary": "Common files for PHP"
+  },
+  {
+    "name": "php-dba",
+    "summary": "A database abstraction layer module for PHP applications"
+  },
+  {
+    "name": "php-dbg",
+    "summary": "The interactive PHP debugger"
+  },
+  {
+    "name": "php-devel",
+    "summary": "Files needed for building PHP extensions"
+  },
+  {
+    "name": "php-embedded",
+    "summary": "PHP library for embedding in applications"
+  },
+  {
+    "name": "php-enchant",
+    "summary": "Enchant spelling extension for PHP applications"
+  },
+  {
+    "name": "php-ffi",
+    "summary": "Foreign Function Interface"
+  },
+  {
+    "name": "php-fpm",
+    "summary": "PHP FastCGI Process Manager"
+  },
+  {
+    "name": "php-gd",
+    "summary": "A module for PHP applications for using the gd graphics library"
+  },
+  {
+    "name": "php-gmp",
+    "summary": "A module for PHP applications for using the GNU MP library"
+  },
+  {
+    "name": "php-intl",
+    "summary": "Internationalization extension for PHP applications"
+  },
+  {
+    "name": "php-ldap",
+    "summary": "A module for PHP applications that use LDAP"
+  },
+  {
+    "name": "php-mbstring",
+    "summary": "A module for PHP applications which need multi-byte string handling"
+  },
+  {
+    "name": "php-mysqlnd",
+    "summary": "A module for PHP applications that use MySQL databases"
+  },
+  {
+    "name": "php-odbc",
+    "summary": "A module for PHP applications that use ODBC databases"
+  },
+  {
+    "name": "php-opcache",
+    "summary": "The Zend OPcache"
+  },
+  {
+    "name": "php-pdo",
+    "summary": "A database access abstraction module for PHP applications"
+  },
+  {
+    "name": "php-pear",
+    "summary": "PHP Extension and Application Repository framework"
+  },
+  {
+    "name": "php-pecl-apcu",
+    "summary": "APC User Cache"
+  },
+  {
+    "name": "php-pecl-apcu-devel",
+    "summary": "APCu developer files (header)"
+  },
+  {
+    "name": "php-pecl-rrd",
+    "summary": "PHP Bindings for rrdtool"
+  },
+  {
+    "name": "php-pecl-xdebug3",
+    "summary": "Provides functions for function traces and profiling"
+  },
+  {
+    "name": "php-pecl-zip",
+    "summary": "A ZIP archive management extension"
+  },
+  {
+    "name": "php-pgsql",
+    "summary": "A PostgreSQL database module for PHP"
+  },
+  {
+    "name": "php-process",
+    "summary": "Modules for PHP script using system process interfaces"
+  },
+  {
+    "name": "php-snmp",
+    "summary": "A module for PHP applications that query SNMP-managed devices"
+  },
+  {
+    "name": "php-soap",
+    "summary": "A module for PHP applications that use the SOAP protocol"
+  },
+  {
+    "name": "php-xml",
+    "summary": "A module for PHP applications which use XML"
+  },
+  {
+    "name": "pinentry",
+    "summary": "Collection of simple PIN or passphrase entry dialogs"
+  },
+  {
+    "name": "pinentry-gnome3",
+    "summary": "Passphrase/PIN entry dialog for GNOME 3"
+  },
+  {
+    "name": "pinentry-tty",
+    "summary": "Passphrase/PIN entry dialog in tty"
+  },
+  {
+    "name": "pinfo",
+    "summary": "An info file viewer"
+  },
+  {
+    "name": "pipewire",
+    "summary": "Media Sharing Server"
+  },
+  {
+    "name": "pipewire-alsa",
+    "summary": "PipeWire media server ALSA support"
+  },
+  {
+    "name": "pipewire-devel",
+    "summary": "Headers and libraries for PipeWire client development"
+  },
+  {
+    "name": "pipewire-gstreamer",
+    "summary": "GStreamer elements for PipeWire"
+  },
+  {
+    "name": "pipewire-jack-audio-connection-kit",
+    "summary": "PipeWire JACK implementation"
+  },
+  {
+    "name": "pipewire-jack-audio-connection-kit-devel",
+    "summary": "Development files for pipewire-jack-audio-connection-kit"
+  },
+  {
+    "name": "pipewire-jack-audio-connection-kit-libs",
+    "summary": "PipeWire JACK implementation libraries"
+  },
+  {
+    "name": "pipewire-libs",
+    "summary": "Libraries for PipeWire clients"
+  },
+  {
+    "name": "pipewire-module-x11",
+    "summary": "PipeWire media server x11 support"
+  },
+  {
+    "name": "pipewire-pulseaudio",
+    "summary": "PipeWire PulseAudio implementation"
+  },
+  {
+    "name": "pipewire-utils",
+    "summary": "PipeWire media server utilities"
+  },
+  {
+    "name": "pixman",
+    "summary": "Pixel manipulation library"
+  },
+  {
+    "name": "pixman-devel",
+    "summary": "Pixel manipulation library development package"
+  },
+  {
+    "name": "pki-acme",
+    "summary": "PKI ACME Package"
+  },
+  {
+    "name": "pki-base",
+    "summary": "PKI Base Package"
+  },
+  {
+    "name": "pki-base-java",
+    "summary": "PKI Base Java Package"
+  },
+  {
+    "name": "pki-ca",
+    "summary": "PKI CA Package"
+  },
+  {
+    "name": "pki-jackson-annotations",
+    "summary": "Core annotations for Jackson data processor"
+  },
+  {
+    "name": "pki-jackson-core",
+    "summary": "Core part of Jackson"
+  },
+  {
+    "name": "pki-jackson-databind",
+    "summary": "General data-binding package for Jackson (2.x)"
+  },
+  {
+    "name": "pki-jackson-jaxrs-json-provider",
+    "summary": "Jackson-JAXRS-JSON"
+  },
+  {
+    "name": "pki-jackson-jaxrs-providers",
+    "summary": "Jackson JAX-RS providers"
+  },
+  {
+    "name": "pki-jackson-module-jaxb-annotations",
+    "summary": "Support for using JAXB annotations as an alternative to \"native\" Jackson annotations"
+  },
+  {
+    "name": "pki-kra",
+    "summary": "PKI KRA Package"
+  },
+  {
+    "name": "pki-resteasy",
+    "summary": "Framework for RESTful Web services and Java applications"
+  },
+  {
+    "name": "pki-resteasy-client",
+    "summary": "Client for resteasy"
+  },
+  {
+    "name": "pki-resteasy-core",
+    "summary": "Core modules for resteasy"
+  },
+  {
+    "name": "pki-resteasy-jackson2-provider",
+    "summary": "Module jackson2-provider for resteasy"
+  },
+  {
+    "name": "pki-resteasy-servlet-initializer",
+    "summary": "resteasy Servlet Initializer"
+  },
+  {
+    "name": "pki-server",
+    "summary": "PKI Server Package"
+  },
+  {
+    "name": "pki-servlet-4.0-api",
+    "summary": "Apache Tomcat Java Servlet v4.0 API Implementation Classes"
+  },
+  {
+    "name": "pki-servlet-engine",
+    "summary": "Apache Servlet/JSP Engine, RI for Servlet 4.0/JSP 2.3 API"
+  },
+  {
+    "name": "pki-symkey",
+    "summary": "PKI Symmetric Key Package"
+  },
+  {
+    "name": "pki-tools",
+    "summary": "PKI Tools Package"
+  },
+  {
+    "name": "plexus-cipher",
+    "summary": "Plexus Cipher: encryption/decryption Component"
+  },
+  {
+    "name": "plexus-classworlds",
+    "summary": "Plexus Classworlds Classloader Framework"
+  },
+  {
+    "name": "plexus-containers-component-annotations",
+    "summary": "Component API from plexus-containers"
+  },
+  {
+    "name": "plexus-interpolation",
+    "summary": "Plexus Interpolation API"
+  },
+  {
+    "name": "plexus-sec-dispatcher",
+    "summary": "Plexus Security Dispatcher Component"
+  },
+  {
+    "name": "plexus-utils",
+    "summary": "Plexus Common Utilities"
+  },
+  {
+    "name": "plotnetcfg",
+    "summary": "A tool to plot network configuration"
+  },
+  {
+    "name": "plotutils",
+    "summary": "GNU vector and raster graphics utilities and libraries"
+  },
+  {
+    "name": "plymouth",
+    "summary": "Graphical Boot Animation and Logger"
+  },
+  {
+    "name": "plymouth-core-libs",
+    "summary": "Plymouth core libraries"
+  },
+  {
+    "name": "plymouth-graphics-libs",
+    "summary": "Plymouth graphics libraries"
+  },
+  {
+    "name": "plymouth-plugin-fade-throbber",
+    "summary": "Plymouth \"Fade-Throbber\" plugin"
+  },
+  {
+    "name": "plymouth-plugin-label",
+    "summary": "Plymouth label plugin"
+  },
+  {
+    "name": "plymouth-plugin-script",
+    "summary": "Plymouth \"script\" plugin"
+  },
+  {
+    "name": "plymouth-plugin-space-flares",
+    "summary": "Plymouth \"space-flares\" plugin"
+  },
+  {
+    "name": "plymouth-plugin-two-step",
+    "summary": "Plymouth \"two-step\" plugin"
+  },
+  {
+    "name": "plymouth-scripts",
+    "summary": "Plymouth related scripts"
+  },
+  {
+    "name": "plymouth-system-theme",
+    "summary": "Plymouth default theme"
+  },
+  {
+    "name": "plymouth-theme-charge",
+    "summary": "Plymouth \"Charge\" plugin"
+  },
+  {
+    "name": "plymouth-theme-fade-in",
+    "summary": "Plymouth \"Fade-In\" theme"
+  },
+  {
+    "name": "plymouth-theme-script",
+    "summary": "Plymouth \"Script\" plugin"
+  },
+  {
+    "name": "plymouth-theme-solar",
+    "summary": "Plymouth \"Solar\" theme"
+  },
+  {
+    "name": "plymouth-theme-spinfinity",
+    "summary": "Plymouth \"Spinfinity\" theme"
+  },
+  {
+    "name": "plymouth-theme-spinner",
+    "summary": "Plymouth \"Spinner\" theme"
+  },
+  {
+    "name": "pmix",
+    "summary": "Process Management Interface Exascale (PMIx)"
+  },
+  {
+    "name": "pmix-devel",
+    "summary": "Development files for pmix"
+  },
+  {
+    "name": "pmix-pmi",
+    "summary": "The pmix implementation of libpmi and libpmi2"
+  },
+  {
+    "name": "pmix-tools",
+    "summary": "Tools for pmix"
+  },
+  {
+    "name": "pnm2ppa",
+    "summary": "Drivers for printing to HP PPA printers"
+  },
+  {
+    "name": "podman",
+    "summary": "Manage Pods, Containers and Container Images"
+  },
+  {
+    "name": "podman-catatonit",
+    "summary": "A signal-forwarding process manager for containers"
+  },
+  {
+    "name": "podman-docker",
+    "summary": "Emulate Docker CLI using podman"
+  },
+  {
+    "name": "podman-gvproxy",
+    "summary": "Go replacement for libslirp and VPNKit"
+  },
+  {
+    "name": "podman-plugins",
+    "summary": "Plugins for podman"
+  },
+  {
+    "name": "podman-remote",
+    "summary": "A remote CLI for Podman: A Simple management tool for pods, containers and images"
+  },
+  {
+    "name": "podman-tests",
+    "summary": "Tests for podman"
+  },
+  {
+    "name": "policycoreutils-dbus",
+    "summary": "SELinux policy core DBUS api"
+  },
+  {
+    "name": "policycoreutils-devel",
+    "summary": "SELinux policy core policy devel utilities"
+  },
+  {
+    "name": "policycoreutils-gui",
+    "summary": "SELinux configuration GUI"
+  },
+  {
+    "name": "policycoreutils-python-utils",
+    "summary": "SELinux policy core python utilities"
+  },
+  {
+    "name": "policycoreutils-sandbox",
+    "summary": "SELinux sandbox utilities"
+  },
+  {
+    "name": "polkit-devel",
+    "summary": "Development files for polkit"
+  },
+  {
+    "name": "polkit-docs",
+    "summary": "Development documentation for polkit"
+  },
+  {
+    "name": "poppler",
+    "summary": "PDF rendering library"
+  },
+  {
+    "name": "poppler-cpp",
+    "summary": "Pure C++ wrapper for poppler"
+  },
+  {
+    "name": "poppler-data",
+    "summary": "Encoding files for use with poppler"
+  },
+  {
+    "name": "poppler-glib",
+    "summary": "Glib wrapper for poppler"
+  },
+  {
+    "name": "poppler-qt5",
+    "summary": "Qt5 wrapper for poppler"
+  },
+  {
+    "name": "poppler-utils",
+    "summary": "Command line utilities for converting PDF files"
+  },
+  {
+    "name": "popt-devel",
+    "summary": "Development files for the popt library"
+  },
+  {
+    "name": "postfix",
+    "summary": "Postfix Mail Transport Agent"
+  },
+  {
+    "name": "postfix-cdb",
+    "summary": "Postfix CDB map support"
+  },
+  {
+    "name": "postfix-ldap",
+    "summary": "Postfix LDAP map support"
+  },
+  {
+    "name": "postfix-lmdb",
+    "summary": "Postfix LDMB map support"
+  },
+  {
+    "name": "postfix-mysql",
+    "summary": "Postfix MySQL map support"
+  },
+  {
+    "name": "postfix-pcre",
+    "summary": "Postfix PCRE map support"
+  },
+  {
+    "name": "postfix-perl-scripts",
+    "summary": "Postfix utilities written in perl"
+  },
+  {
+    "name": "postfix-pgsql",
+    "summary": "Postfix PostgreSQL map support"
+  },
+  {
+    "name": "postfix-sqlite",
+    "summary": "Postfix SQLite map support"
+  },
+  {
+    "name": "postgres-decoderbufs",
+    "summary": "PostgreSQL Protocol Buffers logical decoder plugin"
+  },
+  {
+    "name": "postgresql",
+    "summary": "PostgreSQL client programs"
+  },
+  {
+    "name": "postgresql-contrib",
+    "summary": "Extension modules distributed with PostgreSQL"
+  },
+  {
+    "name": "postgresql-jdbc",
+    "summary": "JDBC driver for PostgreSQL"
+  },
+  {
+    "name": "postgresql-odbc",
+    "summary": "PostgreSQL ODBC driver"
+  },
+  {
+    "name": "postgresql-plperl",
+    "summary": "The Perl procedural language for PostgreSQL"
+  },
+  {
+    "name": "postgresql-plpython3",
+    "summary": "The Python3 procedural language for PostgreSQL"
+  },
+  {
+    "name": "postgresql-pltcl",
+    "summary": "The Tcl procedural language for PostgreSQL"
+  },
+  {
+    "name": "postgresql-private-libs",
+    "summary": "The shared libraries required only for this build of PostgreSQL server"
+  },
+  {
+    "name": "postgresql-server",
+    "summary": "The programs needed to create and run a PostgreSQL server"
+  },
+  {
+    "name": "postgresql-upgrade",
+    "summary": "Support for upgrading from the previous major release of PostgreSQL"
+  },
+  {
+    "name": "potrace",
+    "summary": "Transform bitmaps into vector graphics"
+  },
+  {
+    "name": "power-profiles-daemon",
+    "summary": "Makes power profiles handling available over D-Bus"
+  },
+  {
+    "name": "powertop",
+    "summary": "Power consumption monitor"
+  },
+  {
+    "name": "pptp",
+    "summary": "Point-to-Point Tunneling Protocol (PPTP) Client"
+  },
+  {
+    "name": "procmail",
+    "summary": "Mail processing program"
+  },
+  {
+    "name": "protobuf",
+    "summary": "Protocol Buffers - Google's data interchange format"
+  },
+  {
+    "name": "protobuf-c",
+    "summary": "C bindings for Google's Protocol Buffers"
+  },
+  {
+    "name": "protobuf-lite",
+    "summary": "Protocol Buffers LITE_RUNTIME libraries"
+  },
+  {
+    "name": "ps_mem",
+    "summary": "Memory profiling tool"
+  },
+  {
+    "name": "pt-sans-fonts",
+    "summary": "PT Sans, a grotesque pan-Cyrillic font family"
+  },
+  {
+    "name": "publicsuffix-list",
+    "summary": "Cross-vendor public domain suffix database"
+  },
+  {
+    "name": "pulseaudio",
+    "summary": "Improved Linux Sound Server"
+  },
+  {
+    "name": "pulseaudio-libs",
+    "summary": "Libraries for PulseAudio clients"
+  },
+  {
+    "name": "pulseaudio-libs-devel",
+    "summary": "Headers and libraries for PulseAudio client development"
+  },
+  {
+    "name": "pulseaudio-libs-glib2",
+    "summary": "GLIB 2.x bindings for PulseAudio clients"
+  },
+  {
+    "name": "pulseaudio-module-bluetooth",
+    "summary": "Bluetooth support for the PulseAudio sound server"
+  },
+  {
+    "name": "pulseaudio-module-x11",
+    "summary": "X11 support for the PulseAudio sound server"
+  },
+  {
+    "name": "pulseaudio-utils",
+    "summary": "PulseAudio sound server utilities"
+  },
+  {
+    "name": "pykickstart",
+    "summary": "Python utilities for manipulating kickstart files."
+  },
+  {
+    "name": "pyproject-srpm-macros",
+    "summary": "Minimal implementation of %pyproject_buildrequires"
+  },
+  {
+    "name": "python-cups-doc",
+    "summary": "Documentation for python-cups"
+  },
+  {
+    "name": "python-qt5-rpm-macros",
+    "summary": "RPM macros python-qt5"
+  },
+  {
+    "name": "python-rpm-macros",
+    "summary": "The common Python RPM macros"
+  },
+  {
+    "name": "python-srpm-macros",
+    "summary": "RPM macros for building Python source packages"
+  },
+  {
+    "name": "python-unversioned-command",
+    "summary": "The \"python\" command that runs Python 3"
+  },
+  {
+    "name": "python3-alembic",
+    "summary": "Database migration tool for SQLAlchemy"
+  },
+  {
+    "name": "python3-appdirs",
+    "summary": "Python module for determining platform-specific directories"
+  },
+  {
+    "name": "python3-argcomplete",
+    "summary": "Bash tab completion for argparse"
+  },
+  {
+    "name": "python3-attrs",
+    "summary": "Python attributes without boilerplate"
+  },
+  {
+    "name": "python3-audit",
+    "summary": "Python3 bindings for libaudit"
+  },
+  {
+    "name": "python3-augeas",
+    "summary": "Python 3 bindings to augeas"
+  },
+  {
+    "name": "python3-awscrt",
+    "summary": "Python bindings for the AWS Common Runtime"
+  },
+  {
+    "name": "python3-babel",
+    "summary": "Library for internationalizing Python applications"
+  },
+  {
+    "name": "python3-bcc",
+    "summary": "Python3 bindings for BPF Compiler Collection (BCC)"
+  },
+  {
+    "name": "python3-bind",
+    "summary": "A module allowing rndc commands to be sent from Python programs"
+  },
+  {
+    "name": "python3-blivet",
+    "summary": "A python3 package for examining and modifying storage configuration."
+  },
+  {
+    "name": "python3-blockdev",
+    "summary": "Python3 gobject-introspection bindings for libblockdev"
+  },
+  {
+    "name": "python3-boom",
+    "summary": "A set of libraries and tools for managing boot loader entries"
+  },
+  {
+    "name": "python3-brlapi",
+    "summary": "Python 3 binding for BrlAPI"
+  },
+  {
+    "name": "python3-brotli",
+    "summary": "Lossless compression algorithm (python 3)"
+  },
+  {
+    "name": "python3-bytesize",
+    "summary": "Python 3 bindings for libbytesize"
+  },
+  {
+    "name": "python3-cairo",
+    "summary": "Python 3 bindings for the cairo library"
+  },
+  {
+    "name": "python3-cepces",
+    "summary": "Python part of cepces"
+  },
+  {
+    "name": "python3-cffi",
+    "summary": "Foreign Function Interface for Python 3 to call C code"
+  },
+  {
+    "name": "python3-clang",
+    "summary": "Python3 bindings for clang"
+  },
+  {
+    "name": "python3-colorama",
+    "summary": "Cross-platform colored terminal text"
+  },
+  {
+    "name": "python3-configobj",
+    "summary": "Config file reading, writing, and validation"
+  },
+  {
+    "name": "python3-createrepo_c",
+    "summary": "Python 3 bindings for the createrepo_c library"
+  },
+  {
+    "name": "python3-criu",
+    "summary": "Python bindings for criu"
+  },
+  {
+    "name": "python3-cryptography",
+    "summary": "PyCA's cryptography library"
+  },
+  {
+    "name": "python3-cups",
+    "summary": "Python3 bindings for CUPS API, known as pycups."
+  },
+  {
+    "name": "python3-dasbus",
+    "summary": "DBus library in Python 3"
+  },
+  {
+    "name": "python3-dbus-client-gen",
+    "summary": "Library for Generating D-Bus Client Code"
+  },
+  {
+    "name": "python3-dbus-python-client-gen",
+    "summary": "Python Library for Generating dbus-python Client Code"
+  },
+  {
+    "name": "python3-dbus-signature-pyparsing",
+    "summary": "Parser for a D-Bus Signature"
+  },
+  {
+    "name": "python3-devel",
+    "summary": "Libraries and header files needed for Python development"
+  },
+  {
+    "name": "python3-distro",
+    "summary": "Linux Distribution - a Linux OS platform information API"
+  },
+  {
+    "name": "python3-dnf-plugin-leaves",
+    "summary": "Leaves Plugin for DNF"
+  },
+  {
+    "name": "python3-dnf-plugin-modulesync",
+    "summary": "Download module metadata and packages and create repository"
+  },
+  {
+    "name": "python3-dnf-plugin-show-leaves",
+    "summary": "Show-leaves Plugin for DNF"
+  },
+  {
+    "name": "python3-docutils",
+    "summary": "System for processing plaintext documentation"
+  },
+  {
+    "name": "python3-enchant",
+    "summary": "Python 3 bindings for Enchant spellchecking library"
+  },
+  {
+    "name": "python3-file-magic",
+    "summary": "Python 3 bindings for the libmagic API"
+  },
+  {
+    "name": "python3-freeradius",
+    "summary": "Python 3 support for freeradius"
+  },
+  {
+    "name": "python3-gluster",
+    "summary": "GlusterFS python library"
+  },
+  {
+    "name": "python3-gobject",
+    "summary": "Python 3 bindings for GObject Introspection"
+  },
+  {
+    "name": "python3-greenlet",
+    "summary": "Lightweight in-process concurrent programming"
+  },
+  {
+    "name": "python3-gssapi",
+    "summary": "Python 3 Bindings for GSSAPI (RFC 2743/2744 and extensions)"
+  },
+  {
+    "name": "python3-i2c-tools",
+    "summary": "Python 3 bindings for Linux SMBus access through i2c-dev"
+  },
+  {
+    "name": "python3-idm-pki",
+    "summary": "IDM PKI Python 3 Package"
+  },
+  {
+    "name": "python3-imath",
+    "summary": "Python module for Imath"
+  },
+  {
+    "name": "python3-iniconfig",
+    "summary": "Brain-dead simple parsing of ini files"
+  },
+  {
+    "name": "python3-into-dbus-python",
+    "summary": "Transformer to dbus-python types"
+  },
+  {
+    "name": "python3-ipaclient",
+    "summary": "Python libraries used by IPA client"
+  },
+  {
+    "name": "python3-ipalib",
+    "summary": "Python3 libraries used by IPA"
+  },
+  {
+    "name": "python3-ipaserver",
+    "summary": "Python libraries used by IPA server"
+  },
+  {
+    "name": "python3-iscsi-initiator-utils",
+    "summary": "Python 3.9 bindings to iscsi-initiator-utils"
+  },
+  {
+    "name": "python3-jinja2",
+    "summary": "General purpose template engine for python3"
+  },
+  {
+    "name": "python3-jmespath",
+    "summary": "JSON Matching Expressions"
+  },
+  {
+    "name": "python3-jsonpatch",
+    "summary": "Applying JSON Patches in Python 3"
+  },
+  {
+    "name": "python3-jsonpointer",
+    "summary": "Resolve JSON Pointers in Python"
+  },
+  {
+    "name": "python3-jsonschema",
+    "summary": "Implementation of JSON Schema validation for Python"
+  },
+  {
+    "name": "python3-justbases",
+    "summary": "A small library for precise conversion between arbitrary bases"
+  },
+  {
+    "name": "python3-justbytes",
+    "summary": "Library for handling computation with address ranges in bytes"
+  },
+  {
+    "name": "python3-jwcrypto",
+    "summary": "Implements JWK, JWS, JWE specifications using python-cryptography"
+  },
+  {
+    "name": "python3-kdcproxy",
+    "summary": "MS-KKDCP (kerberos proxy) WSGI module"
+  },
+  {
+    "name": "python3-keycloak-httpd-client-install",
+    "summary": "Tools to configure Apache HTTPD as Keycloak client"
+  },
+  {
+    "name": "python3-keylime",
+    "summary": "The Python Keylime module"
+  },
+  {
+    "name": "python3-kickstart",
+    "summary": "Python 3 library for manipulating kickstart files."
+  },
+  {
+    "name": "python3-langtable",
+    "summary": "Python module to query the langtable-data"
+  },
+  {
+    "name": "python3-lark-parser",
+    "summary": "Lark is a modern general-purpose parsing library for Python"
+  },
+  {
+    "name": "python3-lasso",
+    "summary": "Liberty Alliance Single Sign On (lasso) Python bindings"
+  },
+  {
+    "name": "python3-ldap",
+    "summary": "An object-oriented API to access LDAP directory servers"
+  },
+  {
+    "name": "python3-leapp",
+    "summary": "OS & Application modernization framework"
+  },
+  {
+    "name": "python3-lib389",
+    "summary": "A library for accessing, testing, and configuring the 389 Directory Server"
+  },
+  {
+    "name": "python3-libevdev",
+    "summary": "Python bindings to the libevdev evdev device wrapper library"
+  },
+  {
+    "name": "python3-libgpiod",
+    "summary": "Python 3 bindings for libgpiod"
+  },
+  {
+    "name": "python3-libguestfs",
+    "summary": "Python 3 bindings for libguestfs"
+  },
+  {
+    "name": "python3-libmodulemd",
+    "summary": "Python 3 bindings for libmodulemd"
+  },
+  {
+    "name": "python3-libmount",
+    "summary": "Python bindings for the libmount library"
+  },
+  {
+    "name": "python3-libnbd",
+    "summary": "Python 3 bindings for libnbd"
+  },
+  {
+    "name": "python3-libnmstate",
+    "summary": "nmstate Python 3 API library"
+  },
+  {
+    "name": "python3-libnvme",
+    "summary": "Python3 bindings for libnvme"
+  },
+  {
+    "name": "python3-libproxy",
+    "summary": "Binding for libproxy and python3"
+  },
+  {
+    "name": "python3-libreport",
+    "summary": "Python 3 bindings for report-libs"
+  },
+  {
+    "name": "python3-libselinux",
+    "summary": "SELinux python 3 bindings for libselinux"
+  },
+  {
+    "name": "python3-libsemanage",
+    "summary": "semanage python 3 bindings for libsemanage"
+  },
+  {
+    "name": "python3-libstoragemgmt",
+    "summary": "Python 3 client libraries and plug-in support for libstoragemgmt"
+  },
+  {
+    "name": "python3-libvirt",
+    "summary": "The libvirt virtualization API python3 binding"
+  },
+  {
+    "name": "python3-lit",
+    "summary": "LLVM lit test runner for Python 3"
+  },
+  {
+    "name": "python3-lldb",
+    "summary": "Python module for LLDB"
+  },
+  {
+    "name": "python3-louis",
+    "summary": "Python 3 language bindings for liblouis"
+  },
+  {
+    "name": "python3-lxml",
+    "summary": "XML processing library combining libxml2/libxslt with the ElementTree API"
+  },
+  {
+    "name": "python3-mako",
+    "summary": "Mako template library for Python"
+  },
+  {
+    "name": "python3-markupsafe",
+    "summary": "Implements a XML/HTML/XHTML Markup safe string for Python 3"
+  },
+  {
+    "name": "python3-meh",
+    "summary": "A python 3 library for handling exceptions"
+  },
+  {
+    "name": "python3-meh-gui",
+    "summary": "Graphical user interface for the python3-meh library"
+  },
+  {
+    "name": "python3-mod_wsgi",
+    "summary": "A WSGI interface for Python web applications in Apache"
+  },
+  {
+    "name": "python3-net-snmp",
+    "summary": "The Python 'netsnmp' module for the Net-SNMP"
+  },
+  {
+    "name": "python3-netaddr",
+    "summary": "A pure Python network address representation and manipulation library"
+  },
+  {
+    "name": "python3-netifaces",
+    "summary": "Python 3 library to retrieve information about network interfaces"
+  },
+  {
+    "name": "python3-networkx",
+    "summary": "Creates and Manipulates Graphs and Networks"
+  },
+  {
+    "name": "python3-newt",
+    "summary": "Python 3 bindings for newt"
+  },
+  {
+    "name": "python3-nispor",
+    "summary": "API for network status querying"
+  },
+  {
+    "name": "python3-numpy",
+    "summary": "A fast multidimensional array facility for Python"
+  },
+  {
+    "name": "python3-numpy-f2py",
+    "summary": "f2py for numpy"
+  },
+  {
+    "name": "python3-oauthlib",
+    "summary": "An implementation of the OAuth request-signing logic"
+  },
+  {
+    "name": "python3-osbuild",
+    "summary": "A build system for OS images"
+  },
+  {
+    "name": "python3-packaging",
+    "summary": "Core utilities for Python packages"
+  },
+  {
+    "name": "python3-pcp",
+    "summary": "Performance Co-Pilot (PCP) Python3 bindings and documentation"
+  },
+  {
+    "name": "python3-pefile",
+    "summary": "Python PE parsing module"
+  },
+  {
+    "name": "python3-perf",
+    "summary": "Python bindings for apps which will manipulate perf events"
+  },
+  {
+    "name": "python3-pid",
+    "summary": "PID file management library"
+  },
+  {
+    "name": "python3-pip",
+    "summary": "A tool for installing and managing Python3 packages"
+  },
+  {
+    "name": "python3-pki",
+    "summary": "PKI Python 3 Package"
+  },
+  {
+    "name": "python3-pluggy",
+    "summary": "The plugin manager stripped of pytest specific details"
+  },
+  {
+    "name": "python3-ply",
+    "summary": "Python Lex-Yacc"
+  },
+  {
+    "name": "python3-podman",
+    "summary": "RESTful API for Podman"
+  },
+  {
+    "name": "python3-policycoreutils",
+    "summary": "SELinux policy core python3 interfaces"
+  },
+  {
+    "name": "python3-prettytable",
+    "summary": "Python library to display tabular data in tables"
+  },
+  {
+    "name": "python3-productmd",
+    "summary": "Library providing parsers for metadata related to OS installation"
+  },
+  {
+    "name": "python3-prompt-toolkit",
+    "summary": "Library for building powerful interactive command line applications in Python"
+  },
+  {
+    "name": "python3-protobuf",
+    "summary": "Python 3 bindings for Google Protocol Buffers"
+  },
+  {
+    "name": "python3-psutil",
+    "summary": "A process and system utilities module for Python"
+  },
+  {
+    "name": "python3-psycopg2",
+    "summary": "A PostgreSQL database adapter for Python 3"
+  },
+  {
+    "name": "python3-pwquality",
+    "summary": "Python bindings for the libpwquality library"
+  },
+  {
+    "name": "python3-py",
+    "summary": "Library with cross-python path, ini-parsing, io, code, log facilities"
+  },
+  {
+    "name": "python3-pyasn1",
+    "summary": "ASN.1 tools for Python 3"
+  },
+  {
+    "name": "python3-pyasn1-modules",
+    "summary": "Modules for pyasn1"
+  },
+  {
+    "name": "python3-pyatspi",
+    "summary": "Python3 bindings for at-spi"
+  },
+  {
+    "name": "python3-pycdlib",
+    "summary": "A pure python ISO9660 read and write library"
+  },
+  {
+    "name": "python3-pycparser",
+    "summary": "C parser and AST generator written in Python"
+  },
+  {
+    "name": "python3-pycurl",
+    "summary": "Python interface to libcurl for Python 3"
+  },
+  {
+    "name": "python3-pyelftools",
+    "summary": "Pure-Python library for parsing and analyzing ELF files"
+  },
+  {
+    "name": "python3-pyghmi",
+    "summary": "Python General Hardware Management Initiative (IPMI and others)"
+  },
+  {
+    "name": "python3-PyMySQL",
+    "summary": "Pure-Python MySQL client library"
+  },
+  {
+    "name": "python3-pyodbc",
+    "summary": "Python DB API 2.0 Module for ODBC"
+  },
+  {
+    "name": "python3-pyparted",
+    "summary": "Python 3 module for GNU parted"
+  },
+  {
+    "name": "python3-pyqt5-sip",
+    "summary": "SIP - Python 3/C++ Bindings Generator for pyqt5"
+  },
+  {
+    "name": "python3-pyrsistent",
+    "summary": "Persistent/Functional/Immutable data structures"
+  },
+  {
+    "name": "python3-pyserial",
+    "summary": "Python serial port access library"
+  },
+  {
+    "name": "python3-pytest",
+    "summary": "Simple powerful testing with Python"
+  },
+  {
+    "name": "python3-pytz",
+    "summary": "World Timezone Definitions for Python"
+  },
+  {
+    "name": "python3-pyusb",
+    "summary": "Python bindings for libusb"
+  },
+  {
+    "name": "python3-pyverbs",
+    "summary": "Python3 API over IB verbs"
+  },
+  {
+    "name": "python3-pywbem",
+    "summary": "Python3 WBEM Client and Provider Interface"
+  },
+  {
+    "name": "python3-pyxdg",
+    "summary": "Python3 library to access freedesktop.org standards"
+  },
+  {
+    "name": "python3-qrcode-core",
+    "summary": "Python 3 QR Code image generator (core library)"
+  },
+  {
+    "name": "python3-qt5",
+    "summary": "Python 3 bindings for Qt5"
+  },
+  {
+    "name": "python3-qt5-base",
+    "summary": "Python 3 bindings for Qt5 base"
+  },
+  {
+    "name": "python3-requests+security",
+    "summary": "Metapackage for python3-requests: security extras"
+  },
+  {
+    "name": "python3-requests+socks",
+    "summary": "Metapackage for python3-requests: socks extras"
+  },
+  {
+    "name": "python3-requests-file",
+    "summary": "Transport adapter for using file:// URLs with python3-requests"
+  },
+  {
+    "name": "python3-requests-ftp",
+    "summary": "FTP transport adapter for python3-requests"
+  },
+  {
+    "name": "python3-requests-gssapi",
+    "summary": "A GSSAPI/SPNEGO authentication handler for python-requests"
+  },
+  {
+    "name": "python3-requests-oauthlib",
+    "summary": "OAuthlib authentication support for Requests."
+  },
+  {
+    "name": "python3-resolvelib",
+    "summary": "Resolve abstract dependencies into concrete ones"
+  },
+  {
+    "name": "python3-rpm-generators",
+    "summary": "Dependency generators for Python RPMs"
+  },
+  {
+    "name": "python3-rpm-macros",
+    "summary": "RPM macros for building Python 3 packages"
+  },
+  {
+    "name": "python3-rtslib",
+    "summary": "API for Linux kernel LIO SCSI target"
+  },
+  {
+    "name": "python3-ruamel-yaml",
+    "summary": "YAML 1.2 loader/dumper package for Python"
+  },
+  {
+    "name": "python3-ruamel-yaml-clib",
+    "summary": "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+  },
+  {
+    "name": "python3-sanlock",
+    "summary": "Python bindings for the sanlock library"
+  },
+  {
+    "name": "python3-scapy",
+    "summary": "Interactive packet manipulation tool and network scanner"
+  },
+  {
+    "name": "python3-scipy",
+    "summary": "Scientific Tools for Python"
+  },
+  {
+    "name": "python3-scour",
+    "summary": "An SVG scrubber"
+  },
+  {
+    "name": "python3-simpleline",
+    "summary": "A Python3 library for creating text UI"
+  },
+  {
+    "name": "python3-snapm",
+    "summary": "A set of tools for managing snapshots"
+  },
+  {
+    "name": "python3-snapm-doc",
+    "summary": "A set of tools for managing snapshots"
+  },
+  {
+    "name": "python3-solv",
+    "summary": "Python bindings for the libsolv library"
+  },
+  {
+    "name": "python3-speechd",
+    "summary": "Python 3 Client API for speech-dispatcher"
+  },
+  {
+    "name": "python3-sqlalchemy",
+    "summary": "Modular and flexible ORM library for Python"
+  },
+  {
+    "name": "python3-subversion",
+    "summary": "Python bindings for Subversion Version Control system"
+  },
+  {
+    "name": "python3-tbb",
+    "summary": "Python 3 TBB module"
+  },
+  {
+    "name": "python3-tdb",
+    "summary": "Python3 bindings for the Tdb library"
+  },
+  {
+    "name": "python3-tkinter",
+    "summary": "A GUI toolkit for Python"
+  },
+  {
+    "name": "python3-toml",
+    "summary": "Python Library for Tom's Obvious, Minimal Language"
+  },
+  {
+    "name": "python3-tomli",
+    "summary": "A little TOML parser for Python"
+  },
+  {
+    "name": "python3-tornado",
+    "summary": "Scalable, non-blocking web server and tools"
+  },
+  {
+    "name": "python3-tracer",
+    "summary": "Common files for tracer"
+  },
+  {
+    "name": "python3-unbound",
+    "summary": "Python 3 modules and extensions for unbound"
+  },
+  {
+    "name": "python3-urllib-gssapi",
+    "summary": "A GSSAPI/SPNEGO authentication handler for urllib/urllib2"
+  },
+  {
+    "name": "python3-virt-firmware",
+    "summary": "Tools for virtual machine firmware volumes"
+  },
+  {
+    "name": "python3-volume_key",
+    "summary": "Python 3 bindings for libvolume_key"
+  },
+  {
+    "name": "python3-wcwidth",
+    "summary": "Measures number of Terminal column cells of wide-character codes"
+  },
+  {
+    "name": "python3-websockets",
+    "summary": "Implementation of the WebSocket Protocol for Python"
+  },
+  {
+    "name": "python3-wx-siplib",
+    "summary": "SIP - Python 3/C++ Bindings Generator for wx"
+  },
+  {
+    "name": "python3-yubico",
+    "summary": "Pure-python library for interacting with Yubikeys"
+  },
+  {
+    "name": "python3.11",
+    "summary": "Version 3.11 of the Python interpreter"
+  },
+  {
+    "name": "python3.11-cffi",
+    "summary": "Foreign Function Interface for Python to call C code"
+  },
+  {
+    "name": "python3.11-charset-normalizer",
+    "summary": "The Real First Universal Charset Detector"
+  },
+  {
+    "name": "python3.11-cryptography",
+    "summary": "PyCA's cryptography library"
+  },
+  {
+    "name": "python3.11-devel",
+    "summary": "Libraries and header files needed for Python development"
+  },
+  {
+    "name": "python3.11-idna",
+    "summary": "Internationalized Domain Names in Applications (IDNA)"
+  },
+  {
+    "name": "python3.11-libs",
+    "summary": "Python runtime libraries"
+  },
+  {
+    "name": "python3.11-lxml",
+    "summary": "XML processing library combining libxml2/libxslt with the ElementTree API"
+  },
+  {
+    "name": "python3.11-mod_wsgi",
+    "summary": "A WSGI interface for Python web applications in Apache"
+  },
+  {
+    "name": "python3.11-numpy",
+    "summary": "A fast multidimensional array facility for Python"
+  },
+  {
+    "name": "python3.11-numpy-f2py",
+    "summary": "f2py for numpy"
+  },
+  {
+    "name": "python3.11-pip",
+    "summary": "A tool for installing and managing Python packages"
+  },
+  {
+    "name": "python3.11-pip-wheel",
+    "summary": "The pip wheel"
+  },
+  {
+    "name": "python3.11-ply",
+    "summary": "Python Lex-Yacc"
+  },
+  {
+    "name": "python3.11-psycopg2",
+    "summary": "A PostgreSQL database adapter for Python"
+  },
+  {
+    "name": "python3.11-pycparser",
+    "summary": "C parser and AST generator written in Python"
+  },
+  {
+    "name": "python3.11-PyMySQL",
+    "summary": "Pure-Python MySQL client library"
+  },
+  {
+    "name": "python3.11-PyMySQL+rsa",
+    "summary": "Metapackage for python3.11-PyMySQL: rsa extras"
+  },
+  {
+    "name": "python3.11-pysocks",
+    "summary": "A Python SOCKS client module"
+  },
+  {
+    "name": "python3.11-pyyaml",
+    "summary": "YAML parser and emitter for Python"
+  },
+  {
+    "name": "python3.11-requests",
+    "summary": "HTTP library, written in Python, for human beings"
+  },
+  {
+    "name": "python3.11-requests+security",
+    "summary": "Metapackage for python3.11-requests: security extras"
+  },
+  {
+    "name": "python3.11-requests+socks",
+    "summary": "Metapackage for python3.11-requests: socks extras"
+  },
+  {
+    "name": "python3.11-scipy",
+    "summary": "Scientific Tools for Python"
+  },
+  {
+    "name": "python3.11-setuptools",
+    "summary": "Easily build and distribute Python packages"
+  },
+  {
+    "name": "python3.11-setuptools-wheel",
+    "summary": "The setuptools wheel"
+  },
+  {
+    "name": "python3.11-six",
+    "summary": "Python 2 and 3 compatibility utilities"
+  },
+  {
+    "name": "python3.11-tkinter",
+    "summary": "A GUI toolkit for Python"
+  },
+  {
+    "name": "python3.11-urllib3",
+    "summary": "Python HTTP library with thread-safe connection pooling and file post"
+  },
+  {
+    "name": "python3.11-wheel",
+    "summary": "Built-package format for Python"
+  },
+  {
+    "name": "python3.12",
+    "summary": "Version 3.12 of the Python interpreter"
+  },
+  {
+    "name": "python3.12-cffi",
+    "summary": "Foreign Function Interface for Python to call C code"
+  },
+  {
+    "name": "python3.12-charset-normalizer",
+    "summary": "The Real First Universal Charset Detector"
+  },
+  {
+    "name": "python3.12-cryptography",
+    "summary": "PyCA's cryptography library"
+  },
+  {
+    "name": "python3.12-devel",
+    "summary": "Libraries and header files needed for Python development"
+  },
+  {
+    "name": "python3.12-idna",
+    "summary": "Internationalized Domain Names in Applications (IDNA)"
+  },
+  {
+    "name": "python3.12-libs",
+    "summary": "Python runtime libraries"
+  },
+  {
+    "name": "python3.12-lxml",
+    "summary": "XML processing library combining libxml2/libxslt with the ElementTree API"
+  },
+  {
+    "name": "python3.12-mod_wsgi",
+    "summary": "A WSGI interface for Python web applications in Apache"
+  },
+  {
+    "name": "python3.12-numpy",
+    "summary": "A fast multidimensional array facility for Python"
+  },
+  {
+    "name": "python3.12-numpy-f2py",
+    "summary": "f2py for numpy"
+  },
+  {
+    "name": "python3.12-pip",
+    "summary": "A tool for installing and managing Python packages"
+  },
+  {
+    "name": "python3.12-pip-wheel",
+    "summary": "The pip wheel"
+  },
+  {
+    "name": "python3.12-ply",
+    "summary": "Python Lex-Yacc"
+  },
+  {
+    "name": "python3.12-psycopg2",
+    "summary": "A PostgreSQL database adapter for Python"
+  },
+  {
+    "name": "python3.12-pycparser",
+    "summary": "C parser and AST generator written in Python"
+  },
+  {
+    "name": "python3.12-PyMySQL",
+    "summary": "Pure-Python MySQL client library"
+  },
+  {
+    "name": "python3.12-PyMySQL+rsa",
+    "summary": "Metapackage for python3.12-PyMySQL: rsa extras"
+  },
+  {
+    "name": "python3.12-pyyaml",
+    "summary": "YAML parser and emitter for Python"
+  },
+  {
+    "name": "python3.12-requests",
+    "summary": "HTTP library, written in Python, for human beings"
+  },
+  {
+    "name": "python3.12-scipy",
+    "summary": "Scientific Tools for Python"
+  },
+  {
+    "name": "python3.12-setuptools",
+    "summary": "Easily build and distribute Python packages"
+  },
+  {
+    "name": "python3.12-tkinter",
+    "summary": "A GUI toolkit for Python"
+  },
+  {
+    "name": "python3.12-urllib3",
+    "summary": "HTTP library with thread-safe connection pooling, file post, and more"
+  },
+  {
+    "name": "python3.12-wheel",
+    "summary": "Built-package format for Python"
+  },
+  {
+    "name": "qemu-ga-win",
+    "summary": "Qemus Guest agent for Windows"
+  },
+  {
+    "name": "qemu-guest-agent",
+    "summary": "QEMU guest agent"
+  },
+  {
+    "name": "qemu-img",
+    "summary": "QEMU command line tool for manipulating disk images"
+  },
+  {
+    "name": "qemu-kvm",
+    "summary": "QEMU is a machine emulator and virtualizer"
+  },
+  {
+    "name": "qemu-kvm-audio-pa",
+    "summary": "QEMU PulseAudio audio driver"
+  },
+  {
+    "name": "qemu-kvm-block-blkio",
+    "summary": "QEMU libblkio block drivers"
+  },
+  {
+    "name": "qemu-kvm-block-curl",
+    "summary": "QEMU CURL block driver"
+  },
+  {
+    "name": "qemu-kvm-block-rbd",
+    "summary": "QEMU Ceph/RBD block driver"
+  },
+  {
+    "name": "qemu-kvm-common",
+    "summary": "QEMU common files needed by all QEMU targets"
+  },
+  {
+    "name": "qemu-kvm-core",
+    "summary": "qemu-kvm core components"
+  },
+  {
+    "name": "qemu-kvm-device-display-virtio-gpu",
+    "summary": "QEMU virtio-gpu display device"
+  },
+  {
+    "name": "qemu-kvm-device-display-virtio-gpu-gl",
+    "summary": "QEMU virtio-gpu-gl display device"
+  },
+  {
+    "name": "qemu-kvm-device-display-virtio-gpu-pci",
+    "summary": "QEMU virtio-gpu-pci display device"
+  },
+  {
+    "name": "qemu-kvm-device-display-virtio-gpu-pci-gl",
+    "summary": "QEMU virtio-gpu-pci-gl display device"
+  },
+  {
+    "name": "qemu-kvm-device-usb-host",
+    "summary": "QEMU usb host device"
+  },
+  {
+    "name": "qemu-kvm-device-usb-redirect",
+    "summary": "QEMU usbredir support"
+  },
+  {
+    "name": "qemu-kvm-docs",
+    "summary": "qemu-kvm documentation"
+  },
+  {
+    "name": "qemu-kvm-tools",
+    "summary": "qemu-kvm support tools"
+  },
+  {
+    "name": "qemu-pr-helper",
+    "summary": "qemu-pr-helper utility for qemu-kvm"
+  },
+  {
+    "name": "qgnomeplatform",
+    "summary": "Qt Platform Theme aimed to accommodate Gnome settings"
+  },
+  {
+    "name": "qpdf-libs",
+    "summary": "QPDF library for transforming PDF files"
+  },
+  {
+    "name": "qt5",
+    "summary": "Qt5 meta package"
+  },
+  {
+    "name": "qt5-assistant",
+    "summary": "Documentation browser for Qt5"
+  },
+  {
+    "name": "qt5-designer",
+    "summary": "Design GUIs for Qt5 applications"
+  },
+  {
+    "name": "qt5-doc",
+    "summary": "Qt5 - Complete documentation"
+  },
+  {
+    "name": "qt5-doctools",
+    "summary": "Qt5 doc tools package"
+  },
+  {
+    "name": "qt5-linguist",
+    "summary": "Qt5 Linguist Tools"
+  },
+  {
+    "name": "qt5-qdbusviewer",
+    "summary": "D-Bus debugger and viewer"
+  },
+  {
+    "name": "qt5-qt3d",
+    "summary": "Qt5 - Qt3D QML bindings and C++ APIs"
+  },
+  {
+    "name": "qt5-qt3d-devel",
+    "summary": "Development files for qt5-qt3d"
+  },
+  {
+    "name": "qt5-qt3d-doc",
+    "summary": "Documentation for qt3d"
+  },
+  {
+    "name": "qt5-qt3d-examples",
+    "summary": "Programming examples for qt5-qt3d"
+  },
+  {
+    "name": "qt5-qtbase",
+    "summary": "Qt5 - QtBase components"
+  },
+  {
+    "name": "qt5-qtbase-common",
+    "summary": "Common files for Qt5"
+  },
+  {
+    "name": "qt5-qtbase-devel",
+    "summary": "Development files for qt5-qtbase"
+  },
+  {
+    "name": "qt5-qtbase-doc",
+    "summary": "Documentation for qtbase"
+  },
+  {
+    "name": "qt5-qtbase-examples",
+    "summary": "Programming examples for qt5-qtbase"
+  },
+  {
+    "name": "qt5-qtbase-gui",
+    "summary": "Qt5 GUI-related libraries"
+  },
+  {
+    "name": "qt5-qtbase-mysql",
+    "summary": "MySQL driver for Qt5's SQL classes"
+  },
+  {
+    "name": "qt5-qtbase-odbc",
+    "summary": "ODBC driver for Qt5's SQL classes"
+  },
+  {
+    "name": "qt5-qtbase-postgresql",
+    "summary": "PostgreSQL driver for Qt5's SQL classes"
+  },
+  {
+    "name": "qt5-qtbase-private-devel",
+    "summary": "Development files for qt5-qtbase private APIs"
+  },
+  {
+    "name": "qt5-qtcharts-doc",
+    "summary": "Documentation for qtcharts"
+  },
+  {
+    "name": "qt5-qtconnectivity",
+    "summary": "Qt5 - Connectivity components"
+  },
+  {
+    "name": "qt5-qtconnectivity-devel",
+    "summary": "Development files for qt5-qtconnectivity"
+  },
+  {
+    "name": "qt5-qtconnectivity-doc",
+    "summary": "Documentation for qtconnectivity"
+  },
+  {
+    "name": "qt5-qtconnectivity-examples",
+    "summary": "Programming examples for qt5-qtconnectivity"
+  },
+  {
+    "name": "qt5-qtdatavis3d-doc",
+    "summary": "Documentation for qtdatavis3d"
+  },
+  {
+    "name": "qt5-qtdeclarative",
+    "summary": "Qt5 - QtDeclarative component"
+  },
+  {
+    "name": "qt5-qtdeclarative-devel",
+    "summary": "Development files for qt5-qtdeclarative"
+  },
+  {
+    "name": "qt5-qtdeclarative-doc",
+    "summary": "Documentation for qtdeclarative"
+  },
+  {
+    "name": "qt5-qtdeclarative-examples",
+    "summary": "Programming examples for qt5-qtdeclarative"
+  },
+  {
+    "name": "qt5-qtdoc",
+    "summary": "Main Qt5 Reference Documentation"
+  },
+  {
+    "name": "qt5-qtgamepad-doc",
+    "summary": "Documentation for qtgamepad"
+  },
+  {
+    "name": "qt5-qtgraphicaleffects",
+    "summary": "Qt5 - QtGraphicalEffects component"
+  },
+  {
+    "name": "qt5-qtgraphicaleffects-doc",
+    "summary": "Documentation for qtgraphicaleffects"
+  },
+  {
+    "name": "qt5-qtimageformats",
+    "summary": "Qt5 - QtImageFormats component"
+  },
+  {
+    "name": "qt5-qtimageformats-doc",
+    "summary": "Documentation for qtimageformats"
+  },
+  {
+    "name": "qt5-qtlocation",
+    "summary": "Qt5 - Location component"
+  },
+  {
+    "name": "qt5-qtlocation-devel",
+    "summary": "Development files for qt5-qtlocation"
+  },
+  {
+    "name": "qt5-qtlocation-doc",
+    "summary": "Documentation for qtlocation"
+  },
+  {
+    "name": "qt5-qtlocation-examples",
+    "summary": "Programming examples for qt5-qtlocation"
+  },
+  {
+    "name": "qt5-qtmultimedia",
+    "summary": "Qt5 - Multimedia support"
+  },
+  {
+    "name": "qt5-qtmultimedia-devel",
+    "summary": "Development files for qt5-qtmultimedia"
+  },
+  {
+    "name": "qt5-qtmultimedia-doc",
+    "summary": "Documentation for qtmultimedia"
+  },
+  {
+    "name": "qt5-qtmultimedia-examples",
+    "summary": "Programming examples for qt5-qtmultimedia"
+  },
+  {
+    "name": "qt5-qtpurchasing-doc",
+    "summary": "Documentation for qtpurchasing"
+  },
+  {
+    "name": "qt5-qtquickcontrols",
+    "summary": "Qt5 - module with set of QtQuick controls"
+  },
+  {
+    "name": "qt5-qtquickcontrols-doc",
+    "summary": "Documentation for qtquickcontrols"
+  },
+  {
+    "name": "qt5-qtquickcontrols-examples",
+    "summary": "Programming examples for qt5-qtquickcontrols"
+  },
+  {
+    "name": "qt5-qtquickcontrols2",
+    "summary": "Qt5 - module with set of QtQuick controls for embedded"
+  },
+  {
+    "name": "qt5-qtquickcontrols2-devel",
+    "summary": "Development files for qt5-qtquickcontrols2"
+  },
+  {
+    "name": "qt5-qtquickcontrols2-doc",
+    "summary": "Documentation for qtquickcontrols2"
+  },
+  {
+    "name": "qt5-qtquickcontrols2-examples",
+    "summary": "Examples for qt5-qtquickcontrols2"
+  },
+  {
+    "name": "qt5-qtremoteobjects-doc",
+    "summary": "Documentation for qtremoteobjects"
+  },
+  {
+    "name": "qt5-qtscript",
+    "summary": "Qt5 - QtScript component"
+  },
+  {
+    "name": "qt5-qtscript-devel",
+    "summary": "Development files for qt5-qtscript"
+  },
+  {
+    "name": "qt5-qtscript-doc",
+    "summary": "Documentation for qtscript"
+  },
+  {
+    "name": "qt5-qtscript-examples",
+    "summary": "Programming examples for qt5-qtscript"
+  },
+  {
+    "name": "qt5-qtscxml-doc",
+    "summary": "Documentation for qtscxml"
+  },
+  {
+    "name": "qt5-qtsensors",
+    "summary": "Qt5 - Sensors component"
+  },
+  {
+    "name": "qt5-qtsensors-devel",
+    "summary": "Development files for qt5-qtsensors"
+  },
+  {
+    "name": "qt5-qtsensors-doc",
+    "summary": "Documentation for qtsensors"
+  },
+  {
+    "name": "qt5-qtsensors-examples",
+    "summary": "Programming examples for qt5-qtsensors"
+  },
+  {
+    "name": "qt5-qtserialbus",
+    "summary": "Qt5 - SerialBus component"
+  },
+  {
+    "name": "qt5-qtserialbus-devel",
+    "summary": "Development files for qt5-qtserialbus"
+  },
+  {
+    "name": "qt5-qtserialbus-doc",
+    "summary": "Documentation for qtserialbus"
+  },
+  {
+    "name": "qt5-qtserialbus-examples",
+    "summary": "Programming examples for qt5-qtserialbus"
+  },
+  {
+    "name": "qt5-qtserialport",
+    "summary": "Qt5 - SerialPort component"
+  },
+  {
+    "name": "qt5-qtserialport-devel",
+    "summary": "Development files for qt5-qtserialport"
+  },
+  {
+    "name": "qt5-qtserialport-doc",
+    "summary": "Documentation for qtserialport"
+  },
+  {
+    "name": "qt5-qtserialport-examples",
+    "summary": "Programming examples for qt5-qtserialport"
+  },
+  {
+    "name": "qt5-qtspeech-doc",
+    "summary": "Documentation for qtspeech"
+  },
+  {
+    "name": "qt5-qtsvg",
+    "summary": "Qt5 - Support for rendering and displaying SVG"
+  },
+  {
+    "name": "qt5-qtsvg-devel",
+    "summary": "Development files for qt5-qtsvg"
+  },
+  {
+    "name": "qt5-qtsvg-doc",
+    "summary": "Documentation for qtsvg"
+  },
+  {
+    "name": "qt5-qtsvg-examples",
+    "summary": "Programming examples for qt5-qtsvg"
+  },
+  {
+    "name": "qt5-qttools",
+    "summary": "Qt5 - QtTool components"
+  },
+  {
+    "name": "qt5-qttools-common",
+    "summary": "Common files for qt5-qttools"
+  },
+  {
+    "name": "qt5-qttools-devel",
+    "summary": "Development files for qt5-qttools"
+  },
+  {
+    "name": "qt5-qttools-doc",
+    "summary": "Documentation for qttools"
+  },
+  {
+    "name": "qt5-qttools-examples",
+    "summary": "Programming examples for qt5-qttools"
+  },
+  {
+    "name": "qt5-qttools-libs-designer",
+    "summary": "Qt5 Designer runtime library"
+  },
+  {
+    "name": "qt5-qttools-libs-designercomponents",
+    "summary": "Qt5 Designer Components runtime library"
+  },
+  {
+    "name": "qt5-qttools-libs-help",
+    "summary": "Qt5 Help runtime library"
+  },
+  {
+    "name": "qt5-qttranslations",
+    "summary": "Qt5 - QtTranslations module"
+  },
+  {
+    "name": "qt5-qtvirtualkeyboard-doc",
+    "summary": "Documentation for qtvirtualkeyboard"
+  },
+  {
+    "name": "qt5-qtwayland",
+    "summary": "Qt5 - Wayland platform support and QtCompositor module"
+  },
+  {
+    "name": "qt5-qtwayland-devel",
+    "summary": "Development files for qt5-qtwayland"
+  },
+  {
+    "name": "qt5-qtwayland-doc",
+    "summary": "Documentation for qtwayland"
+  },
+  {
+    "name": "qt5-qtwayland-examples",
+    "summary": "Programming examples for qt5-qtwayland"
+  },
+  {
+    "name": "qt5-qtwebchannel",
+    "summary": "Qt5 - WebChannel component"
+  },
+  {
+    "name": "qt5-qtwebchannel-devel",
+    "summary": "Development files for qt5-qtwebchannel"
+  },
+  {
+    "name": "qt5-qtwebchannel-doc",
+    "summary": "Documentation for qtwebchannel"
+  },
+  {
+    "name": "qt5-qtwebchannel-examples",
+    "summary": "Programming examples for qt5-qtwebchannel"
+  },
+  {
+    "name": "qt5-qtwebsockets",
+    "summary": "Qt5 - WebSockets component"
+  },
+  {
+    "name": "qt5-qtwebsockets-devel",
+    "summary": "Development files for qt5-qtwebsockets"
+  },
+  {
+    "name": "qt5-qtwebsockets-doc",
+    "summary": "Documentation for qtwebsockets"
+  },
+  {
+    "name": "qt5-qtwebsockets-examples",
+    "summary": "Programming examples for qt5-qtwebsockets"
+  },
+  {
+    "name": "qt5-qtwebview-doc",
+    "summary": "Documentation for qtwebview"
+  },
+  {
+    "name": "qt5-qtx11extras",
+    "summary": "Qt5 - X11 support library"
+  },
+  {
+    "name": "qt5-qtx11extras-devel",
+    "summary": "Development files for qt5-qtx11extras"
+  },
+  {
+    "name": "qt5-qtx11extras-doc",
+    "summary": "Documentation for qtx11extras"
+  },
+  {
+    "name": "qt5-qtxmlpatterns",
+    "summary": "Qt5 - QtXmlPatterns component"
+  },
+  {
+    "name": "qt5-qtxmlpatterns-devel",
+    "summary": "Development files for qt5-qtxmlpatterns"
+  },
+  {
+    "name": "qt5-qtxmlpatterns-doc",
+    "summary": "Documentation for qtxmlpatterns"
+  },
+  {
+    "name": "qt5-qtxmlpatterns-examples",
+    "summary": "Programming examples for qt5-qtxmlpatterns"
+  },
+  {
+    "name": "qt5-rpm-macros",
+    "summary": "RPM macros for building Qt5 and KDE Frameworks 5 packages"
+  },
+  {
+    "name": "qt5-srpm-macros",
+    "summary": "RPM macros for source Qt5 packages"
+  },
+  {
+    "name": "quota-doc",
+    "summary": "Additional documentation for disk quotas"
+  },
+  {
+    "name": "quota-nld",
+    "summary": "quota_nld daemon"
+  },
+  {
+    "name": "quota-rpc",
+    "summary": "RPC quota daemon"
+  },
+  {
+    "name": "quota-warnquota",
+    "summary": "Send e-mail to users over quota"
+  },
+  {
+    "name": "radvd",
+    "summary": "A Router Advertisement daemon"
+  },
+  {
+    "name": "raptor2",
+    "summary": "RDF Parser Toolkit for Redland"
+  },
+  {
+    "name": "rasdaemon",
+    "summary": "Utility to receive RAS error tracings"
+  },
+  {
+    "name": "rasqal",
+    "summary": "RDF Query Library"
+  },
+  {
+    "name": "rdma-core-devel",
+    "summary": "RDMA core development libraries and headers"
+  },
+  {
+    "name": "readline-devel",
+    "summary": "Files needed to develop programs which use the readline library"
+  },
+  {
+    "name": "realtime-tests",
+    "summary": "Programs that test various rt-features"
+  },
+  {
+    "name": "redfish-finder",
+    "summary": "Utility for parsing SMBIOS information and configuring canonical BMC access"
+  },
+  {
+    "name": "redhat-backgrounds",
+    "summary": "Red Hat-related desktop backgrounds"
+  },
+  {
+    "name": "redhat-cloud-client-configuration",
+    "summary": "Red Hat cloud client configuration"
+  },
+  {
+    "name": "redhat-cloud-client-configuration-cdn",
+    "summary": "Red Hat cloud client configuration - CDN"
+  },
+  {
+    "name": "redhat-display-fonts",
+    "summary": "Red Hat Display fonts"
+  },
+  {
+    "name": "redhat-indexhtml",
+    "summary": "Browser default start page for Red Hat Enterprise Linux"
+  },
+  {
+    "name": "redhat-logos",
+    "summary": "Red Hat-related icons and pictures"
+  },
+  {
+    "name": "redhat-logos-httpd",
+    "summary": "Red Hat-related icons and pictures used by httpd"
+  },
+  {
+    "name": "redhat-logos-ipa",
+    "summary": "Red Hat-related icons and pictures used by ipa"
+  },
+  {
+    "name": "redhat-mono-fonts",
+    "summary": "Red Hat Mono fonts"
+  },
+  {
+    "name": "redhat-rpm-config",
+    "summary": "Red Hat specific rpm configuration files"
+  },
+  {
+    "name": "redhat-text-fonts",
+    "summary": "Red Hat Text fonts"
+  },
+  {
+    "name": "redis",
+    "summary": "A persistent key-value database"
+  },
+  {
+    "name": "redis-devel",
+    "summary": "Development header for Redis module development"
+  },
+  {
+    "name": "redis-doc",
+    "summary": "Documentation for Redis including man pages"
+  },
+  {
+    "name": "redland",
+    "summary": "RDF Application Framework"
+  },
+  {
+    "name": "regexp",
+    "summary": "Simple regular expressions API"
+  },
+  {
+    "name": "rest",
+    "summary": "A library for access to RESTful web services"
+  },
+  {
+    "name": "rhc",
+    "summary": "rhc connects the system to Red Hat hosted services"
+  },
+  {
+    "name": "rhc-worker-playbook",
+    "summary": "Python worker for Red Hat connector that launches Ansible Runner"
+  },
+  {
+    "name": "rhel-system-roles",
+    "summary": "Set of interfaces for unified system management"
+  },
+  {
+    "name": "rig",
+    "summary": "Monitor a system for events and trigger specific actions"
+  },
+  {
+    "name": "rls",
+    "summary": "Rust Language Server for IDE integration"
+  },
+  {
+    "name": "rpcgen",
+    "summary": "RPC protocol compiler"
+  },
+  {
+    "name": "rpm-apidocs",
+    "summary": "API documentation for RPM libraries"
+  },
+  {
+    "name": "rpm-build",
+    "summary": "Scripts and executable programs used to build packages"
+  },
+  {
+    "name": "rpm-cron",
+    "summary": "Create daily logs of installed packages."
+  },
+  {
+    "name": "rpm-devel",
+    "summary": "Development files for manipulating RPM packages"
+  },
+  {
+    "name": "rpm-mpi-hooks",
+    "summary": "RPM dependency generator hooks for MPI packages"
+  },
+  {
+    "name": "rpm-ostree",
+    "summary": "Hybrid image/package system"
+  },
+  {
+    "name": "rpm-ostree-libs",
+    "summary": "Shared library for rpm-ostree"
+  },
+  {
+    "name": "rpm-plugin-fapolicyd",
+    "summary": "Rpm plugin for fapolicyd functionality"
+  },
+  {
+    "name": "rpm-plugin-ima",
+    "summary": "Rpm plugin ima file signatures"
+  },
+  {
+    "name": "rpm-plugin-syslog",
+    "summary": "Rpm plugin for syslog functionality"
+  },
+  {
+    "name": "rpm-plugin-systemd-inhibit",
+    "summary": "Rpm plugin for systemd inhibit functionality"
+  },
+  {
+    "name": "rpmdevtools",
+    "summary": "RPM Development Tools"
+  },
+  {
+    "name": "rpmlint",
+    "summary": "Tool for checking common errors in RPM packages"
+  },
+  {
+    "name": "rrdtool",
+    "summary": "Round Robin Database Tool to store and display time-series data"
+  },
+  {
+    "name": "rrdtool-perl",
+    "summary": "Perl RRDtool bindings"
+  },
+  {
+    "name": "rshim",
+    "summary": "User-space driver for Mellanox BlueField SoC"
+  },
+  {
+    "name": "rsync-daemon",
+    "summary": "Service for anonymous access to rsync"
+  },
+  {
+    "name": "rsync-rrsync",
+    "summary": "A script to setup restricted rsync users via ssh logins"
+  },
+  {
+    "name": "rsyslog",
+    "summary": "Enhanced system logging and kernel message trapping daemon"
+  },
+  {
+    "name": "rsyslog-crypto",
+    "summary": "Encryption support"
+  },
+  {
+    "name": "rsyslog-doc",
+    "summary": "HTML documentation for rsyslog"
+  },
+  {
+    "name": "rsyslog-elasticsearch",
+    "summary": "ElasticSearch output module for rsyslog"
+  },
+  {
+    "name": "rsyslog-gnutls",
+    "summary": "TLS protocol support for rsyslog via GnuTLS library"
+  },
+  {
+    "name": "rsyslog-gssapi",
+    "summary": "GSSAPI authentication and encryption support for rsyslog"
+  },
+  {
+    "name": "rsyslog-kafka",
+    "summary": "Provides the omkafka module"
+  },
+  {
+    "name": "rsyslog-logrotate",
+    "summary": "Log rotation for rsyslog"
+  },
+  {
+    "name": "rsyslog-mmaudit",
+    "summary": "Message modification module supporting Linux audit format"
+  },
+  {
+    "name": "rsyslog-mmfields",
+    "summary": "Fields extraction module"
+  },
+  {
+    "name": "rsyslog-mmjsonparse",
+    "summary": "JSON enhanced logging support"
+  },
+  {
+    "name": "rsyslog-mmkubernetes",
+    "summary": "Provides the mmkubernetes module"
+  },
+  {
+    "name": "rsyslog-mmnormalize",
+    "summary": "Log normalization support for rsyslog"
+  },
+  {
+    "name": "rsyslog-mmsnmptrapd",
+    "summary": "Message modification module for snmptrapd generated messages"
+  },
+  {
+    "name": "rsyslog-mysql",
+    "summary": "MySQL support for rsyslog"
+  },
+  {
+    "name": "rsyslog-omamqp1",
+    "summary": "Provides the omamqp1 module"
+  },
+  {
+    "name": "rsyslog-openssl",
+    "summary": "TLS protocol support for rsyslog via OpenSSL library"
+  },
+  {
+    "name": "rsyslog-pgsql",
+    "summary": "PostgresSQL support for rsyslog"
+  },
+  {
+    "name": "rsyslog-relp",
+    "summary": "RELP protocol support for rsyslog"
+  },
+  {
+    "name": "rsyslog-snmp",
+    "summary": "SNMP protocol support for rsyslog"
+  },
+  {
+    "name": "rsyslog-udpspoof",
+    "summary": "Provides the omudpspoof module"
+  },
+  {
+    "name": "rtkit",
+    "summary": "Realtime Policy and Watchdog Daemon"
+  },
+  {
+    "name": "rtla",
+    "summary": "Real-Time Linux Analysis tools"
+  },
+  {
+    "name": "ruby",
+    "summary": "An interpreter of object-oriented scripting language"
+  },
+  {
+    "name": "ruby-default-gems",
+    "summary": "Default gems which are part of Ruby StdLib"
+  },
+  {
+    "name": "ruby-devel",
+    "summary": "A Ruby development environment"
+  },
+  {
+    "name": "ruby-libs",
+    "summary": "Libraries necessary to run Ruby"
+  },
+  {
+    "name": "rubygem-bigdecimal",
+    "summary": "BigDecimal provides arbitrary-precision floating point decimal arithmetic"
+  },
+  {
+    "name": "rubygem-bundler",
+    "summary": "Library and utilities to manage a Ruby application's gem dependencies"
+  },
+  {
+    "name": "rubygem-io-console",
+    "summary": "IO/Console is a simple console utilizing library"
+  },
+  {
+    "name": "rubygem-irb",
+    "summary": "The Interactive Ruby"
+  },
+  {
+    "name": "rubygem-json",
+    "summary": "This is a JSON implementation as a Ruby extension in C"
+  },
+  {
+    "name": "rubygem-minitest",
+    "summary": "Minitest provides a complete suite of testing facilities"
+  },
+  {
+    "name": "rubygem-mysql2",
+    "summary": "A simple, fast Mysql library for Ruby, binding to libmysql"
+  },
+  {
+    "name": "rubygem-pg",
+    "summary": "A Ruby interface to the PostgreSQL RDBMS"
+  },
+  {
+    "name": "rubygem-power_assert",
+    "summary": "Power Assert for Ruby"
+  },
+  {
+    "name": "rubygem-psych",
+    "summary": "A libyaml wrapper for Ruby"
+  },
+  {
+    "name": "rubygem-rake",
+    "summary": "Ruby based make-like utility"
+  },
+  {
+    "name": "rubygem-rbs",
+    "summary": "Type signature for Ruby"
+  },
+  {
+    "name": "rubygem-rdoc",
+    "summary": "A tool to generate HTML and command-line documentation for Ruby projects"
+  },
+  {
+    "name": "rubygem-rexml",
+    "summary": "An XML toolkit for Ruby"
+  },
+  {
+    "name": "rubygem-rss",
+    "summary": "Family of libraries that support various formats of XML \"feeds\""
+  },
+  {
+    "name": "rubygem-test-unit",
+    "summary": "An xUnit family unit testing framework for Ruby"
+  },
+  {
+    "name": "rubygem-typeprof",
+    "summary": "TypeProf is a type analysis tool for Ruby code based on abstract interpretation"
+  },
+  {
+    "name": "rubygems",
+    "summary": "The Ruby standard for packaging ruby libraries"
+  },
+  {
+    "name": "rubygems-devel",
+    "summary": "Macros and development tools for packaging RubyGems"
+  },
+  {
+    "name": "runc",
+    "summary": "CLI for running Open Containers"
+  },
+  {
+    "name": "rust",
+    "summary": "The Rust Programming Language"
+  },
+  {
+    "name": "rust-analysis",
+    "summary": "Compiler analysis data for the Rust standard library"
+  },
+  {
+    "name": "rust-analyzer",
+    "summary": "Rust implementation of the Language Server Protocol"
+  },
+  {
+    "name": "rust-debugger-common",
+    "summary": "Common debugger pretty printers for Rust"
+  },
+  {
+    "name": "rust-doc",
+    "summary": "Documentation for Rust"
+  },
+  {
+    "name": "rust-gdb",
+    "summary": "GDB pretty printers for Rust"
+  },
+  {
+    "name": "rust-lldb",
+    "summary": "LLDB pretty printers for Rust"
+  },
+  {
+    "name": "rust-src",
+    "summary": "Sources for the Rust standard library"
+  },
+  {
+    "name": "rust-srpm-macros",
+    "summary": "RPM macros for building Rust source packages"
+  },
+  {
+    "name": "rust-std-static",
+    "summary": "Standard library for Rust"
+  },
+  {
+    "name": "rust-std-static-wasm32-unknown-unknown",
+    "summary": "Standard library for Rust wasm32-unknown-unknown"
+  },
+  {
+    "name": "rust-std-static-wasm32-wasi",
+    "summary": "Standard library for Rust wasm32-wasi"
+  },
+  {
+    "name": "rust-std-static-wasm32-wasip1",
+    "summary": "Standard library for Rust wasm32-wasip1"
+  },
+  {
+    "name": "rust-toolset",
+    "summary": "Package that installs rust-toolset"
+  },
+  {
+    "name": "rustfmt",
+    "summary": "Tool to find and fix Rust formatting issues"
+  },
+  {
+    "name": "rv",
+    "summary": "RV: Runtime Verification"
+  },
+  {
+    "name": "s-nail",
+    "summary": "Environment for sending and receiving mail"
+  },
+  {
+    "name": "s390utils",
+    "summary": "Utilities and daemons for IBM z Systems"
+  },
+  {
+    "name": "s390utils-se-data",
+    "summary": "Data for Secure Execution"
+  },
+  {
+    "name": "saab-fonts",
+    "summary": "Free Punjabi Unicode OpenType Serif Font"
+  },
+  {
+    "name": "samba-client",
+    "summary": "Samba client programs"
+  },
+  {
+    "name": "samba-gpupdate",
+    "summary": "Samba GPO support for clients"
+  },
+  {
+    "name": "samba-krb5-printing",
+    "summary": "Samba CUPS backend for printing with Kerberos"
+  },
+  {
+    "name": "samba-vfs-iouring",
+    "summary": "Samba VFS module for io_uring"
+  },
+  {
+    "name": "samba-winbind-clients",
+    "summary": "Samba winbind clients"
+  },
+  {
+    "name": "samba-winbind-krb5-locator",
+    "summary": "Samba winbind krb5 locator"
+  },
+  {
+    "name": "sane-airscan",
+    "summary": "SANE backend for AirScan (eSCL) and WSD document scanners"
+  },
+  {
+    "name": "sane-backends",
+    "summary": "Scanner access software"
+  },
+  {
+    "name": "sane-backends-daemon",
+    "summary": "Scanner network daemon"
+  },
+  {
+    "name": "sane-backends-devel",
+    "summary": "SANE development toolkit"
+  },
+  {
+    "name": "sane-backends-doc",
+    "summary": "SANE backends documentation"
+  },
+  {
+    "name": "sane-backends-drivers-cameras",
+    "summary": "Scanner backend drivers for digital cameras"
+  },
+  {
+    "name": "sane-backends-drivers-scanners",
+    "summary": "SANE backend drivers for scanners"
+  },
+  {
+    "name": "sane-backends-libs",
+    "summary": "SANE libraries"
+  },
+  {
+    "name": "sanlock",
+    "summary": "A shared storage lock manager"
+  },
+  {
+    "name": "sanlock-lib",
+    "summary": "A shared storage lock manager library"
+  },
+  {
+    "name": "satyr",
+    "summary": "Tools to create anonymous, machine-friendly problem reports"
+  },
+  {
+    "name": "sbc",
+    "summary": "Sub Band Codec used by bluetooth A2DP"
+  },
+  {
+    "name": "sbd",
+    "summary": "Storage-based death"
+  },
+  {
+    "name": "sblim-cmpi-base",
+    "summary": "SBLIM CMPI Base Providers"
+  },
+  {
+    "name": "sblim-indication_helper",
+    "summary": "Toolkit for CMPI indication providers"
+  },
+  {
+    "name": "sblim-sfcb",
+    "summary": "Small Footprint CIM Broker"
+  },
+  {
+    "name": "sblim-sfcc",
+    "summary": "Small Footprint CIM Client Library"
+  },
+  {
+    "name": "sblim-sfcCommon",
+    "summary": "Common functions for SBLIM Small Footprint CIM Broker and CIM Client Library."
+  },
+  {
+    "name": "sblim-wbemcli",
+    "summary": "SBLIM WBEM Command Line Interface"
+  },
+  {
+    "name": "scap-security-guide",
+    "summary": "Security guidance and baselines in SCAP formats"
+  },
+  {
+    "name": "scap-security-guide-doc",
+    "summary": "HTML formatted security guides generated from XCCDF benchmarks"
+  },
+  {
+    "name": "scap-workbench",
+    "summary": "Scanning, tailoring, editing and validation tool for SCAP content"
+  },
+  {
+    "name": "scl-utils",
+    "summary": "Utilities for alternative packaging"
+  },
+  {
+    "name": "scl-utils-build",
+    "summary": "RPM build macros for alternative packaging"
+  },
+  {
+    "name": "scrub",
+    "summary": "Disk scrubbing program"
+  },
+  {
+    "name": "sdl12-compat",
+    "summary": "SDL 1.2 runtime compatibility library using SDL 2.0"
+  },
+  {
+    "name": "SDL2",
+    "summary": "Cross-platform multimedia library"
+  },
+  {
+    "name": "SDL2-devel",
+    "summary": "Files needed to develop Simple DirectMedia Layer applications"
+  },
+  {
+    "name": "seahorse",
+    "summary": "A GNOME application for managing encryption keys"
+  },
+  {
+    "name": "selinux-policy-devel",
+    "summary": "SELinux policy development files"
+  },
+  {
+    "name": "sendmail",
+    "summary": "A widely used Mail Transport Agent (MTA)"
+  },
+  {
+    "name": "sendmail-cf",
+    "summary": "The files needed to reconfigure Sendmail"
+  },
+  {
+    "name": "sendmail-doc",
+    "summary": "Documentation about the Sendmail Mail Transport Agent program"
+  },
+  {
+    "name": "setools",
+    "summary": "Policy analysis tools for SELinux"
+  },
+  {
+    "name": "setools-console-analyses",
+    "summary": "Policy analysis command-line tools for SELinux"
+  },
+  {
+    "name": "setools-gui",
+    "summary": "Policy analysis graphical tools for SELinux"
+  },
+  {
+    "name": "setroubleshoot",
+    "summary": "Helps troubleshoot SELinux problems"
+  },
+  {
+    "name": "setroubleshoot-plugins",
+    "summary": "Analysis plugins for use with setroubleshoot"
+  },
+  {
+    "name": "setroubleshoot-server",
+    "summary": "SELinux troubleshoot server"
+  },
+  {
+    "name": "setxkbmap",
+    "summary": "X11 keymap client"
+  },
+  {
+    "name": "sgml-common",
+    "summary": "Common SGML catalog and DTD files"
+  },
+  {
+    "name": "sgpio",
+    "summary": "SGPIO captive backplane tool"
+  },
+  {
+    "name": "shim-unsigned-aarch64",
+    "summary": "First-stage UEFI bootloader"
+  },
+  {
+    "name": "sid",
+    "summary": "Storage Instantiation Daemon (SID)"
+  },
+  {
+    "name": "sid-base-libs",
+    "summary": "Libraries for Storage Instantiation Daemon (SID) base"
+  },
+  {
+    "name": "sid-iface-libs",
+    "summary": "Libraries for Storage Instantiation Daemon (SID) interfaces"
+  },
+  {
+    "name": "sid-log-libs",
+    "summary": "Libraries for Storage Instantiation Daemon (SID) logging"
+  },
+  {
+    "name": "sid-mod-block-blkid",
+    "summary": "Blkid block module for Storage Instantiation Daemon (SID)"
+  },
+  {
+    "name": "sid-mod-block-dm-mpath",
+    "summary": "Device-mapper multipath block module for Storage Instantiation Daemon (SID)"
+  },
+  {
+    "name": "sid-mod-dummies",
+    "summary": "Dummy block and type module for Storage Instantiation Daemon (SID)"
+  },
+  {
+    "name": "sid-resource-libs",
+    "summary": "Libraries for Storage Instantiation Daemon (SID) resources"
+  },
+  {
+    "name": "sid-tools",
+    "summary": "Storage Instantiation Daemon (SID) supporting tools"
+  },
+  {
+    "name": "sil-abyssinica-fonts",
+    "summary": "SIL Abyssinica fonts"
+  },
+  {
+    "name": "sil-nuosu-fonts",
+    "summary": "The Nuosu SIL Font"
+  },
+  {
+    "name": "sil-padauk-fonts",
+    "summary": "A font for Burmese and the Myanmar script"
+  },
+  {
+    "name": "sil-scheherazade-fonts",
+    "summary": "An Arabic script unicode font"
+  },
+  {
+    "name": "sip6",
+    "summary": "SIP - Python/C++ Bindings Generator"
+  },
+  {
+    "name": "sisu",
+    "summary": "Eclipse dependency injection framework"
+  },
+  {
+    "name": "skopeo",
+    "summary": "Inspect container images and repositories on registries"
+  },
+  {
+    "name": "skopeo-tests",
+    "summary": "Tests for skopeo"
+  },
+  {
+    "name": "slang-devel",
+    "summary": "Development files for the S-Lang extension language"
+  },
+  {
+    "name": "slapi-nis",
+    "summary": "NIS Server and Schema Compatibility plugins for Directory Server"
+  },
+  {
+    "name": "slf4j",
+    "summary": "Simple Logging Facade for Java"
+  },
+  {
+    "name": "slf4j-jdk14",
+    "summary": "SLF4J JDK14 Binding"
+  },
+  {
+    "name": "slirp4netns",
+    "summary": "slirp for network namespaces"
+  },
+  {
+    "name": "smc-meera-fonts",
+    "summary": "Open Type Fonts for Malayalam script"
+  },
+  {
+    "name": "smc-rachana-fonts",
+    "summary": "Open Type Fonts for Malayalam script"
+  },
+  {
+    "name": "smc-tools",
+    "summary": "Shared Memory Communication Tools"
+  },
+  {
+    "name": "snapm",
+    "summary": "A set of tools for managing snapshots"
+  },
+  {
+    "name": "snappy-devel",
+    "summary": "Development files for snappy"
+  },
+  {
+    "name": "socat",
+    "summary": "Bidirectional data relay between two data channels ('netcat++')"
+  },
+  {
+    "name": "softhsm",
+    "summary": "Software version of a PKCS#11 Hardware Security Module"
+  },
+  {
+    "name": "sombok",
+    "summary": "Unicode Text Segmentation Package"
+  },
+  {
+    "name": "sound-theme-freedesktop",
+    "summary": "freedesktop.org sound theme"
+  },
+  {
+    "name": "soundtouch",
+    "summary": "Audio Processing library for changing Tempo, Pitch and Playback Rates"
+  },
+  {
+    "name": "source-highlight",
+    "summary": "Produces a document with syntax highlighting"
+  },
+  {
+    "name": "spamassassin",
+    "summary": "Spam filter for email which can be invoked from mail delivery agents"
+  },
+  {
+    "name": "speech-dispatcher",
+    "summary": "To provide a high-level device independent layer for speech synthesis"
+  },
+  {
+    "name": "speech-dispatcher-doc",
+    "summary": "Documentation for speech-dispatcher"
+  },
+  {
+    "name": "speech-dispatcher-espeak-ng",
+    "summary": "Speech Dispatcher espeak-ng module"
+  },
+  {
+    "name": "speech-tools-libs",
+    "summary": "Edinburgh speech tools libraries"
+  },
+  {
+    "name": "speex",
+    "summary": "A voice compression format (codec)"
+  },
+  {
+    "name": "speexdsp",
+    "summary": "A voice compression format (DSP)"
+  },
+  {
+    "name": "spice-vdagent",
+    "summary": "Agent for Spice guests"
+  },
+  {
+    "name": "spirv-tools",
+    "summary": "API and commands for processing SPIR-V modules"
+  },
+  {
+    "name": "spirv-tools-libs",
+    "summary": "Library files for spirv-tools"
+  },
+  {
+    "name": "splix",
+    "summary": "Driver for QPDL/SPL2 printers (Samsung and several Xerox printers)"
+  },
+  {
+    "name": "sqlite",
+    "summary": "Library that implements an embeddable SQL database engine"
+  },
+  {
+    "name": "sqlite-devel",
+    "summary": "Development tools for the sqlite3 embeddable SQL database engine"
+  },
+  {
+    "name": "squid",
+    "summary": "The Squid proxy caching server"
+  },
+  {
+    "name": "sscg",
+    "summary": "Simple SSL certificate generator"
+  },
+  {
+    "name": "ssh-key-dir",
+    "summary": "sshd AuthorizedKeysCommand to read ~/.ssh/authorized_keys.d"
+  },
+  {
+    "name": "sshpass",
+    "summary": "Non-interactive SSH authentication utility"
+  },
+  {
+    "name": "sssd-idp",
+    "summary": "Kerberos plugins and OIDC helper for external identity providers."
+  },
+  {
+    "name": "stalld",
+    "summary": "Daemon that finds starving tasks and gives them a temporary boost"
+  },
+  {
+    "name": "startup-notification",
+    "summary": "Library for tracking application startup"
+  },
+  {
+    "name": "startup-notification-devel",
+    "summary": "Development portions of startup-notification"
+  },
+  {
+    "name": "stix-fonts",
+    "summary": "STIX, a scientific and engineering font family"
+  },
+  {
+    "name": "stratis-cli",
+    "summary": "Command-line tool for interacting with the Stratis daemon"
+  },
+  {
+    "name": "stratisd",
+    "summary": "Daemon that manages block devices to create filesystems"
+  },
+  {
+    "name": "stratisd-dracut",
+    "summary": "Dracut modules for use with stratisd"
+  },
+  {
+    "name": "stratisd-tools",
+    "summary": "Tools that support Stratis operation"
+  },
+  {
+    "name": "stress-ng",
+    "summary": "Stress test a computer system in various ways"
+  },
+  {
+    "name": "subversion",
+    "summary": "A Modern Concurrent Version Control System"
+  },
+  {
+    "name": "subversion-devel",
+    "summary": "Development package for the Subversion libraries"
+  },
+  {
+    "name": "subversion-gnome",
+    "summary": "GNOME Keyring support for Subversion"
+  },
+  {
+    "name": "subversion-libs",
+    "summary": "Libraries for Subversion Version Control system"
+  },
+  {
+    "name": "subversion-perl",
+    "summary": "Perl bindings to the Subversion libraries"
+  },
+  {
+    "name": "subversion-tools",
+    "summary": "Supplementary tools for Subversion"
+  },
+  {
+    "name": "sudo-python-plugin",
+    "summary": "Python plugin for sudo"
+  },
+  {
+    "name": "suitesparse",
+    "summary": "A collection of sparse matrix libraries"
+  },
+  {
+    "name": "supermin",
+    "summary": "Tool for creating supermin appliances"
+  },
+  {
+    "name": "sushi",
+    "summary": "A quick previewer for Nautilus"
+  },
+  {
+    "name": "switcheroo-control",
+    "summary": "D-Bus service to check the availability of dual-GPU"
+  },
+  {
+    "name": "swtpm",
+    "summary": "TPM Emulator"
+  },
+  {
+    "name": "swtpm-libs",
+    "summary": "Private libraries for swtpm TPM emulators"
+  },
+  {
+    "name": "swtpm-tools",
+    "summary": "Tools for the TPM emulator"
+  },
+  {
+    "name": "synce4l",
+    "summary": "SyncE implementation for Linux"
+  },
+  {
+    "name": "sysfsutils",
+    "summary": "Utilities for interfacing with sysfs"
+  },
+  {
+    "name": "syslinux-tftpboot",
+    "summary": "SYSLINUX modules in /tftpboot, available for network booting"
+  },
+  {
+    "name": "sysprof-capture-devel",
+    "summary": "Development files for sysprof-capture static library"
+  },
+  {
+    "name": "sysstat",
+    "summary": "Collection of performance monitoring tools for Linux"
+  },
+  {
+    "name": "system-config-printer-libs",
+    "summary": "Libraries and shared code for printer administration tool"
+  },
+  {
+    "name": "system-config-printer-udev",
+    "summary": "Rules for udev for automatic configuration of USB printers"
+  },
+  {
+    "name": "system-reinstall-bootc",
+    "summary": "Utility to reinstall the current system using bootc"
+  },
+  {
+    "name": "systemd-boot-unsigned",
+    "summary": "UEFI boot manager (unsigned version)"
+  },
+  {
+    "name": "systemd-devel",
+    "summary": "Development headers for systemd"
+  },
+  {
+    "name": "systemd-journal-remote",
+    "summary": "Tools to send journal events over the network"
+  },
+  {
+    "name": "systemd-ukify",
+    "summary": "Tool to build Unified Kernel Images"
+  },
+  {
+    "name": "systemtap",
+    "summary": "Programmable system-wide instrumentation system"
+  },
+  {
+    "name": "systemtap-client",
+    "summary": "Programmable system-wide instrumentation system - client"
+  },
+  {
+    "name": "systemtap-devel",
+    "summary": "Programmable system-wide instrumentation system - development headers, tools"
+  },
+  {
+    "name": "systemtap-exporter",
+    "summary": "Systemtap-prometheus interoperation mechanism"
+  },
+  {
+    "name": "systemtap-initscript",
+    "summary": "Systemtap Initscripts"
+  },
+  {
+    "name": "systemtap-runtime",
+    "summary": "Programmable system-wide instrumentation system - runtime"
+  },
+  {
+    "name": "systemtap-runtime-java",
+    "summary": "Systemtap Java Runtime Support"
+  },
+  {
+    "name": "systemtap-runtime-python3",
+    "summary": "Systemtap Python 3 Runtime Support"
+  },
+  {
+    "name": "systemtap-runtime-virtguest",
+    "summary": "Systemtap Cross-VM Instrumentation - guest"
+  },
+  {
+    "name": "systemtap-runtime-virthost",
+    "summary": "Systemtap Cross-VM Instrumentation - host"
+  },
+  {
+    "name": "systemtap-sdt-devel",
+    "summary": "Static probe support tools"
+  },
+  {
+    "name": "systemtap-sdt-dtrace",
+    "summary": "Static probe support dtrace tool"
+  },
+  {
+    "name": "systemtap-server",
+    "summary": "Instrumentation System Server"
+  },
+  {
+    "name": "taglib",
+    "summary": "Audio Meta-Data Library"
+  },
+  {
+    "name": "tang",
+    "summary": "Network Presence Binding Daemon"
+  },
+  {
+    "name": "target-restore",
+    "summary": "Systemd service for targetcli/rtslib"
+  },
+  {
+    "name": "targetcli",
+    "summary": "An administration shell for storage targets"
+  },
+  {
+    "name": "tbb",
+    "summary": "The Threading Building Blocks library abstracts low-level threading details"
+  },
+  {
+    "name": "tbb-devel",
+    "summary": "The Threading Building Blocks C++ headers and shared development libraries"
+  },
+  {
+    "name": "tbb-doc",
+    "summary": "The Threading Building Blocks documentation"
+  },
+  {
+    "name": "tcl-devel",
+    "summary": "Tcl scripting language development environment"
+  },
+  {
+    "name": "tcl-doc",
+    "summary": "Tcl documentation"
+  },
+  {
+    "name": "tcpdump",
+    "summary": "A network traffic monitoring tool"
+  },
+  {
+    "name": "tcsh",
+    "summary": "An enhanced version of csh, the C shell"
+  },
+  {
+    "name": "tdb-tools",
+    "summary": "Developer tools for the Tdb library"
+  },
+  {
+    "name": "teckit",
+    "summary": "Conversion library and mapping compiler"
+  },
+  {
+    "name": "telnet",
+    "summary": "The client program for the Telnet remote login protocol"
+  },
+  {
+    "name": "telnet-server",
+    "summary": "The server program for the Telnet remote login protocol"
+  },
+  {
+    "name": "tesseract",
+    "summary": "Raw OCR Engine"
+  },
+  {
+    "name": "tesseract-langpack-afr",
+    "summary": "Afrikaans language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-amh",
+    "summary": "Amharic language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ara",
+    "summary": "Arabic language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-asm",
+    "summary": "Assamese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-aze",
+    "summary": "Azerbaijani language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-aze_cyrl",
+    "summary": "Azerbaijani (Cyrillic) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-bel",
+    "summary": "Belarusian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ben",
+    "summary": "Bengali language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-bod",
+    "summary": "Tibetan (Standard) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-bos",
+    "summary": "Bosnian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-bre",
+    "summary": "Breton language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-bul",
+    "summary": "Bulgarian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-cat",
+    "summary": "Catalan language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ceb",
+    "summary": "Cebuano language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ces",
+    "summary": "Czech language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-chi_sim",
+    "summary": "Chinese (Simplified) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-chi_sim_vert",
+    "summary": "Chinese (Simplified, Vertical) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-chi_tra",
+    "summary": "Chinese (Traditional) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-chi_tra_vert",
+    "summary": "Chinese (Traditional, Vertical) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-chr",
+    "summary": "Cherokee language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-cos",
+    "summary": "Corsican language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-cym",
+    "summary": "Welsh language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-dan",
+    "summary": "Danish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-deu",
+    "summary": "German language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-div",
+    "summary": "Dhivehi; Maldivian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-dzo",
+    "summary": "Dzongkha language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ell",
+    "summary": "Greek language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-eng",
+    "summary": "English language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-enm",
+    "summary": "Middle English (1100-1500) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-epo",
+    "summary": "Esperanto language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-est",
+    "summary": "Estonian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-eus",
+    "summary": "Basque language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-fao",
+    "summary": "Faroese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-fas",
+    "summary": "Persian (Farsi) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-fil",
+    "summary": "Filipino; Pilipino language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-fin",
+    "summary": "Finnish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-fra",
+    "summary": "French language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-frk",
+    "summary": "Fraktur language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-frm",
+    "summary": "Middle French (ca. 1400-1600) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-fry",
+    "summary": "Western Frisian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-gla",
+    "summary": "Gaelic; Scottish Gaelic language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-gle",
+    "summary": "Irish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-glg",
+    "summary": "Galician language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-grc",
+    "summary": "Ancient Greek language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-guj",
+    "summary": "Gujarati language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-hat",
+    "summary": "Haitian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-heb",
+    "summary": "Hebrew language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-hin",
+    "summary": "Hindi language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-hrv",
+    "summary": "Croatian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-hun",
+    "summary": "Hungarian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-hye",
+    "summary": "Armenian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-iku",
+    "summary": "Inuktitut language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ind",
+    "summary": "Indonesian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-isl",
+    "summary": "Icelandic language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ita",
+    "summary": "Italian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ita_old",
+    "summary": "Italian (Old) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-jav",
+    "summary": "Javanese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-jpn",
+    "summary": "Japanese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-jpn_vert",
+    "summary": "\"Japanese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kan",
+    "summary": "Kannada language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kat",
+    "summary": "Georgian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kat_old",
+    "summary": "Georgian (Old) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kaz",
+    "summary": "Kazakh language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-khm",
+    "summary": "Khmer language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kir",
+    "summary": "Kyrgyz language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kmr",
+    "summary": "Kurmanji language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kor",
+    "summary": "Korean language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kor_vert",
+    "summary": "\"Korean language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-lao",
+    "summary": "Lao language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-lat",
+    "summary": "Latin language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-lav",
+    "summary": "Latvian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-lit",
+    "summary": "Lithuanian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ltz",
+    "summary": "Luxembourgish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mal",
+    "summary": "Malayalam language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mar",
+    "summary": "Marathi language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mkd",
+    "summary": "Macedonian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mlt",
+    "summary": "Maltese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mon",
+    "summary": "Mongolian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mri",
+    "summary": "Maori language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-msa",
+    "summary": "Malay language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mya",
+    "summary": "Burmese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-nep",
+    "summary": "Nepali language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-nld",
+    "summary": "Dutch language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-nor",
+    "summary": "Norwegian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-oci",
+    "summary": "Occitan language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ori",
+    "summary": "Oriya language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-pan",
+    "summary": "Panjabi language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-pol",
+    "summary": "Polish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-por",
+    "summary": "Portuguese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-pus",
+    "summary": "Pashto language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-que",
+    "summary": "Quechuan language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ron",
+    "summary": "Romanian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-rus",
+    "summary": "Russian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-san",
+    "summary": "Sanskrit language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-sin",
+    "summary": "Sinhala language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-slk",
+    "summary": "Slovakian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-slv",
+    "summary": "Slovenian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-snd",
+    "summary": "Sindhi language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-spa",
+    "summary": "Spanish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-spa_old",
+    "summary": "Spanish (Old) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-sqi",
+    "summary": "Albanian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-srp",
+    "summary": "Serbian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-srp_latn",
+    "summary": "Serbian (Latin) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-sun",
+    "summary": "Sundanese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-swa",
+    "summary": "Swahili language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-swe",
+    "summary": "Swedish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-syr",
+    "summary": "Syriac language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tam",
+    "summary": "Tamil language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tat",
+    "summary": "Tatar language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tel",
+    "summary": "Telugu language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tgk",
+    "summary": "Tajik language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tha",
+    "summary": "Thai language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tir",
+    "summary": "Tigrinya language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ton",
+    "summary": "Tongan language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tur",
+    "summary": "Turkish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-uig",
+    "summary": "Uyghur language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ukr",
+    "summary": "Ukrainian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-urd",
+    "summary": "Urdu language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-uzb",
+    "summary": "Uzbek language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-uzb_cyrl",
+    "summary": "Uzbek (Cyrillic) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-vie",
+    "summary": "Vietnamese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-yid",
+    "summary": "Yiddish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-yor",
+    "summary": "Yoruba language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-tessdata-doc",
+    "summary": "Documentation for tesseract-tessdata"
+  },
+  {
+    "name": "tex-fonts-hebrew",
+    "summary": "Culmus Hebrew fonts support for LaTeX"
+  },
+  {
+    "name": "tex-preview",
+    "summary": "Preview style files for LaTeX"
+  },
+  {
+    "name": "texlive",
+    "summary": "TeX formatting system"
+  },
+  {
+    "name": "texlive-adjustbox",
+    "summary": "adjustbox package"
+  },
+  {
+    "name": "texlive-ae",
+    "summary": "Virtual fonts for T1 encoded CMR-fonts"
+  },
+  {
+    "name": "texlive-algorithms",
+    "summary": "A suite of tools for typesetting algorithms in pseudo-code"
+  },
+  {
+    "name": "texlive-alphalph",
+    "summary": "Convert numbers to letters"
+  },
+  {
+    "name": "texlive-amscls",
+    "summary": "AMS document classes for LaTeX"
+  },
+  {
+    "name": "texlive-amsfonts",
+    "summary": "TeX fonts from the American Mathematical Society"
+  },
+  {
+    "name": "texlive-amsmath",
+    "summary": "AMS mathematical facilities for LaTeX"
+  },
+  {
+    "name": "texlive-anyfontsize",
+    "summary": "Select any font size in LaTeX"
+  },
+  {
+    "name": "texlive-anysize",
+    "summary": "A simple package to set up document margins"
+  },
+  {
+    "name": "texlive-appendix",
+    "summary": "Extra control of appendices"
+  },
+  {
+    "name": "texlive-arabxetex",
+    "summary": "An ArabTeX-like interface for XeLaTeX"
+  },
+  {
+    "name": "texlive-arphic",
+    "summary": "Arphic (Chinese) font packages"
+  },
+  {
+    "name": "texlive-atbegshi",
+    "summary": "Execute stuff at \\shipout time"
+  },
+  {
+    "name": "texlive-attachfile",
+    "summary": "Attach arbitrary files to a PDF document"
+  },
+  {
+    "name": "texlive-attachfile2",
+    "summary": "Attach files into PDF"
+  },
+  {
+    "name": "texlive-atveryend",
+    "summary": "Hooks at the very end of a document"
+  },
+  {
+    "name": "texlive-auxhook",
+    "summary": "Hooks for auxiliary files"
+  },
+  {
+    "name": "texlive-avantgar",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-awesomebox",
+    "summary": "raw admonition blocks in your documents, illustrated with FontAwesome icons"
+  },
+  {
+    "name": "texlive-babel",
+    "summary": "Multilingual support for Plain TeX or LaTeX"
+  },
+  {
+    "name": "texlive-babel-english",
+    "summary": "Babel support for English"
+  },
+  {
+    "name": "texlive-babelbib",
+    "summary": "Multilingual bibliographies"
+  },
+  {
+    "name": "texlive-base",
+    "summary": "TeX Live filesystem, metadata and licenses shipped in text form"
+  },
+  {
+    "name": "texlive-beamer",
+    "summary": "A LaTeX class for producing presentations and slides"
+  },
+  {
+    "name": "texlive-bera",
+    "summary": "Bera fonts"
+  },
+  {
+    "name": "texlive-beton",
+    "summary": "Use Concrete fonts"
+  },
+  {
+    "name": "texlive-bibtex",
+    "summary": "Process bibliographies for LaTeX, etc"
+  },
+  {
+    "name": "texlive-bibtopic",
+    "summary": "Include multiple bibliographies in a document"
+  },
+  {
+    "name": "texlive-bidi",
+    "summary": "Support for bidirectional typesetting in plain TeX and LaTeX"
+  },
+  {
+    "name": "texlive-bigfoot",
+    "summary": "Footnotes for critical editions"
+  },
+  {
+    "name": "texlive-bigintcalc",
+    "summary": "Integer calculations on very large numbers"
+  },
+  {
+    "name": "texlive-bitset",
+    "summary": "Handle bit-vector datatype"
+  },
+  {
+    "name": "texlive-bookman",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-bookmark",
+    "summary": "A new bookmark (outline) organization for hyperref"
+  },
+  {
+    "name": "texlive-booktabs",
+    "summary": "Publication quality tables in LaTeX"
+  },
+  {
+    "name": "texlive-breakurl",
+    "summary": "Line-breakable \\url-like links in hyperref when compiling via dvips/ps2pdf"
+  },
+  {
+    "name": "texlive-breqn",
+    "summary": "Automatic line breaking of displayed equations"
+  },
+  {
+    "name": "texlive-capt-of",
+    "summary": "Captions on more than floats"
+  },
+  {
+    "name": "texlive-caption",
+    "summary": "Customising captions in floating environments"
+  },
+  {
+    "name": "texlive-carlisle",
+    "summary": "David Carlisle's small packages"
+  },
+  {
+    "name": "texlive-catchfile",
+    "summary": "Catch an external file into a macro"
+  },
+  {
+    "name": "texlive-changebar",
+    "summary": "Generate changebars in LaTeX documents"
+  },
+  {
+    "name": "texlive-changepage",
+    "summary": "Margin adjustment and detection of odd/even pages"
+  },
+  {
+    "name": "texlive-charter",
+    "summary": "Charter fonts"
+  },
+  {
+    "name": "texlive-chngcntr",
+    "summary": "Change the resetting of counters"
+  },
+  {
+    "name": "texlive-cite",
+    "summary": "Improved citation handling in LaTeX"
+  },
+  {
+    "name": "texlive-cjk",
+    "summary": "CJK language support"
+  },
+  {
+    "name": "texlive-classpack",
+    "summary": "XML mastering for LaTeX classes and packages"
+  },
+  {
+    "name": "texlive-cm",
+    "summary": "Computer Modern fonts"
+  },
+  {
+    "name": "texlive-cm-lgc",
+    "summary": "Type 1 CM-based fonts for Latin, Greek and Cyrillic"
+  },
+  {
+    "name": "texlive-cm-super",
+    "summary": "CM-Super family of fonts"
+  },
+  {
+    "name": "texlive-cmap",
+    "summary": "cmap package"
+  },
+  {
+    "name": "texlive-cmextra",
+    "summary": "cmextra package"
+  },
+  {
+    "name": "texlive-cns",
+    "summary": "cns package"
+  },
+  {
+    "name": "texlive-collectbox",
+    "summary": "collectbox package"
+  },
+  {
+    "name": "texlive-collection-basic",
+    "summary": "Essential programs and files"
+  },
+  {
+    "name": "texlive-collection-fontsrecommended",
+    "summary": "Recommended fonts"
+  },
+  {
+    "name": "texlive-collection-htmlxml",
+    "summary": "HTML/SGML/XML support"
+  },
+  {
+    "name": "texlive-collection-latex",
+    "summary": "Basic LaTeX packages"
+  },
+  {
+    "name": "texlive-collection-latexrecommended",
+    "summary": "LaTeX recommended packages"
+  },
+  {
+    "name": "texlive-collection-xetex",
+    "summary": "XeTeX packages"
+  },
+  {
+    "name": "texlive-colorprofiles",
+    "summary": "Collection of free ICC profiles"
+  },
+  {
+    "name": "texlive-colortbl",
+    "summary": "Add colour to LaTeX tables"
+  },
+  {
+    "name": "texlive-context",
+    "summary": "The ConTeXt macro package"
+  },
+  {
+    "name": "texlive-courier",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-crop",
+    "summary": "Support for cropmarks"
+  },
+  {
+    "name": "texlive-csquotes",
+    "summary": "Context sensitive quotation facilities"
+  },
+  {
+    "name": "texlive-ctable",
+    "summary": "Easily typeset centered tables"
+  },
+  {
+    "name": "texlive-ctablestack",
+    "summary": "Catcode table stable support"
+  },
+  {
+    "name": "texlive-currfile",
+    "summary": "Provide file name and path of input files"
+  },
+  {
+    "name": "texlive-datetime",
+    "summary": "Change format of \\today with commands for current time"
+  },
+  {
+    "name": "texlive-dehyph",
+    "summary": "German hyphenation patterns for traditional orthography"
+  },
+  {
+    "name": "texlive-dvipdfmx",
+    "summary": "An extended version of dvipdfm"
+  },
+  {
+    "name": "texlive-dvipng",
+    "summary": "A fast DVI to PNG/GIF converter"
+  },
+  {
+    "name": "texlive-dvips",
+    "summary": "A DVI to PostScript driver"
+  },
+  {
+    "name": "texlive-dvisvgm",
+    "summary": "Convert DVI files to Scalable Vector Graphics format (SVG)"
+  },
+  {
+    "name": "texlive-ec",
+    "summary": "Computer modern fonts in T1 and TS1 encodings"
+  },
+  {
+    "name": "texlive-eepic",
+    "summary": "Extensions to epic and the LaTeX drawing tools"
+  },
+  {
+    "name": "texlive-enctex",
+    "summary": "A TeX extension that translates input on its way into TeX"
+  },
+  {
+    "name": "texlive-enumitem",
+    "summary": "Control layout of itemize, enumerate, description"
+  },
+  {
+    "name": "texlive-environ",
+    "summary": "A new interface for environments in LaTeX"
+  },
+  {
+    "name": "texlive-epsf",
+    "summary": "Simple macros for EPS inclusion"
+  },
+  {
+    "name": "texlive-epstopdf",
+    "summary": "Convert EPS to 'encapsulated' PDF using Ghostscript"
+  },
+  {
+    "name": "texlive-epstopdf-pkg",
+    "summary": "Call epstopdf \"on the fly\""
+  },
+  {
+    "name": "texlive-eqparbox",
+    "summary": "Create equal-widthed parboxes"
+  },
+  {
+    "name": "texlive-eso-pic",
+    "summary": "Add picture commands (or backgrounds) to every page"
+  },
+  {
+    "name": "texlive-etex",
+    "summary": "An extended version of TeX, from the NTS project"
+  },
+  {
+    "name": "texlive-etex-pkg",
+    "summary": "E-TeX support package"
+  },
+  {
+    "name": "texlive-etexcmds",
+    "summary": "Avoid name clashes with e-TeX commands"
+  },
+  {
+    "name": "texlive-etoc",
+    "summary": "Completely customisable TOCs"
+  },
+  {
+    "name": "texlive-etoolbox",
+    "summary": "Tool-box for LaTeX programmers using e-TeX"
+  },
+  {
+    "name": "texlive-euenc",
+    "summary": "Unicode font encoding definitions for XeTeX"
+  },
+  {
+    "name": "texlive-euler",
+    "summary": "Use AMS Euler fonts for math"
+  },
+  {
+    "name": "texlive-euro",
+    "summary": "Provide Euro values for national currency amounts"
+  },
+  {
+    "name": "texlive-eurosym",
+    "summary": "MetaFont and macros for Euro sign"
+  },
+  {
+    "name": "texlive-extsizes",
+    "summary": "Extend the standard classes' size options"
+  },
+  {
+    "name": "texlive-fancybox",
+    "summary": "Variants of \\fbox and other games with boxes"
+  },
+  {
+    "name": "texlive-fancyhdr",
+    "summary": "Extensive control of page headers and footers in LaTeX2e"
+  },
+  {
+    "name": "texlive-fancyref",
+    "summary": "A LaTeX package for fancy cross-referencing"
+  },
+  {
+    "name": "texlive-fancyvrb",
+    "summary": "Sophisticated verbatim text"
+  },
+  {
+    "name": "texlive-filecontents",
+    "summary": "Extended filecontents and filecontents* environments"
+  },
+  {
+    "name": "texlive-filehook",
+    "summary": "Hooks for input files"
+  },
+  {
+    "name": "texlive-finstrut",
+    "summary": "Adjust behaviour of the ends of footnotes"
+  },
+  {
+    "name": "texlive-fix2col",
+    "summary": "Fix miscellaneous two column mode features"
+  },
+  {
+    "name": "texlive-fixlatvian",
+    "summary": "Improve Latvian language support in XeLaTeX"
+  },
+  {
+    "name": "texlive-float",
+    "summary": "Improved interface for floating objects"
+  },
+  {
+    "name": "texlive-fmtcount",
+    "summary": "Display the value of a LaTeX counter in a variety of formats"
+  },
+  {
+    "name": "texlive-fncychap",
+    "summary": "Seven predefined chapter heading styles"
+  },
+  {
+    "name": "texlive-fontawesome",
+    "summary": "Font containing web-related icons"
+  },
+  {
+    "name": "texlive-fontbook",
+    "summary": "Generate a font book"
+  },
+  {
+    "name": "texlive-fonts-tlwg",
+    "summary": "Thai fonts for LaTeX from TLWG"
+  },
+  {
+    "name": "texlive-fontspec",
+    "summary": "Advanced font selection in XeLaTeX and LuaLaTeX"
+  },
+  {
+    "name": "texlive-fontware",
+    "summary": "fontware package"
+  },
+  {
+    "name": "texlive-fontwrap",
+    "summary": "Bind fonts to specific unicode blocks"
+  },
+  {
+    "name": "texlive-footmisc",
+    "summary": "A range of footnote options"
+  },
+  {
+    "name": "texlive-footnotehyper",
+    "summary": "hyperref aware footnote.sty"
+  },
+  {
+    "name": "texlive-fp",
+    "summary": "Fixed point arithmetic"
+  },
+  {
+    "name": "texlive-fpl",
+    "summary": "SC and OsF fonts for URW Palladio L"
+  },
+  {
+    "name": "texlive-framed",
+    "summary": "Framed or shaded regions that can break across pages"
+  },
+  {
+    "name": "texlive-garuda-c90",
+    "summary": "TeX support (from CJK) for the garuda font"
+  },
+  {
+    "name": "texlive-geometry",
+    "summary": "Flexible and complete interface to document dimensions"
+  },
+  {
+    "name": "texlive-gettitlestring",
+    "summary": "Clean up title references"
+  },
+  {
+    "name": "texlive-glyphlist",
+    "summary": "glyphlist package"
+  },
+  {
+    "name": "texlive-graphics",
+    "summary": "Standard LaTeX graphics"
+  },
+  {
+    "name": "texlive-graphics-cfg",
+    "summary": "Sample configuration files for LaTeX color and graphics"
+  },
+  {
+    "name": "texlive-graphics-def",
+    "summary": "Colour and graphics option files"
+  },
+  {
+    "name": "texlive-grfext",
+    "summary": "Manipulate the graphics package's list of extensions"
+  },
+  {
+    "name": "texlive-grffile",
+    "summary": "Extended file name support for graphics (legacy package)"
+  },
+  {
+    "name": "texlive-gsftopk",
+    "summary": "Convert \"ghostscript fonts\" to PK files"
+  },
+  {
+    "name": "texlive-hanging",
+    "summary": "Hanging paragraphs"
+  },
+  {
+    "name": "texlive-helvetic",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-hobsub",
+    "summary": "Construct package bundles"
+  },
+  {
+    "name": "texlive-hologo",
+    "summary": "A collection of logos with bookmark support"
+  },
+  {
+    "name": "texlive-hycolor",
+    "summary": "Implements colour for packages hyperref and bookmark"
+  },
+  {
+    "name": "texlive-hyperref",
+    "summary": "Extensive support for hypertext in LaTeX"
+  },
+  {
+    "name": "texlive-hyph-utf8",
+    "summary": "Hyphenation patterns expressed in UTF-8"
+  },
+  {
+    "name": "texlive-hyphen-base",
+    "summary": "hyphen-base package"
+  },
+  {
+    "name": "texlive-hyphenat",
+    "summary": "Disable/enable hypenation"
+  },
+  {
+    "name": "texlive-hyphenex",
+    "summary": "US English hyphenation exceptions file"
+  },
+  {
+    "name": "texlive-ifmtarg",
+    "summary": "If-then-else command for processing potentially empty arguments"
+  },
+  {
+    "name": "texlive-ifoddpage",
+    "summary": "ifoddpage package"
+  },
+  {
+    "name": "texlive-ifplatform",
+    "summary": "Conditionals to test which platform is being used"
+  },
+  {
+    "name": "texlive-iftex",
+    "summary": "Am I running under pdfTeX, XeTeX or LuaTeX?"
+  },
+  {
+    "name": "texlive-import",
+    "summary": "Establish input relative to a directory"
+  },
+  {
+    "name": "texlive-index",
+    "summary": "Extended index for LaTeX including multiple indexes"
+  },
+  {
+    "name": "texlive-infwarerr",
+    "summary": "Complete set of information/warning/error message macros"
+  },
+  {
+    "name": "texlive-intcalc",
+    "summary": "Expandable arithmetic operations with integers"
+  },
+  {
+    "name": "texlive-jadetex",
+    "summary": "Macros supporting Jade DSSSL output"
+  },
+  {
+    "name": "texlive-jknapltx",
+    "summary": "Miscellaneous packages by Joerg Knappen"
+  },
+  {
+    "name": "texlive-kastrup",
+    "summary": "kastrup package"
+  },
+  {
+    "name": "texlive-kerkis",
+    "summary": "Kerkis (Greek) font family"
+  },
+  {
+    "name": "texlive-knuth-lib",
+    "summary": "A small library of MetaFont sources"
+  },
+  {
+    "name": "texlive-knuth-local",
+    "summary": "Knuth's local information"
+  },
+  {
+    "name": "texlive-koma-script",
+    "summary": "A bundle of versatile classes and packages"
+  },
+  {
+    "name": "texlive-kpathsea",
+    "summary": "Path searching library for TeX-related files"
+  },
+  {
+    "name": "texlive-kvdefinekeys",
+    "summary": "Define keys for use in the kvsetkeys package"
+  },
+  {
+    "name": "texlive-kvoptions",
+    "summary": "Key value format for package options"
+  },
+  {
+    "name": "texlive-kvsetkeys",
+    "summary": "Key value parser with default handler support"
+  },
+  {
+    "name": "texlive-l3backend",
+    "summary": "LaTeX3 backend drivers"
+  },
+  {
+    "name": "texlive-l3experimental",
+    "summary": "Experimental LaTeX3 concepts"
+  },
+  {
+    "name": "texlive-l3kernel",
+    "summary": "LaTeX3 programming conventions"
+  },
+  {
+    "name": "texlive-l3packages",
+    "summary": "High-level LaTeX3 concepts"
+  },
+  {
+    "name": "texlive-lastpage",
+    "summary": "Reference last page for Page N of M type footers"
+  },
+  {
+    "name": "texlive-latex",
+    "summary": "A TeX macro package that defines LaTeX"
+  },
+  {
+    "name": "texlive-latex-fonts",
+    "summary": "A collection of fonts used in LaTeX distributions"
+  },
+  {
+    "name": "texlive-latex2man",
+    "summary": "Translate LaTeX-based manual pages into Unix man format"
+  },
+  {
+    "name": "texlive-latexbug",
+    "summary": "Bug-classification for LaTeX related bugs"
+  },
+  {
+    "name": "texlive-latexconfig",
+    "summary": "latexconfig package"
+  },
+  {
+    "name": "texlive-letltxmacro",
+    "summary": "Let assignment for LaTeX macros"
+  },
+  {
+    "name": "texlive-lettrine",
+    "summary": "Typeset dropped capitals"
+  },
+  {
+    "name": "texlive-lib",
+    "summary": "Shared libraries for TeX-related files"
+  },
+  {
+    "name": "texlive-linegoal",
+    "summary": "A \"dimen\" that returns the space left on the line"
+  },
+  {
+    "name": "texlive-lineno",
+    "summary": "Line numbers on paragraphs"
+  },
+  {
+    "name": "texlive-listings",
+    "summary": "Typeset source code listings using LaTeX"
+  },
+  {
+    "name": "texlive-listofitems",
+    "summary": "Grab items in lists using user-specified sep char"
+  },
+  {
+    "name": "texlive-lm",
+    "summary": "Latin modern fonts in outline formats"
+  },
+  {
+    "name": "texlive-lm-math",
+    "summary": "OpenType maths fonts for Latin Modern"
+  },
+  {
+    "name": "texlive-ltabptch",
+    "summary": "Bug fix for longtable"
+  },
+  {
+    "name": "texlive-ltxcmds",
+    "summary": "Some LaTeX kernel commands for general use"
+  },
+  {
+    "name": "texlive-ltxmisc",
+    "summary": "Miscellaneous LaTeX packages, etc"
+  },
+  {
+    "name": "texlive-lua-alt-getopt",
+    "summary": "Process application arguments the same way as getopt_long"
+  },
+  {
+    "name": "texlive-luahbtex",
+    "summary": "LuaTeX with HarfBuzz library for glyph shaping"
+  },
+  {
+    "name": "texlive-lualatex-math",
+    "summary": "Fixes for mathematics-related LuaLaTeX issues"
+  },
+  {
+    "name": "texlive-lualibs",
+    "summary": "Additional Lua functions for LuaTeX macro programmers"
+  },
+  {
+    "name": "texlive-luaotfload",
+    "summary": "OpenType 'loader' for Plain TeX and LaTeX"
+  },
+  {
+    "name": "texlive-luatex",
+    "summary": "The LuaTeX engine"
+  },
+  {
+    "name": "texlive-luatex85",
+    "summary": "pdfTeX aliases for LuaTeX"
+  },
+  {
+    "name": "texlive-luatexbase",
+    "summary": "Basic resource management for LuaTeX code"
+  },
+  {
+    "name": "texlive-lwarp",
+    "summary": "Converts LaTeX to HTML"
+  },
+  {
+    "name": "texlive-makecmds",
+    "summary": "The new \\makecommand command always (re)defines a command"
+  },
+  {
+    "name": "texlive-makeindex",
+    "summary": "Process index output to produce typesettable code"
+  },
+  {
+    "name": "texlive-manfnt-font",
+    "summary": "manfnt-font package"
+  },
+  {
+    "name": "texlive-marginnote",
+    "summary": "Notes in the margin, even where \\marginpar fails"
+  },
+  {
+    "name": "texlive-marvosym",
+    "summary": "Martin Vogel's Symbols (marvosym) font"
+  },
+  {
+    "name": "texlive-mathpazo",
+    "summary": "Fonts to typeset mathematics to match Palatino"
+  },
+  {
+    "name": "texlive-mathspec",
+    "summary": "Specify arbitrary fonts for mathematics in XeTeX"
+  },
+  {
+    "name": "texlive-mathtools",
+    "summary": "Mathematical tools to use with amsmath"
+  },
+  {
+    "name": "texlive-mdwtools",
+    "summary": "Miscellaneous tools by Mark Wooding"
+  },
+  {
+    "name": "texlive-memoir",
+    "summary": "Typeset fiction, non-fiction and mathematical books"
+  },
+  {
+    "name": "texlive-metafont",
+    "summary": "A system for specifying fonts"
+  },
+  {
+    "name": "texlive-metalogo",
+    "summary": "Extended TeX logo macros"
+  },
+  {
+    "name": "texlive-metapost",
+    "summary": "A development of Metafont for creating graphics"
+  },
+  {
+    "name": "texlive-mflogo",
+    "summary": "LaTeX support for MetaFont logo fonts"
+  },
+  {
+    "name": "texlive-mflogo-font",
+    "summary": "Metafont logo font"
+  },
+  {
+    "name": "texlive-mfnfss",
+    "summary": "Packages to typeset oldgerman and pandora fonts in LaTeX"
+  },
+  {
+    "name": "texlive-mfware",
+    "summary": "Supporting tools for use with Metafont"
+  },
+  {
+    "name": "texlive-microtype",
+    "summary": "Subliminal refinements towards typographical perfection"
+  },
+  {
+    "name": "texlive-minitoc",
+    "summary": "Produce a table of contents for each chapter, part or section"
+  },
+  {
+    "name": "texlive-mnsymbol",
+    "summary": "Mathematical symbol font for Adobe MinionPro"
+  },
+  {
+    "name": "texlive-modes",
+    "summary": "A collection of Metafont mode_def's"
+  },
+  {
+    "name": "texlive-mparhack",
+    "summary": "A workaround for a LaTeX bug in marginpars"
+  },
+  {
+    "name": "texlive-mptopdf",
+    "summary": "mpost to PDF, native MetaPost graphics inclusion"
+  },
+  {
+    "name": "texlive-ms",
+    "summary": "Various LaTeX packages by Martin Schroder"
+  },
+  {
+    "name": "texlive-multido",
+    "summary": "A loop facility for Generic TeX"
+  },
+  {
+    "name": "texlive-multirow",
+    "summary": "Create tabular cells spanning multiple rows"
+  },
+  {
+    "name": "texlive-natbib",
+    "summary": "Flexible bibliography support"
+  },
+  {
+    "name": "texlive-ncctools",
+    "summary": "A collection of general packages for LaTeX"
+  },
+  {
+    "name": "texlive-ncntrsbk",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-needspace",
+    "summary": "Insert pagebreak if not enough space"
+  },
+  {
+    "name": "texlive-newfloat",
+    "summary": "Define new floating environments"
+  },
+  {
+    "name": "texlive-newunicodechar",
+    "summary": "Definitions of the meaning of Unicode characters"
+  },
+  {
+    "name": "texlive-norasi-c90",
+    "summary": "TeX support (from CJK) for the norasi font in thailatex"
+  },
+  {
+    "name": "texlive-notoccite",
+    "summary": "Prevent trouble from citations in table of contents, etc"
+  },
+  {
+    "name": "texlive-ntgclass",
+    "summary": "\"European\" versions of standard classes"
+  },
+  {
+    "name": "texlive-oberdiek",
+    "summary": "A bundle of packages submitted by Heiko Oberdiek"
+  },
+  {
+    "name": "texlive-obsolete",
+    "summary": "This package handles obsolete texlive subpackages"
+  },
+  {
+    "name": "texlive-overpic",
+    "summary": "Combine LaTeX commands over included graphics"
+  },
+  {
+    "name": "texlive-palatino",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-paralist",
+    "summary": "Enumerate and itemize within paragraphs"
+  },
+  {
+    "name": "texlive-parallel",
+    "summary": "Typeset parallel texts"
+  },
+  {
+    "name": "texlive-parskip",
+    "summary": "Layout with zero \\parindent, non-zero \\parskip"
+  },
+  {
+    "name": "texlive-passivetex",
+    "summary": "Support package for XML/SGML typesetting"
+  },
+  {
+    "name": "texlive-pdfcolmk",
+    "summary": "Improved colour support under pdfTeX (legacy stub)"
+  },
+  {
+    "name": "texlive-pdfescape",
+    "summary": "Implements pdfTeX's escape features using TeX or e-TeX"
+  },
+  {
+    "name": "texlive-pdflscape",
+    "summary": "Make landscape pages display as landscape"
+  },
+  {
+    "name": "texlive-pdfpages",
+    "summary": "Include PDF documents in LaTeX"
+  },
+  {
+    "name": "texlive-pdftex",
+    "summary": "A TeX extension for direct creation of PDF"
+  },
+  {
+    "name": "texlive-pdftexcmds",
+    "summary": "LuaTeX support for pdfTeX utility functions"
+  },
+  {
+    "name": "texlive-pgf",
+    "summary": "Create PostScript and PDF graphics in TeX"
+  },
+  {
+    "name": "texlive-philokalia",
+    "summary": "A font to typeset the Philokalia Books"
+  },
+  {
+    "name": "texlive-placeins",
+    "summary": "Control float placement"
+  },
+  {
+    "name": "texlive-plain",
+    "summary": "plain package"
+  },
+  {
+    "name": "texlive-polyglossia",
+    "summary": "Modern multilingual typesetting with XeLaTeX"
+  },
+  {
+    "name": "texlive-powerdot",
+    "summary": "A presentation class"
+  },
+  {
+    "name": "texlive-preprint",
+    "summary": "A bundle of packages provided \"as is\""
+  },
+  {
+    "name": "texlive-psfrag",
+    "summary": "Replace strings in encapsulated PostScript figures"
+  },
+  {
+    "name": "texlive-pslatex",
+    "summary": "Use PostScript fonts by default"
+  },
+  {
+    "name": "texlive-psnfss",
+    "summary": "Font support for common PostScript fonts"
+  },
+  {
+    "name": "texlive-pspicture",
+    "summary": "PostScript picture support"
+  },
+  {
+    "name": "texlive-pst-3d",
+    "summary": "A PSTricks package for tilting and other pseudo-3D tricks"
+  },
+  {
+    "name": "texlive-pst-arrow",
+    "summary": "special arrows for PSTricks"
+  },
+  {
+    "name": "texlive-pst-blur",
+    "summary": "PSTricks package for \"blurred\" shadows"
+  },
+  {
+    "name": "texlive-pst-coil",
+    "summary": "A PSTricks package for coils, etc"
+  },
+  {
+    "name": "texlive-pst-eps",
+    "summary": "Create EPS files from PSTricks figures"
+  },
+  {
+    "name": "texlive-pst-fill",
+    "summary": "Fill or tile areas with PSTricks"
+  },
+  {
+    "name": "texlive-pst-grad",
+    "summary": "Filling with colour gradients, using PStricks"
+  },
+  {
+    "name": "texlive-pst-math",
+    "summary": "Enhancement of PostScript math operators to use with pstricks"
+  },
+  {
+    "name": "texlive-pst-node",
+    "summary": "Draw connections using pstricks"
+  },
+  {
+    "name": "texlive-pst-plot",
+    "summary": "Plot data using PSTricks"
+  },
+  {
+    "name": "texlive-pst-slpe",
+    "summary": "Sophisticated colour gradients"
+  },
+  {
+    "name": "texlive-pst-text",
+    "summary": "Text and character manipulation in PSTricks"
+  },
+  {
+    "name": "texlive-pst-tools",
+    "summary": "PStricks support functions"
+  },
+  {
+    "name": "texlive-pst-tree",
+    "summary": "Trees, using pstricks"
+  },
+  {
+    "name": "texlive-pstricks",
+    "summary": "PostScript macros for TeX"
+  },
+  {
+    "name": "texlive-pstricks-add",
+    "summary": "A collection of add-ons and bugfixes for PSTricks"
+  },
+  {
+    "name": "texlive-ptext",
+    "summary": "A 'lipsum' for Persian"
+  },
+  {
+    "name": "texlive-pxfonts",
+    "summary": "Palatino-like fonts in support of mathematics"
+  },
+  {
+    "name": "texlive-qstest",
+    "summary": "Bundle for unit tests and pattern matching"
+  },
+  {
+    "name": "texlive-ragged2e",
+    "summary": "Alternative versions of \"ragged\"-type commands"
+  },
+  {
+    "name": "texlive-rcs",
+    "summary": "Use RCS (revision control system) tags in LaTeX documents"
+  },
+  {
+    "name": "texlive-realscripts",
+    "summary": "Access OpenType subscript and superscript glyphs"
+  },
+  {
+    "name": "texlive-refcount",
+    "summary": "Counter operations with label references"
+  },
+  {
+    "name": "texlive-rerunfilecheck",
+    "summary": "Checksum based rerun checks on auxiliary files"
+  },
+  {
+    "name": "texlive-rsfs",
+    "summary": "Ralph Smith's Formal Script font"
+  },
+  {
+    "name": "texlive-sansmath",
+    "summary": "Maths in a sans font"
+  },
+  {
+    "name": "texlive-sansmathaccent",
+    "summary": "Correct placement of accents in sans-serif maths"
+  },
+  {
+    "name": "texlive-sauerj",
+    "summary": "A bundle of utilities by Jonathan Sauer"
+  },
+  {
+    "name": "texlive-scheme-basic",
+    "summary": "basic scheme (plain and latex)"
+  },
+  {
+    "name": "texlive-section",
+    "summary": "Modifying section commands in LaTeX"
+  },
+  {
+    "name": "texlive-sectsty",
+    "summary": "Control sectional headers"
+  },
+  {
+    "name": "texlive-seminar",
+    "summary": "Make overhead slides"
+  },
+  {
+    "name": "texlive-sepnum",
+    "summary": "Print numbers in a \"friendly\" format"
+  },
+  {
+    "name": "texlive-setspace",
+    "summary": "Set space between lines"
+  },
+  {
+    "name": "texlive-showexpl",
+    "summary": "Typesetting LaTeX source code"
+  },
+  {
+    "name": "texlive-soul",
+    "summary": "Hyphenation for letterspacing, underlining, and more"
+  },
+  {
+    "name": "texlive-stackengine",
+    "summary": "Highly customised stacking of objects, insets, baseline changes, etc"
+  },
+  {
+    "name": "texlive-stmaryrd",
+    "summary": "St Mary Road symbols for theoretical computer science"
+  },
+  {
+    "name": "texlive-stringenc",
+    "summary": "Converting a string between different encodings"
+  },
+  {
+    "name": "texlive-subfig",
+    "summary": "Figures broken into subfigures"
+  },
+  {
+    "name": "texlive-subfigure",
+    "summary": "Deprecated: Figures divided into subfigures"
+  },
+  {
+    "name": "texlive-svn-prov",
+    "summary": "Subversion variants of \\Provides... macros"
+  },
+  {
+    "name": "texlive-symbol",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-t2",
+    "summary": "Support for using T2 encoding"
+  },
+  {
+    "name": "texlive-tabu",
+    "summary": "Flexible LaTeX tabulars"
+  },
+  {
+    "name": "texlive-tabulary",
+    "summary": "Tabular with variable width columns balanced"
+  },
+  {
+    "name": "texlive-tex",
+    "summary": "A sophisticated typesetting engine"
+  },
+  {
+    "name": "texlive-tex-gyre",
+    "summary": "TeX Fonts extending freely available URW fonts"
+  },
+  {
+    "name": "texlive-tex-gyre-math",
+    "summary": "Maths fonts to match tex-gyre text fonts"
+  },
+  {
+    "name": "texlive-tex-ini-files",
+    "summary": "Model TeX format creation files"
+  },
+  {
+    "name": "texlive-tex4ht",
+    "summary": "Convert (La)TeX to HTML/XML"
+  },
+  {
+    "name": "texlive-texlive-common-doc",
+    "summary": "Documentation for texlive-common"
+  },
+  {
+    "name": "texlive-texlive-docindex",
+    "summary": "top-level TeX Live doc.html, etc"
+  },
+  {
+    "name": "texlive-texlive-en",
+    "summary": "TeX Live manual (English)"
+  },
+  {
+    "name": "texlive-texlive-msg-translations",
+    "summary": "translations of the TeX Live installer and TeX Live Manager"
+  },
+  {
+    "name": "texlive-texlive-scripts",
+    "summary": "TeX Live infrastructure programs"
+  },
+  {
+    "name": "texlive-texlive-scripts-extra",
+    "summary": "TeX Live scripts"
+  },
+  {
+    "name": "texlive-texlive.infra",
+    "summary": "basic TeX Live infrastructure"
+  },
+  {
+    "name": "texlive-textcase",
+    "summary": "Case conversion ignoring mathematics, etc"
+  },
+  {
+    "name": "texlive-textpos",
+    "summary": "Place boxes at arbitrary positions on the LaTeX page"
+  },
+  {
+    "name": "texlive-threeparttable",
+    "summary": "Tables with captions and notes all the same width"
+  },
+  {
+    "name": "texlive-thumbpdf",
+    "summary": "Thumbnails for pdfTeX and dvips/ps2pdf"
+  },
+  {
+    "name": "texlive-times",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-tipa",
+    "summary": "Fonts and macros for IPA phonetics characters"
+  },
+  {
+    "name": "texlive-titlesec",
+    "summary": "Select alternative section titles"
+  },
+  {
+    "name": "texlive-titling",
+    "summary": "Control over the typesetting of the \\maketitle command"
+  },
+  {
+    "name": "texlive-tocloft",
+    "summary": "Control table of contents, figures, etc"
+  },
+  {
+    "name": "texlive-tools",
+    "summary": "The LaTeX standard tools bundle"
+  },
+  {
+    "name": "texlive-translator",
+    "summary": "Easy translation of strings in LaTeX"
+  },
+  {
+    "name": "texlive-trimspaces",
+    "summary": "Trim spaces around an argument or within a macro"
+  },
+  {
+    "name": "texlive-txfonts",
+    "summary": "Times-like fonts in support of mathematics"
+  },
+  {
+    "name": "texlive-type1cm",
+    "summary": "Arbitrary size font selection in LaTeX"
+  },
+  {
+    "name": "texlive-typehtml",
+    "summary": "Typeset HTML directly from LaTeX"
+  },
+  {
+    "name": "texlive-ucharcat",
+    "summary": "Implementation of the (new in 2015) XeTeX \\Ucharcat command in lua, for LuaTeX"
+  },
+  {
+    "name": "texlive-ucharclasses",
+    "summary": "Switch fonts in XeTeX according to what is being processed"
+  },
+  {
+    "name": "texlive-ucs",
+    "summary": "Extended UTF-8 input encoding support for LaTeX"
+  },
+  {
+    "name": "texlive-uhc",
+    "summary": "Fonts for the Korean language"
+  },
+  {
+    "name": "texlive-ulem",
+    "summary": "Package for underlining"
+  },
+  {
+    "name": "texlive-underscore",
+    "summary": "Control the behaviour of \"_\" in text"
+  },
+  {
+    "name": "texlive-unicode-data",
+    "summary": "Unicode data and loaders for TeX"
+  },
+  {
+    "name": "texlive-unicode-math",
+    "summary": "Unicode mathematics support for XeTeX and LuaTeX"
+  },
+  {
+    "name": "texlive-uniquecounter",
+    "summary": "Provides unlimited unique counter"
+  },
+  {
+    "name": "texlive-unisugar",
+    "summary": "Define syntactic sugar for Unicode LaTeX"
+  },
+  {
+    "name": "texlive-updmap-map",
+    "summary": "Font maps"
+  },
+  {
+    "name": "texlive-upquote",
+    "summary": "Show \"realistic\" quotes in verbatim"
+  },
+  {
+    "name": "texlive-url",
+    "summary": "Verbatim with URL-sensitive line breaks"
+  },
+  {
+    "name": "texlive-utopia",
+    "summary": "Adobe Utopia fonts"
+  },
+  {
+    "name": "texlive-varwidth",
+    "summary": "A variable-width minipage"
+  },
+  {
+    "name": "texlive-wadalab",
+    "summary": "Wadalab (Japanese) font packages"
+  },
+  {
+    "name": "texlive-was",
+    "summary": "A collection of small packages by Walter Schmidt"
+  },
+  {
+    "name": "texlive-wasy",
+    "summary": "The wasy fonts (Waldi symbol fonts)"
+  },
+  {
+    "name": "texlive-wasy-type1",
+    "summary": "Type 1 versions of wasy fonts"
+  },
+  {
+    "name": "texlive-wasysym",
+    "summary": "LaTeX support file to use the WASY2 fonts"
+  },
+  {
+    "name": "texlive-wrapfig",
+    "summary": "Produces figures which text can flow around"
+  },
+  {
+    "name": "texlive-xcolor",
+    "summary": "Driver-independent color extensions for LaTeX and pdfLaTeX"
+  },
+  {
+    "name": "texlive-xdvi",
+    "summary": "A DVI previewer for the X Window System"
+  },
+  {
+    "name": "texlive-xecjk",
+    "summary": "Support for CJK documents in XeLaTeX"
+  },
+  {
+    "name": "texlive-xecolor",
+    "summary": "Support for color in XeLaTeX"
+  },
+  {
+    "name": "texlive-xecyr",
+    "summary": "Using Cyrillic languages in XeTeX"
+  },
+  {
+    "name": "texlive-xeindex",
+    "summary": "Automatic index generation for XeLaTeX"
+  },
+  {
+    "name": "texlive-xepersian",
+    "summary": "Persian for LaTeX, using XeTeX"
+  },
+  {
+    "name": "texlive-xesearch",
+    "summary": "A string finder for XeTeX"
+  },
+  {
+    "name": "texlive-xetex",
+    "summary": "Unicode and OpenType-enabled TeX engine"
+  },
+  {
+    "name": "texlive-xetex-itrans",
+    "summary": "Itrans input maps for use with XeLaTeX"
+  },
+  {
+    "name": "texlive-xetex-pstricks",
+    "summary": "Running PStricks under XeTeX"
+  },
+  {
+    "name": "texlive-xetex-tibetan",
+    "summary": "XeTeX input maps for Unicode Tibetan"
+  },
+  {
+    "name": "texlive-xetexconfig",
+    "summary": "Configuration files for XeTeX"
+  },
+  {
+    "name": "texlive-xetexfontinfo",
+    "summary": "Report font features in XeTeX"
+  },
+  {
+    "name": "texlive-xifthen",
+    "summary": "Extended conditional commands"
+  },
+  {
+    "name": "texlive-xkeyval",
+    "summary": "Extension of the keyval package"
+  },
+  {
+    "name": "texlive-xltxtra",
+    "summary": "\"Extras\" for LaTeX users of XeTeX"
+  },
+  {
+    "name": "texlive-xmltex",
+    "summary": "Support for parsing XML documents"
+  },
+  {
+    "name": "texlive-xmltexconfig",
+    "summary": "xmltexconfig package"
+  },
+  {
+    "name": "texlive-xstring",
+    "summary": "String manipulation for (La)TeX"
+  },
+  {
+    "name": "texlive-xtab",
+    "summary": "Break tables across pages"
+  },
+  {
+    "name": "texlive-xunicode",
+    "summary": "Generate Unicode characters from accented glyphs"
+  },
+  {
+    "name": "texlive-zapfchan",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-zapfding",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-zref",
+    "summary": "A new reference scheme for LaTeX"
+  },
+  {
+    "name": "tftp",
+    "summary": "The client for the Trivial File Transfer Protocol (TFTP)"
+  },
+  {
+    "name": "tftp-server",
+    "summary": "The server for the Trivial File Transfer Protocol (TFTP)"
+  },
+  {
+    "name": "thai-scalable-fonts-common",
+    "summary": "Common files of thai-scalable-fonts"
+  },
+  {
+    "name": "thai-scalable-garuda-fonts",
+    "summary": "Thai Garuda fonts"
+  },
+  {
+    "name": "thai-scalable-kinnari-fonts",
+    "summary": "Thai Kinnari fonts"
+  },
+  {
+    "name": "thai-scalable-loma-fonts",
+    "summary": "Thai Loma fonts"
+  },
+  {
+    "name": "thai-scalable-norasi-fonts",
+    "summary": "Thai Norasi fonts"
+  },
+  {
+    "name": "thai-scalable-purisa-fonts",
+    "summary": "Thai Purisa fonts"
+  },
+  {
+    "name": "thai-scalable-sawasdee-fonts",
+    "summary": "Thai Sawasdee fonts"
+  },
+  {
+    "name": "thai-scalable-tlwgmono-fonts",
+    "summary": "Thai TlwgMono fonts"
+  },
+  {
+    "name": "thai-scalable-tlwgtypewriter-fonts",
+    "summary": "Thai TlwgTypewriter fonts"
+  },
+  {
+    "name": "thai-scalable-tlwgtypist-fonts",
+    "summary": "Thai TlwgTypist fonts"
+  },
+  {
+    "name": "thai-scalable-tlwgtypo-fonts",
+    "summary": "Thai TlwgTypo fonts"
+  },
+  {
+    "name": "thai-scalable-umpush-fonts",
+    "summary": "Thai Umpush fonts"
+  },
+  {
+    "name": "thai-scalable-waree-fonts",
+    "summary": "Thai Waree fonts"
+  },
+  {
+    "name": "theora-tools",
+    "summary": "Command line tools for Theora videos"
+  },
+  {
+    "name": "thunderbird",
+    "summary": "Mozilla Thunderbird mail/newsgroup client"
+  },
+  {
+    "name": "tigervnc",
+    "summary": "A TigerVNC remote display system"
+  },
+  {
+    "name": "tigervnc-icons",
+    "summary": "Icons for TigerVNC viewer"
+  },
+  {
+    "name": "tigervnc-license",
+    "summary": "License of TigerVNC suite"
+  },
+  {
+    "name": "tigervnc-selinux",
+    "summary": "SELinux module for TigerVNC"
+  },
+  {
+    "name": "tigervnc-server",
+    "summary": "A TigerVNC server"
+  },
+  {
+    "name": "tigervnc-server-minimal",
+    "summary": "A minimal installation of TigerVNC server"
+  },
+  {
+    "name": "tigervnc-server-module",
+    "summary": "TigerVNC module to Xorg"
+  },
+  {
+    "name": "tinycdb",
+    "summary": "Utility and library for manipulating constant databases"
+  },
+  {
+    "name": "tk",
+    "summary": "The graphical toolkit for the Tcl scripting language"
+  },
+  {
+    "name": "tk-devel",
+    "summary": "Tk graphical toolkit development files"
+  },
+  {
+    "name": "tlog",
+    "summary": "Terminal I/O logger"
+  },
+  {
+    "name": "tmpwatch",
+    "summary": "A utility for removing files based on when they were last accessed"
+  },
+  {
+    "name": "tog-pegasus",
+    "summary": "OpenPegasus WBEM Services for Linux"
+  },
+  {
+    "name": "tog-pegasus-libs",
+    "summary": "The OpenPegasus Libraries"
+  },
+  {
+    "name": "tokyocabinet",
+    "summary": "A modern implementation of a DBM"
+  },
+  {
+    "name": "tomcat",
+    "summary": "Apache Servlet/JSP Engine, RI for Servlet 4.0/JSP 2.3 API"
+  },
+  {
+    "name": "tomcat-admin-webapps",
+    "summary": "The host-manager and manager web applications for Apache Tomcat"
+  },
+  {
+    "name": "tomcat-docs-webapp",
+    "summary": "The docs web application for Apache Tomcat"
+  },
+  {
+    "name": "tomcat-el-3.0-api",
+    "summary": "Apache Tomcat Expression Language v3.0 API Implementation Classes"
+  },
+  {
+    "name": "tomcat-jsp-2.3-api",
+    "summary": "Apache Tomcat JavaServer Pages v2.3 API Implementation Classes"
+  },
+  {
+    "name": "tomcat-lib",
+    "summary": "Libraries needed to run the Tomcat Web container"
+  },
+  {
+    "name": "tomcat-servlet-4.0-api",
+    "summary": "Apache Tomcat Java Servlet v4.0 API Implementation Classes"
+  },
+  {
+    "name": "tomcat-webapps",
+    "summary": "The ROOT web application for Apache Tomcat"
+  },
+  {
+    "name": "tomcatjss",
+    "summary": "JSS Connector for Apache Tomcat"
+  },
+  {
+    "name": "toolbox",
+    "summary": "Tool for containerized command line environments on Linux"
+  },
+  {
+    "name": "toolbox-tests",
+    "summary": "Tests for toolbox"
+  },
+  {
+    "name": "totem-pl-parser",
+    "summary": "Totem Playlist Parser library"
+  },
+  {
+    "name": "tpm2-abrmd",
+    "summary": "A system daemon implementing TPM2 Access Broker and Resource Manager"
+  },
+  {
+    "name": "tpm2-abrmd-selinux",
+    "summary": "SELinux policies for tpm2-abrmd"
+  },
+  {
+    "name": "tpm2-pkcs11",
+    "summary": "PKCS#11 interface for TPM 2.0 hardware"
+  },
+  {
+    "name": "tpm2-pkcs11-tools",
+    "summary": "The tools required to setup and configure TPM2 for PKCS#11"
+  },
+  {
+    "name": "tpm2-tools",
+    "summary": "A bunch of TPM testing toolS build upon tpm2-tss"
+  },
+  {
+    "name": "tracer-common",
+    "summary": "Common files for tracer"
+  },
+  {
+    "name": "tracker",
+    "summary": "Desktop-neutral metadata database and search tool"
+  },
+  {
+    "name": "tracker-miners",
+    "summary": "Tracker miners and metadata extractors"
+  },
+  {
+    "name": "ttmkfdir",
+    "summary": "Utility to create fonts.scale files for truetype fonts"
+  },
+  {
+    "name": "tuned-gtk",
+    "summary": "GTK GUI for tuned"
+  },
+  {
+    "name": "tuned-ppd",
+    "summary": "PPD compatibility daemon"
+  },
+  {
+    "name": "tuned-profiles-atomic",
+    "summary": "Additional tuned profile(s) targeted to Atomic"
+  },
+  {
+    "name": "tuned-profiles-mssql",
+    "summary": "Additional tuned profile(s) for MS SQL Server"
+  },
+  {
+    "name": "tuned-profiles-oracle",
+    "summary": "Additional tuned profile(s) targeted to Oracle loads"
+  },
+  {
+    "name": "tuned-profiles-postgresql",
+    "summary": "Additional tuned profile(s) targeted to PostgreSQL server loads"
+  },
+  {
+    "name": "tuned-profiles-spectrumscale",
+    "summary": "Additional tuned profile(s) optimized for IBM Spectrum Scale"
+  },
+  {
+    "name": "tuned-utils",
+    "summary": "Various tuned utilities"
+  },
+  {
+    "name": "twolame",
+    "summary": "Optimized MPEG Audio Layer 2 encoding library based on tooLAME"
+  },
+  {
+    "name": "twolame-libs",
+    "summary": "TwoLAME is an optimized MPEG Audio Layer 2 encoding library based on tooLAME"
+  },
+  {
+    "name": "tzdata-java",
+    "summary": "Timezone data for Java"
+  },
+  {
+    "name": "ucs-miscfixed-fonts",
+    "summary": "Selected set of bitmap fonts"
+  },
+  {
+    "name": "ucx",
+    "summary": "UCX is a communication library implementing high-performance messaging"
+  },
+  {
+    "name": "ucx-cma",
+    "summary": "UCX CMA support"
+  },
+  {
+    "name": "ucx-devel",
+    "summary": "Header files required for developing with UCX"
+  },
+  {
+    "name": "ucx-ib",
+    "summary": "UCX RDMA support"
+  },
+  {
+    "name": "ucx-rdmacm",
+    "summary": "UCX RDMA connection manager support"
+  },
+  {
+    "name": "udftools",
+    "summary": "Linux UDF Filesystem userspace utilities"
+  },
+  {
+    "name": "udica",
+    "summary": "A tool for generating SELinux security policies for containers"
+  },
+  {
+    "name": "udisks2",
+    "summary": "Disk Manager"
+  },
+  {
+    "name": "udisks2-iscsi",
+    "summary": "Module for iSCSI"
+  },
+  {
+    "name": "udisks2-lsm",
+    "summary": "Module for LSM"
+  },
+  {
+    "name": "udisks2-lvm2",
+    "summary": "Module for LVM2"
+  },
+  {
+    "name": "uki-direct",
+    "summary": "Tools for virtual machine firmware volumes - test cases - manage UKI kernels."
+  },
+  {
+    "name": "unbound",
+    "summary": "Validating, recursive, and caching DNS(SEC) resolver"
+  },
+  {
+    "name": "unbound-dracut",
+    "summary": "Unbound dracut module"
+  },
+  {
+    "name": "unbound-libs",
+    "summary": "Libraries used by the unbound server and client applications"
+  },
+  {
+    "name": "unicode-ucd",
+    "summary": "Unicode Character Database"
+  },
+  {
+    "name": "univocity-parsers",
+    "summary": "Collection of parsers for Java"
+  },
+  {
+    "name": "unixODBC",
+    "summary": "A complete ODBC driver manager for Linux"
+  },
+  {
+    "name": "upower",
+    "summary": "Power Management Service"
+  },
+  {
+    "name": "uresourced",
+    "summary": "Dynamically allocate resources to the active user"
+  },
+  {
+    "name": "urlview",
+    "summary": "URL extractor/launcher"
+  },
+  {
+    "name": "urw-base35-bookman-fonts",
+    "summary": "URW Bookman font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-c059-fonts",
+    "summary": "C059 font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-d050000l-fonts",
+    "summary": "D050000L font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-fonts",
+    "summary": "Core Font Set containing 35 freely distributable fonts from (URW)++"
+  },
+  {
+    "name": "urw-base35-fonts-common",
+    "summary": "Common files of the (URW)++ Level 2 Core Font Set"
+  },
+  {
+    "name": "urw-base35-gothic-fonts",
+    "summary": "URW Gothic font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-nimbus-mono-ps-fonts",
+    "summary": "Nimbus Mono PS font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-nimbus-roman-fonts",
+    "summary": "Nimbus Roman font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-nimbus-sans-fonts",
+    "summary": "Nimbus Sans font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-p052-fonts",
+    "summary": "P052 font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-standard-symbols-ps-fonts",
+    "summary": "Standard Symbols PS font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-z003-fonts",
+    "summary": "Z003 font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "usbguard",
+    "summary": "A tool for implementing USB device usage policy"
+  },
+  {
+    "name": "usbguard-dbus",
+    "summary": "USBGuard D-Bus Service"
+  },
+  {
+    "name": "usbguard-notifier",
+    "summary": "A tool for detecting usbguard policy and device presence changes"
+  },
+  {
+    "name": "usbguard-selinux",
+    "summary": "USBGuard selinux"
+  },
+  {
+    "name": "usbguard-tools",
+    "summary": "USBGuard Tools"
+  },
+  {
+    "name": "usbredir",
+    "summary": "USB network redirection protocol libraries"
+  },
+  {
+    "name": "usbredir-server",
+    "summary": "Simple USB host TCP server"
+  },
+  {
+    "name": "usermode-gtk",
+    "summary": "Graphical tools for certain user account management tasks"
+  },
+  {
+    "name": "utf8proc",
+    "summary": "Library for processing UTF-8 encoded Unicode strings"
+  },
+  {
+    "name": "uuid",
+    "summary": "Universally Unique Identifier library"
+  },
+  {
+    "name": "uuid-c++",
+    "summary": "C++ support for Universally Unique Identifier library"
+  },
+  {
+    "name": "uuid-dce",
+    "summary": "DCE support for Universally Unique Identifier library"
+  },
+  {
+    "name": "uuidd",
+    "summary": "Helper daemon to guarantee uniqueness of time-based UUIDs"
+  },
+  {
+    "name": "valgrind",
+    "summary": "Tool for finding memory management bugs in programs"
+  },
+  {
+    "name": "valgrind-devel",
+    "summary": "Development files for valgrind aware programs"
+  },
+  {
+    "name": "varnish",
+    "summary": "High-performance HTTP accelerator"
+  },
+  {
+    "name": "varnish-docs",
+    "summary": "Documentation files for varnish"
+  },
+  {
+    "name": "varnish-modules",
+    "summary": "A collection of modules (\"vmods\") extending Varnish VCL"
+  },
+  {
+    "name": "vim-common",
+    "summary": "The common files needed by any version of the VIM editor"
+  },
+  {
+    "name": "vim-enhanced",
+    "summary": "A version of the VIM editor which includes recent enhancements"
+  },
+  {
+    "name": "vim-X11",
+    "summary": "The VIM version of the vi editor for the X Window System - GVim"
+  },
+  {
+    "name": "virt-install",
+    "summary": "Utilities for installing virtual machines"
+  },
+  {
+    "name": "virt-manager",
+    "summary": "Desktop tool for managing virtual machines via libvirt"
+  },
+  {
+    "name": "virt-manager-common",
+    "summary": "Common files used by the different Virtual Machine Manager interfaces"
+  },
+  {
+    "name": "virt-top",
+    "summary": "Utility like top(1) for displaying virtualization stats"
+  },
+  {
+    "name": "virt-viewer",
+    "summary": "Virtual Machine Viewer"
+  },
+  {
+    "name": "virt-who",
+    "summary": "Agent for reporting virtual guest IDs to subscription-manager"
+  },
+  {
+    "name": "virt-win-reg",
+    "summary": "Access and modify the Windows Registry of a Windows VM"
+  },
+  {
+    "name": "virtiofsd",
+    "summary": "Virtio-fs vhost-user device daemon (Rust version)"
+  },
+  {
+    "name": "voikko-fi",
+    "summary": "A description of Finnish morphology written for libvoikko"
+  },
+  {
+    "name": "volume_key",
+    "summary": "An utility for manipulating storage encryption keys and passphrases"
+  },
+  {
+    "name": "volume_key-libs",
+    "summary": "A library for manipulating storage encryption keys and passphrases"
+  },
+  {
+    "name": "vsftpd",
+    "summary": "Very Secure Ftp Daemon"
+  },
+  {
+    "name": "vte-profile",
+    "summary": "Profile script for VTE terminal emulator library"
+  },
+  {
+    "name": "vte291",
+    "summary": "Terminal emulator library"
+  },
+  {
+    "name": "vulkan-headers",
+    "summary": "Vulkan Header files and API registry"
+  },
+  {
+    "name": "vulkan-loader",
+    "summary": "Vulkan ICD desktop loader"
+  },
+  {
+    "name": "vulkan-loader-devel",
+    "summary": "Development files for vulkan-loader"
+  },
+  {
+    "name": "vulkan-tools",
+    "summary": "Vulkan tools"
+  },
+  {
+    "name": "vulkan-validation-layers",
+    "summary": "Vulkan validation layers"
+  },
+  {
+    "name": "vulkan-volk-devel",
+    "summary": "Development files for vulkan-volk"
+  },
+  {
+    "name": "WALinuxAgent",
+    "summary": "The Microsoft Azure Linux Agent"
+  },
+  {
+    "name": "WALinuxAgent-udev",
+    "summary": "Udev rules for Microsoft Azure"
+  },
+  {
+    "name": "watchdog",
+    "summary": "Software and/or Hardware watchdog daemon"
+  },
+  {
+    "name": "wavpack",
+    "summary": "A completely open audiocodec"
+  },
+  {
+    "name": "wayland-devel",
+    "summary": "Development files for wayland"
+  },
+  {
+    "name": "wayland-protocols-devel",
+    "summary": "Wayland protocols that adds functionality not available in the core protocol"
+  },
+  {
+    "name": "wayland-utils",
+    "summary": "Wayland utilities"
+  },
+  {
+    "name": "waypipe",
+    "summary": "Wayland forwarding proxy"
+  },
+  {
+    "name": "web-assets-filesystem",
+    "summary": "The basic directory layout for Web Assets"
+  },
+  {
+    "name": "webkit2gtk3",
+    "summary": "GTK Web content engine library"
+  },
+  {
+    "name": "webkit2gtk3-devel",
+    "summary": "Development files for webkit2gtk3"
+  },
+  {
+    "name": "webkit2gtk3-jsc",
+    "summary": "JavaScript engine from webkit2gtk3"
+  },
+  {
+    "name": "webkit2gtk3-jsc-devel",
+    "summary": "Development files for JavaScript engine from webkit2gtk3"
+  },
+  {
+    "name": "webrtc-audio-processing",
+    "summary": "Library for echo cancellation"
+  },
+  {
+    "name": "weldr-client",
+    "summary": "Command line utility to control osbuild-composer"
+  },
+  {
+    "name": "wget",
+    "summary": "A utility for retrieving files using the HTTP or FTP protocols"
+  },
+  {
+    "name": "whois",
+    "summary": "Improved WHOIS client"
+  },
+  {
+    "name": "whois-nls",
+    "summary": "Gettext catalogs for whois tools"
+  },
+  {
+    "name": "wireguard-tools",
+    "summary": "Fast, modern, secure VPN tunnel"
+  },
+  {
+    "name": "wireplumber",
+    "summary": "A modular session/policy manager for PipeWire"
+  },
+  {
+    "name": "wireplumber-libs",
+    "summary": "Libraries for WirePlumber clients"
+  },
+  {
+    "name": "wireshark",
+    "summary": "Network traffic analyzer"
+  },
+  {
+    "name": "wireshark-cli",
+    "summary": "Network traffic analyzer"
+  },
+  {
+    "name": "woff2",
+    "summary": "Web Open Font Format 2.0 library"
+  },
+  {
+    "name": "wpebackend-fdo",
+    "summary": "A WPE backend designed for Linux desktop systems"
+  },
+  {
+    "name": "wsmancli",
+    "summary": "WS-Management-Command line Interface"
+  },
+  {
+    "name": "x3270-x11",
+    "summary": "IBM 3278/3279 terminal emulator for the X Window System"
+  },
+  {
+    "name": "xalan-j2",
+    "summary": "Java XSLT processor"
+  },
+  {
+    "name": "xapian-core",
+    "summary": "The Xapian Probabilistic Information Retrieval Library"
+  },
+  {
+    "name": "xapian-core-libs",
+    "summary": "Xapian search engine libraries"
+  },
+  {
+    "name": "Xaw3d",
+    "summary": "A version of the MIT Athena widget set for X"
+  },
+  {
+    "name": "xcb-util",
+    "summary": "Convenience libraries sitting on top of libxcb"
+  },
+  {
+    "name": "xcb-util-cursor",
+    "summary": "Cursor library on top of libxcb"
+  },
+  {
+    "name": "xcb-util-cursor-devel",
+    "summary": "Development and header files for xcb-util-cursos"
+  },
+  {
+    "name": "xcb-util-image",
+    "summary": "Port of Xlib's XImage and XShmImage functions on top of libxcb"
+  },
+  {
+    "name": "xcb-util-image-devel",
+    "summary": "Development and header files for xcb-util-image"
+  },
+  {
+    "name": "xcb-util-keysyms",
+    "summary": "Standard X key constants and keycodes conversion on top of libxcb"
+  },
+  {
+    "name": "xcb-util-renderutil",
+    "summary": "Convenience functions for the Render extension"
+  },
+  {
+    "name": "xcb-util-renderutil-devel",
+    "summary": "Development and header files for xcb-util-renderutil"
+  },
+  {
+    "name": "xcb-util-wm",
+    "summary": "Client and window-manager helper library on top of libxcb"
+  },
+  {
+    "name": "xdg-dbus-proxy",
+    "summary": "Filtering proxy for D-Bus connections"
+  },
+  {
+    "name": "xdg-desktop-portal",
+    "summary": "Portal frontend service to flatpak"
+  },
+  {
+    "name": "xdg-desktop-portal-gnome",
+    "summary": "Backend implementation for xdg-desktop-portal using GNOME"
+  },
+  {
+    "name": "xdg-desktop-portal-gtk",
+    "summary": "Backend implementation for xdg-desktop-portal using GTK+"
+  },
+  {
+    "name": "xdg-user-dirs",
+    "summary": "Handles user special directories"
+  },
+  {
+    "name": "xdg-user-dirs-gtk",
+    "summary": "Gnome integration of special directories"
+  },
+  {
+    "name": "xdg-utils",
+    "summary": "Basic desktop integration functions"
+  },
+  {
+    "name": "xdp-tools",
+    "summary": "Utilities and example programs for use with XDP"
+  },
+  {
+    "name": "xerces-j2",
+    "summary": "Java XML parser"
+  },
+  {
+    "name": "xfsprogs-devel",
+    "summary": "XFS filesystem-specific headers"
+  },
+  {
+    "name": "xfsprogs-xfs_scrub",
+    "summary": "XFS filesystem online scrubbing utilities"
+  },
+  {
+    "name": "xhtml1-dtds",
+    "summary": "XHTML 1.0 document type definitions"
+  },
+  {
+    "name": "xhtml2fo-style-xsl",
+    "summary": "Antenna House, Inc. XHTML to XSL:FO stylesheets"
+  },
+  {
+    "name": "xkbcomp",
+    "summary": "XKB keymap compiler"
+  },
+  {
+    "name": "xkeyboard-config",
+    "summary": "X Keyboard Extension configuration data"
+  },
+  {
+    "name": "xkeyboard-config-devel",
+    "summary": "Development files for xkeyboard-config"
+  },
+  {
+    "name": "xml-common",
+    "summary": "Common XML catalog and DTD files"
+  },
+  {
+    "name": "xml-commons-apis",
+    "summary": "APIs for DOM, SAX, and JAXP"
+  },
+  {
+    "name": "xml-commons-resolver",
+    "summary": "Resolver subproject of xml-commons"
+  },
+  {
+    "name": "xmlrpc-c",
+    "summary": "Lightweight RPC library based on XML and HTTP"
+  },
+  {
+    "name": "xmlrpc-c-client",
+    "summary": "C client libraries for xmlrpc-c"
+  },
+  {
+    "name": "xmlsec1",
+    "summary": "Library providing support for \"XML Signature\" and \"XML Encryption\" standards"
+  },
+  {
+    "name": "xmlsec1-nss",
+    "summary": "NSS crypto plugin for XML Security Library"
+  },
+  {
+    "name": "xmlsec1-openssl",
+    "summary": "OpenSSL crypto plugin for XML Security Library"
+  },
+  {
+    "name": "xmlstarlet",
+    "summary": "Command Line XML Toolkit"
+  },
+  {
+    "name": "xmlto",
+    "summary": "A tool for converting XML files to various formats"
+  },
+  {
+    "name": "xmlto-tex",
+    "summary": "A set of xmlto backends with TeX requirements"
+  },
+  {
+    "name": "xmlto-xhtml",
+    "summary": "A set of xmlto backends for xhtml1 source format"
+  },
+  {
+    "name": "xorg-x11-drivers",
+    "summary": "X.Org X11 driver installation package"
+  },
+  {
+    "name": "xorg-x11-drv-dummy",
+    "summary": "Xorg X11 dummy video driver"
+  },
+  {
+    "name": "xorg-x11-drv-evdev",
+    "summary": "Xorg X11 evdev input driver"
+  },
+  {
+    "name": "xorg-x11-drv-fbdev",
+    "summary": "Xorg X11 fbdev video driver"
+  },
+  {
+    "name": "xorg-x11-drv-libinput",
+    "summary": "Xorg X11 libinput input driver"
+  },
+  {
+    "name": "xorg-x11-drv-v4l",
+    "summary": "Xorg X11 v4l video driver"
+  },
+  {
+    "name": "xorg-x11-drv-wacom",
+    "summary": "Xorg X11 wacom input driver"
+  },
+  {
+    "name": "xorg-x11-drv-wacom-serial-support",
+    "summary": "Files for enabling the wacom_w8001 kernel driver"
+  },
+  {
+    "name": "xorg-x11-fonts-100dpi",
+    "summary": "A set of 100dpi resolution fonts for the X Window System"
+  },
+  {
+    "name": "xorg-x11-fonts-75dpi",
+    "summary": "A set of 75dpi resolution fonts for the X Window System"
+  },
+  {
+    "name": "xorg-x11-fonts-cyrillic",
+    "summary": "Cyrillic fonts for X"
+  },
+  {
+    "name": "xorg-x11-fonts-ethiopic",
+    "summary": "Ethiopic fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-1-100dpi",
+    "summary": "A set of 100dpi ISO-8859-1 fonts for X"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-1-75dpi",
+    "summary": "A set of 75dpi ISO-8859-1 fonts for X"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-14-100dpi",
+    "summary": "ISO8859-14-100dpi fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-14-75dpi",
+    "summary": "ISO8859-14-75dpi fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-15-100dpi",
+    "summary": "ISO8859-15-100dpi fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-15-75dpi",
+    "summary": "ISO8859-15-75dpi fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-2-100dpi",
+    "summary": "A set of 100dpi Central European language fonts for X"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-2-75dpi",
+    "summary": "A set of 75dpi Central European language fonts for X"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-9-100dpi",
+    "summary": "ISO8859-9-100dpi fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-9-75dpi",
+    "summary": "ISO8859-9-75dpi fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-misc",
+    "summary": "misc bitmap fonts for the X Window System"
+  },
+  {
+    "name": "xorg-x11-fonts-Type1",
+    "summary": "Type1 fonts provided by the X Window System"
+  },
+  {
+    "name": "xorg-x11-proto-devel",
+    "summary": "X.Org X11 Protocol headers"
+  },
+  {
+    "name": "xorg-x11-server-common",
+    "summary": "Xorg server common files"
+  },
+  {
+    "name": "xorg-x11-server-utils",
+    "summary": "X.Org X11 X server utilities"
+  },
+  {
+    "name": "xorg-x11-server-Xdmx",
+    "summary": "Distributed Multihead X Server and utilities"
+  },
+  {
+    "name": "xorg-x11-server-Xephyr",
+    "summary": "A nested server"
+  },
+  {
+    "name": "xorg-x11-server-Xnest",
+    "summary": "A nested server"
+  },
+  {
+    "name": "xorg-x11-server-Xorg",
+    "summary": "Xorg X server"
+  },
+  {
+    "name": "xorg-x11-server-Xvfb",
+    "summary": "A X Windows System virtual framebuffer X server"
+  },
+  {
+    "name": "xorg-x11-server-Xwayland",
+    "summary": "Xwayland"
+  },
+  {
+    "name": "xorg-x11-utils",
+    "summary": "X.Org X11 X client utilities"
+  },
+  {
+    "name": "xorg-x11-xauth",
+    "summary": "X.Org X11 X authority utilities"
+  },
+  {
+    "name": "xorg-x11-xbitmaps",
+    "summary": "X.Org X11 application bitmaps"
+  },
+  {
+    "name": "xorg-x11-xinit",
+    "summary": "X.Org X11 X Window System xinit startup scripts"
+  },
+  {
+    "name": "xorg-x11-xinit-session",
+    "summary": "Display manager support for ~/.xsession and ~/.Xclients"
+  },
+  {
+    "name": "xorriso",
+    "summary": "ISO-9660 and Rock Ridge image manipulation tool"
+  },
+  {
+    "name": "xrestop",
+    "summary": "X Resource Monitor"
+  },
+  {
+    "name": "xsane",
+    "summary": "X Window System front-end for the SANE scanner interface"
+  },
+  {
+    "name": "xsane-common",
+    "summary": "Common files for xsane packages"
+  },
+  {
+    "name": "xterm",
+    "summary": "Terminal emulator for the X Window System"
+  },
+  {
+    "name": "xterm-resize",
+    "summary": "Set environment and terminal settings to current window size"
+  },
+  {
+    "name": "xxhash",
+    "summary": "Extremely fast hash algorithm"
+  },
+  {
+    "name": "xxhash-libs",
+    "summary": "Extremely fast hash algorithm - library"
+  },
+  {
+    "name": "xz-devel",
+    "summary": "Devel libraries & headers for liblzma"
+  },
+  {
+    "name": "xz-java",
+    "summary": "Java implementation of XZ data compression"
+  },
+  {
+    "name": "xz-lzma-compat",
+    "summary": "Older LZMA format compatibility binaries"
+  },
+  {
+    "name": "yajl",
+    "summary": "Yet Another JSON Library (YAJL)"
+  },
+  {
+    "name": "yara",
+    "summary": "Pattern matching Swiss knife for malware researchers"
+  },
+  {
+    "name": "yelp",
+    "summary": "Help browser for the GNOME desktop"
+  },
+  {
+    "name": "yelp-libs",
+    "summary": "Libraries for yelp"
+  },
+  {
+    "name": "yelp-tools",
+    "summary": "Create, manage, and publish documentation for Yelp"
+  },
+  {
+    "name": "yelp-xsl",
+    "summary": "XSL stylesheets for the yelp help browser"
+  },
+  {
+    "name": "zenity",
+    "summary": "Display dialog boxes from shell scripts"
+  },
+  {
+    "name": "zlib-devel",
+    "summary": "Header files and libraries for Zlib development"
+  },
+  {
+    "name": "zram-generator",
+    "summary": "Systemd unit generator for zram swap devices"
+  },
+  {
+    "name": "zziplib",
+    "summary": "Lightweight library to easily extract data from zip files"
+  },
+  {
+    "name": "zziplib-utils",
+    "summary": "Utilities for the zziplib library"
+  }
+]

--- a/distributions/rhel-9.6/rhel-9.6-aarch64-baseos-packages.json
+++ b/distributions/rhel-9.6/rhel-9.6-aarch64-baseos-packages.json
@@ -1,0 +1,3626 @@
+[
+  {
+    "name": "acl",
+    "summary": "Access control list utilities"
+  },
+  {
+    "name": "acpica-tools",
+    "summary": "ACPICA tools for the development and debug of ACPI tables"
+  },
+  {
+    "name": "adcli",
+    "summary": "Active Directory enrollment"
+  },
+  {
+    "name": "adobe-source-code-pro-fonts",
+    "summary": "A set of mono-spaced OpenType fonts designed for coding environments"
+  },
+  {
+    "name": "alternatives",
+    "summary": "A tool to maintain symbolic links determining default commands"
+  },
+  {
+    "name": "at",
+    "summary": "Job spooling tools"
+  },
+  {
+    "name": "atlas",
+    "summary": "Automatically Tuned Linear Algebra Software"
+  },
+  {
+    "name": "attr",
+    "summary": "Utilities for managing filesystem extended attributes"
+  },
+  {
+    "name": "audispd-plugins",
+    "summary": "Plugins for the audit event dispatcher"
+  },
+  {
+    "name": "audispd-plugins-zos",
+    "summary": "z/OS plugin for the audit event dispatcher"
+  },
+  {
+    "name": "audit",
+    "summary": "User space tools for kernel auditing"
+  },
+  {
+    "name": "audit-libs",
+    "summary": "Dynamic library for libaudit"
+  },
+  {
+    "name": "authselect",
+    "summary": "Configures authentication and identity sources from supported profiles"
+  },
+  {
+    "name": "authselect-libs",
+    "summary": "Utility library used by the authselect tool"
+  },
+  {
+    "name": "autofs",
+    "summary": "A tool for automatically mounting and unmounting filesystems"
+  },
+  {
+    "name": "avahi",
+    "summary": "Local network service discovery"
+  },
+  {
+    "name": "avahi-libs",
+    "summary": "Libraries for avahi run-time use"
+  },
+  {
+    "name": "basesystem",
+    "summary": "The skeleton package which defines a simple Red Hat Enterprise Linux system"
+  },
+  {
+    "name": "bash",
+    "summary": "The GNU Bourne Again shell"
+  },
+  {
+    "name": "bash-completion",
+    "summary": "Programmable completion for Bash"
+  },
+  {
+    "name": "bc",
+    "summary": "GNU's bc (a numeric processing language) and dc (a calculator)"
+  },
+  {
+    "name": "binutils",
+    "summary": "A GNU collection of binary utilities"
+  },
+  {
+    "name": "binutils-gold",
+    "summary": "The GOLD linker, a faster alternative to the BFD linker"
+  },
+  {
+    "name": "bluez",
+    "summary": "Bluetooth utilities"
+  },
+  {
+    "name": "bluez-libs",
+    "summary": "Libraries for use in Bluetooth applications"
+  },
+  {
+    "name": "bolt",
+    "summary": "Thunderbolt device manager"
+  },
+  {
+    "name": "bpftool",
+    "summary": "Inspection and simple manipulation of eBPF programs and maps"
+  },
+  {
+    "name": "bubblewrap",
+    "summary": "Core execution tool for unprivileged containers"
+  },
+  {
+    "name": "bzip2",
+    "summary": "A file compression utility"
+  },
+  {
+    "name": "bzip2-libs",
+    "summary": "Libraries for applications using bzip2"
+  },
+  {
+    "name": "c-ares",
+    "summary": "A library that performs asynchronous DNS operations"
+  },
+  {
+    "name": "ca-certificates",
+    "summary": "The Mozilla CA root certificate bundle"
+  },
+  {
+    "name": "cachefilesd",
+    "summary": "CacheFiles user-space management daemon"
+  },
+  {
+    "name": "chkconfig",
+    "summary": "A system tool for maintaining the /etc/rc*.d hierarchy"
+  },
+  {
+    "name": "chrony",
+    "summary": "An NTP client/server"
+  },
+  {
+    "name": "chrpath",
+    "summary": "Modify rpath of compiled programs"
+  },
+  {
+    "name": "cifs-utils",
+    "summary": "Utilities for mounting and managing CIFS mounts"
+  },
+  {
+    "name": "cockpit",
+    "summary": "Web Console for Linux servers"
+  },
+  {
+    "name": "cockpit-bridge",
+    "summary": "Cockpit bridge server-side component"
+  },
+  {
+    "name": "cockpit-doc",
+    "summary": "Cockpit deployment and developer guide"
+  },
+  {
+    "name": "cockpit-system",
+    "summary": "Cockpit admin interface package for configuring and troubleshooting a system"
+  },
+  {
+    "name": "cockpit-ws",
+    "summary": "Cockpit Web Service"
+  },
+  {
+    "name": "coreutils",
+    "summary": "A set of basic GNU tools commonly used in shell scripts"
+  },
+  {
+    "name": "coreutils-common",
+    "summary": "coreutils common optional components"
+  },
+  {
+    "name": "coreutils-single",
+    "summary": "coreutils multicall binary"
+  },
+  {
+    "name": "cpio",
+    "summary": "A GNU archiving program"
+  },
+  {
+    "name": "cracklib",
+    "summary": "A password-checking library"
+  },
+  {
+    "name": "cracklib-dicts",
+    "summary": "The standard CrackLib dictionaries"
+  },
+  {
+    "name": "cronie",
+    "summary": "Cron daemon for executing programs at set times"
+  },
+  {
+    "name": "cronie-anacron",
+    "summary": "Utility for running regular jobs"
+  },
+  {
+    "name": "cronie-noanacron",
+    "summary": "Utility for running simple regular jobs in old cron style"
+  },
+  {
+    "name": "crontabs",
+    "summary": "Root crontab files used to schedule the execution of programs"
+  },
+  {
+    "name": "crypto-policies",
+    "summary": "System-wide crypto policies"
+  },
+  {
+    "name": "crypto-policies-scripts",
+    "summary": "Tool to switch between crypto policies"
+  },
+  {
+    "name": "cryptsetup",
+    "summary": "Utility for setting up encrypted disks"
+  },
+  {
+    "name": "cryptsetup-libs",
+    "summary": "Cryptsetup shared library"
+  },
+  {
+    "name": "cups-libs",
+    "summary": "CUPS printing system - libraries"
+  },
+  {
+    "name": "curl",
+    "summary": "A utility for getting files from remote servers (FTP, HTTP, and others)"
+  },
+  {
+    "name": "curl-minimal",
+    "summary": "Conservatively configured build of curl for minimal installations"
+  },
+  {
+    "name": "cxl-libs",
+    "summary": "Management library for CXL devices"
+  },
+  {
+    "name": "cyrus-sasl",
+    "summary": "The Cyrus SASL library"
+  },
+  {
+    "name": "cyrus-sasl-gssapi",
+    "summary": "GSSAPI authentication support for Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-lib",
+    "summary": "Shared libraries needed by applications which use Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-plain",
+    "summary": "PLAIN and LOGIN authentication support for Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-scram",
+    "summary": "SCRAM auxprop support for Cyrus SASL"
+  },
+  {
+    "name": "daxctl-libs",
+    "summary": "Management library for \"Device DAX\" devices"
+  },
+  {
+    "name": "dbus",
+    "summary": "D-BUS message bus"
+  },
+  {
+    "name": "dbus-broker",
+    "summary": "Linux D-Bus Message Broker"
+  },
+  {
+    "name": "dbus-common",
+    "summary": "D-BUS message bus configuration"
+  },
+  {
+    "name": "dbus-libs",
+    "summary": "Libraries for accessing D-BUS"
+  },
+  {
+    "name": "dbus-tools",
+    "summary": "D-BUS Tools and Utilities"
+  },
+  {
+    "name": "dejavu-sans-fonts",
+    "summary": "DejaVu Sans, a variable-width sans-serif font family"
+  },
+  {
+    "name": "dejavu-sans-mono-fonts",
+    "summary": "DejaVu Sans Mono, a mono-space sans-serif font family"
+  },
+  {
+    "name": "dejavu-serif-fonts",
+    "summary": "DejaVu Serif, a variable-width serif font family"
+  },
+  {
+    "name": "device-mapper",
+    "summary": "Device mapper utility"
+  },
+  {
+    "name": "device-mapper-event",
+    "summary": "Device-mapper event daemon"
+  },
+  {
+    "name": "device-mapper-event-libs",
+    "summary": "Device-mapper event daemon shared library"
+  },
+  {
+    "name": "device-mapper-libs",
+    "summary": "Device-mapper shared library"
+  },
+  {
+    "name": "device-mapper-multipath",
+    "summary": "Tools to manage multipath devices using device-mapper"
+  },
+  {
+    "name": "device-mapper-multipath-libs",
+    "summary": "The device-mapper-multipath modules and shared library"
+  },
+  {
+    "name": "device-mapper-persistent-data",
+    "summary": "Device-mapper Persistent Data Tools"
+  },
+  {
+    "name": "dhcp-client",
+    "summary": "Provides the ISC DHCP client daemon and dhclient-script"
+  },
+  {
+    "name": "dhcp-common",
+    "summary": "Common files used by ISC dhcp client, server and relay agent"
+  },
+  {
+    "name": "dhcp-relay",
+    "summary": "Provides the ISC DHCP relay agent"
+  },
+  {
+    "name": "dhcp-server",
+    "summary": "Provides the ISC DHCP server"
+  },
+  {
+    "name": "diffutils",
+    "summary": "GNU collection of diff utilities"
+  },
+  {
+    "name": "dmidecode",
+    "summary": "Tool to analyse BIOS DMI data"
+  },
+  {
+    "name": "dnf",
+    "summary": "Package manager"
+  },
+  {
+    "name": "dnf-automatic",
+    "summary": "Package manager - automated upgrades"
+  },
+  {
+    "name": "dnf-data",
+    "summary": "Common data and configuration files for DNF"
+  },
+  {
+    "name": "dnf-plugins-core",
+    "summary": "Core Plugins for DNF"
+  },
+  {
+    "name": "dos2unix",
+    "summary": "Text file format converters"
+  },
+  {
+    "name": "dosfstools",
+    "summary": "Utilities for making and checking MS-DOS FAT filesystems on Linux"
+  },
+  {
+    "name": "dracut",
+    "summary": "Initramfs generator using udev"
+  },
+  {
+    "name": "dracut-config-generic",
+    "summary": "dracut configuration to turn off hostonly image generation"
+  },
+  {
+    "name": "dracut-config-rescue",
+    "summary": "dracut configuration to turn on rescue image generation"
+  },
+  {
+    "name": "dracut-network",
+    "summary": "dracut modules to build a dracut initramfs with network support"
+  },
+  {
+    "name": "dracut-squash",
+    "summary": "dracut module to build an initramfs with most files in a squashfs image"
+  },
+  {
+    "name": "dracut-tools",
+    "summary": "dracut tools to build the local initramfs"
+  },
+  {
+    "name": "e2fsprogs",
+    "summary": "Utilities for managing ext2, ext3, and ext4 file systems"
+  },
+  {
+    "name": "e2fsprogs-libs",
+    "summary": "Ext2/3/4 file system specific shared libraries"
+  },
+  {
+    "name": "ed",
+    "summary": "The GNU line editor"
+  },
+  {
+    "name": "efi-filesystem",
+    "summary": "The basic directory layout for EFI machines"
+  },
+  {
+    "name": "efibootmgr",
+    "summary": "EFI Boot Manager"
+  },
+  {
+    "name": "efivar-libs",
+    "summary": "Library to manage UEFI variables"
+  },
+  {
+    "name": "elfutils",
+    "summary": "A collection of utilities and DSOs to handle ELF files and DWARF data"
+  },
+  {
+    "name": "elfutils-debuginfod-client",
+    "summary": "Library and command line client for build-id HTTP ELF/DWARF server"
+  },
+  {
+    "name": "elfutils-default-yama-scope",
+    "summary": "Default yama attach scope sysctl setting"
+  },
+  {
+    "name": "elfutils-libelf",
+    "summary": "Library to read and write ELF files"
+  },
+  {
+    "name": "elfutils-libs",
+    "summary": "Libraries to handle compiled objects"
+  },
+  {
+    "name": "environment-modules",
+    "summary": "Provides dynamic modification of a user's environment"
+  },
+  {
+    "name": "ethtool",
+    "summary": "Settings tool for Ethernet NICs"
+  },
+  {
+    "name": "exfatprogs",
+    "summary": "Userspace utilities for exFAT filesystems"
+  },
+  {
+    "name": "expat",
+    "summary": "An XML parser library"
+  },
+  {
+    "name": "fcoe-utils",
+    "summary": "Fibre Channel over Ethernet utilities"
+  },
+  {
+    "name": "file",
+    "summary": "Utility for determining file types"
+  },
+  {
+    "name": "file-libs",
+    "summary": "Libraries for applications using libmagic"
+  },
+  {
+    "name": "filesystem",
+    "summary": "The basic directory layout for a Linux system"
+  },
+  {
+    "name": "findutils",
+    "summary": "The GNU versions of find utilities (find and xargs)"
+  },
+  {
+    "name": "firewalld",
+    "summary": "A firewall daemon with D-Bus interface providing a dynamic firewall"
+  },
+  {
+    "name": "firewalld-filesystem",
+    "summary": "Firewalld directory layout and rpm macros"
+  },
+  {
+    "name": "fonts-filesystem",
+    "summary": "Directories used by font packages"
+  },
+  {
+    "name": "freetype",
+    "summary": "A free and portable font rendering engine"
+  },
+  {
+    "name": "fuse",
+    "summary": "File System in Userspace (FUSE) v2 utilities"
+  },
+  {
+    "name": "fuse-common",
+    "summary": "Common files for File System in Userspace (FUSE) v2 and v3"
+  },
+  {
+    "name": "fuse-libs",
+    "summary": "File System in Userspace (FUSE) v2 libraries"
+  },
+  {
+    "name": "fwupd",
+    "summary": "Firmware update daemon"
+  },
+  {
+    "name": "gawk",
+    "summary": "The GNU version of the AWK text processing utility"
+  },
+  {
+    "name": "gdbm-libs",
+    "summary": "Libraries files for gdbm"
+  },
+  {
+    "name": "gettext",
+    "summary": "GNU libraries and utilities for producing multi-lingual messages"
+  },
+  {
+    "name": "gettext-libs",
+    "summary": "Libraries for gettext"
+  },
+  {
+    "name": "glib-networking",
+    "summary": "Networking support for GLib"
+  },
+  {
+    "name": "glib2",
+    "summary": "A library of handy utility functions"
+  },
+  {
+    "name": "glibc",
+    "summary": "The GNU libc libraries"
+  },
+  {
+    "name": "glibc-all-langpacks",
+    "summary": "All language packs for glibc."
+  },
+  {
+    "name": "glibc-common",
+    "summary": "Common binaries and locale data for glibc"
+  },
+  {
+    "name": "glibc-gconv-extra",
+    "summary": "All iconv converter modules for glibc."
+  },
+  {
+    "name": "glibc-langpack-aa",
+    "summary": "Locale data for Afar"
+  },
+  {
+    "name": "glibc-langpack-af",
+    "summary": "Locale data for Afrikaans"
+  },
+  {
+    "name": "glibc-langpack-agr",
+    "summary": "Locale data for Aguaruna"
+  },
+  {
+    "name": "glibc-langpack-ak",
+    "summary": "Locale data for Akan"
+  },
+  {
+    "name": "glibc-langpack-am",
+    "summary": "Locale data for Amharic"
+  },
+  {
+    "name": "glibc-langpack-an",
+    "summary": "Locale data for Aragonese"
+  },
+  {
+    "name": "glibc-langpack-anp",
+    "summary": "Locale data for Angika"
+  },
+  {
+    "name": "glibc-langpack-ar",
+    "summary": "Locale data for Arabic"
+  },
+  {
+    "name": "glibc-langpack-as",
+    "summary": "Locale data for Assamese"
+  },
+  {
+    "name": "glibc-langpack-ast",
+    "summary": "Locale data for Asturian"
+  },
+  {
+    "name": "glibc-langpack-ayc",
+    "summary": "Locale data for Southern Aymara"
+  },
+  {
+    "name": "glibc-langpack-az",
+    "summary": "Locale data for Azerbaijani"
+  },
+  {
+    "name": "glibc-langpack-be",
+    "summary": "Locale data for Belarusian"
+  },
+  {
+    "name": "glibc-langpack-bem",
+    "summary": "Locale data for Bemba"
+  },
+  {
+    "name": "glibc-langpack-ber",
+    "summary": "Locale data for Berber"
+  },
+  {
+    "name": "glibc-langpack-bg",
+    "summary": "Locale data for Bulgarian"
+  },
+  {
+    "name": "glibc-langpack-bhb",
+    "summary": "Locale data for Bhili"
+  },
+  {
+    "name": "glibc-langpack-bho",
+    "summary": "Locale data for Bhojpuri"
+  },
+  {
+    "name": "glibc-langpack-bi",
+    "summary": "Locale data for Bislama"
+  },
+  {
+    "name": "glibc-langpack-bn",
+    "summary": "Locale data for Bangla"
+  },
+  {
+    "name": "glibc-langpack-bo",
+    "summary": "Locale data for Tibetan"
+  },
+  {
+    "name": "glibc-langpack-br",
+    "summary": "Locale data for Breton"
+  },
+  {
+    "name": "glibc-langpack-brx",
+    "summary": "Locale data for Bodo"
+  },
+  {
+    "name": "glibc-langpack-bs",
+    "summary": "Locale data for Bosnian"
+  },
+  {
+    "name": "glibc-langpack-byn",
+    "summary": "Locale data for Blin"
+  },
+  {
+    "name": "glibc-langpack-ca",
+    "summary": "Locale data for Catalan"
+  },
+  {
+    "name": "glibc-langpack-ce",
+    "summary": "Locale data for Chechen"
+  },
+  {
+    "name": "glibc-langpack-chr",
+    "summary": "Locale data for Cherokee"
+  },
+  {
+    "name": "glibc-langpack-ckb",
+    "summary": "Locale data for Central Kurdish"
+  },
+  {
+    "name": "glibc-langpack-cmn",
+    "summary": "Locale data for Mandarin Chinese"
+  },
+  {
+    "name": "glibc-langpack-crh",
+    "summary": "Locale data for Crimean Turkish"
+  },
+  {
+    "name": "glibc-langpack-cs",
+    "summary": "Locale data for Czech"
+  },
+  {
+    "name": "glibc-langpack-csb",
+    "summary": "Locale data for Kashubian"
+  },
+  {
+    "name": "glibc-langpack-cv",
+    "summary": "Locale data for Chuvash"
+  },
+  {
+    "name": "glibc-langpack-cy",
+    "summary": "Locale data for Welsh"
+  },
+  {
+    "name": "glibc-langpack-da",
+    "summary": "Locale data for Danish"
+  },
+  {
+    "name": "glibc-langpack-de",
+    "summary": "Locale data for German"
+  },
+  {
+    "name": "glibc-langpack-doi",
+    "summary": "Locale data for Dogri"
+  },
+  {
+    "name": "glibc-langpack-dsb",
+    "summary": "Locale data for Lower Sorbian"
+  },
+  {
+    "name": "glibc-langpack-dv",
+    "summary": "Locale data for Divehi"
+  },
+  {
+    "name": "glibc-langpack-dz",
+    "summary": "Locale data for Dzongkha"
+  },
+  {
+    "name": "glibc-langpack-el",
+    "summary": "Locale data for Greek"
+  },
+  {
+    "name": "glibc-langpack-en",
+    "summary": "Locale data for English"
+  },
+  {
+    "name": "glibc-langpack-eo",
+    "summary": "Locale data for Esperanto"
+  },
+  {
+    "name": "glibc-langpack-es",
+    "summary": "Locale data for Spanish"
+  },
+  {
+    "name": "glibc-langpack-et",
+    "summary": "Locale data for Estonian"
+  },
+  {
+    "name": "glibc-langpack-eu",
+    "summary": "Locale data for Basque"
+  },
+  {
+    "name": "glibc-langpack-fa",
+    "summary": "Locale data for Persian"
+  },
+  {
+    "name": "glibc-langpack-ff",
+    "summary": "Locale data for Fulah"
+  },
+  {
+    "name": "glibc-langpack-fi",
+    "summary": "Locale data for Finnish"
+  },
+  {
+    "name": "glibc-langpack-fil",
+    "summary": "Locale data for Filipino"
+  },
+  {
+    "name": "glibc-langpack-fo",
+    "summary": "Locale data for Faroese"
+  },
+  {
+    "name": "glibc-langpack-fr",
+    "summary": "Locale data for French"
+  },
+  {
+    "name": "glibc-langpack-fur",
+    "summary": "Locale data for Friulian"
+  },
+  {
+    "name": "glibc-langpack-fy",
+    "summary": "Locale data for Western Frisian"
+  },
+  {
+    "name": "glibc-langpack-ga",
+    "summary": "Locale data for Irish"
+  },
+  {
+    "name": "glibc-langpack-gd",
+    "summary": "Locale data for Scottish Gaelic"
+  },
+  {
+    "name": "glibc-langpack-gez",
+    "summary": "Locale data for Geez"
+  },
+  {
+    "name": "glibc-langpack-gl",
+    "summary": "Locale data for Galician"
+  },
+  {
+    "name": "glibc-langpack-gu",
+    "summary": "Locale data for Gujarati"
+  },
+  {
+    "name": "glibc-langpack-gv",
+    "summary": "Locale data for Manx"
+  },
+  {
+    "name": "glibc-langpack-ha",
+    "summary": "Locale data for Hausa"
+  },
+  {
+    "name": "glibc-langpack-hak",
+    "summary": "Locale data for Hakka Chinese"
+  },
+  {
+    "name": "glibc-langpack-he",
+    "summary": "Locale data for Hebrew"
+  },
+  {
+    "name": "glibc-langpack-hi",
+    "summary": "Locale data for Hindi"
+  },
+  {
+    "name": "glibc-langpack-hif",
+    "summary": "Locale data for Fiji Hindi"
+  },
+  {
+    "name": "glibc-langpack-hne",
+    "summary": "Locale data for Chhattisgarhi"
+  },
+  {
+    "name": "glibc-langpack-hr",
+    "summary": "Locale data for Croatian"
+  },
+  {
+    "name": "glibc-langpack-hsb",
+    "summary": "Locale data for Upper Sorbian"
+  },
+  {
+    "name": "glibc-langpack-ht",
+    "summary": "Locale data for Haitian Creole"
+  },
+  {
+    "name": "glibc-langpack-hu",
+    "summary": "Locale data for Hungarian"
+  },
+  {
+    "name": "glibc-langpack-hy",
+    "summary": "Locale data for Armenian"
+  },
+  {
+    "name": "glibc-langpack-ia",
+    "summary": "Locale data for Interlingua"
+  },
+  {
+    "name": "glibc-langpack-id",
+    "summary": "Locale data for Indonesian"
+  },
+  {
+    "name": "glibc-langpack-ig",
+    "summary": "Locale data for Igbo"
+  },
+  {
+    "name": "glibc-langpack-ik",
+    "summary": "Locale data for Inupiaq"
+  },
+  {
+    "name": "glibc-langpack-is",
+    "summary": "Locale data for Icelandic"
+  },
+  {
+    "name": "glibc-langpack-it",
+    "summary": "Locale data for Italian"
+  },
+  {
+    "name": "glibc-langpack-iu",
+    "summary": "Locale data for Inuktitut"
+  },
+  {
+    "name": "glibc-langpack-ja",
+    "summary": "Locale data for Japanese"
+  },
+  {
+    "name": "glibc-langpack-ka",
+    "summary": "Locale data for Georgian"
+  },
+  {
+    "name": "glibc-langpack-kab",
+    "summary": "Locale data for Kabyle"
+  },
+  {
+    "name": "glibc-langpack-kk",
+    "summary": "Locale data for Kazakh"
+  },
+  {
+    "name": "glibc-langpack-kl",
+    "summary": "Locale data for Kalaallisut"
+  },
+  {
+    "name": "glibc-langpack-km",
+    "summary": "Locale data for Khmer"
+  },
+  {
+    "name": "glibc-langpack-kn",
+    "summary": "Locale data for Kannada"
+  },
+  {
+    "name": "glibc-langpack-ko",
+    "summary": "Locale data for Korean"
+  },
+  {
+    "name": "glibc-langpack-kok",
+    "summary": "Locale data for Konkani"
+  },
+  {
+    "name": "glibc-langpack-ks",
+    "summary": "Locale data for Kashmiri"
+  },
+  {
+    "name": "glibc-langpack-ku",
+    "summary": "Locale data for Kurdish"
+  },
+  {
+    "name": "glibc-langpack-kw",
+    "summary": "Locale data for Cornish"
+  },
+  {
+    "name": "glibc-langpack-ky",
+    "summary": "Locale data for Kyrgyz"
+  },
+  {
+    "name": "glibc-langpack-lb",
+    "summary": "Locale data for Luxembourgish"
+  },
+  {
+    "name": "glibc-langpack-lg",
+    "summary": "Locale data for Ganda"
+  },
+  {
+    "name": "glibc-langpack-li",
+    "summary": "Locale data for Limburgish"
+  },
+  {
+    "name": "glibc-langpack-lij",
+    "summary": "Locale data for Ligurian"
+  },
+  {
+    "name": "glibc-langpack-ln",
+    "summary": "Locale data for Lingala"
+  },
+  {
+    "name": "glibc-langpack-lo",
+    "summary": "Locale data for Lao"
+  },
+  {
+    "name": "glibc-langpack-lt",
+    "summary": "Locale data for Lithuanian"
+  },
+  {
+    "name": "glibc-langpack-lv",
+    "summary": "Locale data for Latvian"
+  },
+  {
+    "name": "glibc-langpack-lzh",
+    "summary": "Locale data for Literary Chinese"
+  },
+  {
+    "name": "glibc-langpack-mag",
+    "summary": "Locale data for Magahi"
+  },
+  {
+    "name": "glibc-langpack-mai",
+    "summary": "Locale data for Maithili"
+  },
+  {
+    "name": "glibc-langpack-mfe",
+    "summary": "Locale data for Morisyen"
+  },
+  {
+    "name": "glibc-langpack-mg",
+    "summary": "Locale data for Malagasy"
+  },
+  {
+    "name": "glibc-langpack-mhr",
+    "summary": "Locale data for Meadow Mari"
+  },
+  {
+    "name": "glibc-langpack-mi",
+    "summary": "Locale data for Maori"
+  },
+  {
+    "name": "glibc-langpack-miq",
+    "summary": "Locale data for Miskito"
+  },
+  {
+    "name": "glibc-langpack-mjw",
+    "summary": "Locale data for Karbi"
+  },
+  {
+    "name": "glibc-langpack-mk",
+    "summary": "Locale data for Macedonian"
+  },
+  {
+    "name": "glibc-langpack-ml",
+    "summary": "Locale data for Malayalam"
+  },
+  {
+    "name": "glibc-langpack-mn",
+    "summary": "Locale data for Mongolian"
+  },
+  {
+    "name": "glibc-langpack-mni",
+    "summary": "Locale data for Manipuri"
+  },
+  {
+    "name": "glibc-langpack-mnw",
+    "summary": "Locale data for Mon"
+  },
+  {
+    "name": "glibc-langpack-mr",
+    "summary": "Locale data for Marathi"
+  },
+  {
+    "name": "glibc-langpack-ms",
+    "summary": "Locale data for Malay"
+  },
+  {
+    "name": "glibc-langpack-mt",
+    "summary": "Locale data for Maltese"
+  },
+  {
+    "name": "glibc-langpack-my",
+    "summary": "Locale data for Burmese"
+  },
+  {
+    "name": "glibc-langpack-nan",
+    "summary": "Locale data for Min Nan Chinese"
+  },
+  {
+    "name": "glibc-langpack-nb",
+    "summary": "Locale data for Norwegian Bokm\u00e5l"
+  },
+  {
+    "name": "glibc-langpack-nds",
+    "summary": "Locale data for Low German"
+  },
+  {
+    "name": "glibc-langpack-ne",
+    "summary": "Locale data for Nepali"
+  },
+  {
+    "name": "glibc-langpack-nhn",
+    "summary": "Locale data for Tlaxcala-Puebla Nahuatl"
+  },
+  {
+    "name": "glibc-langpack-niu",
+    "summary": "Locale data for Niuean"
+  },
+  {
+    "name": "glibc-langpack-nl",
+    "summary": "Locale data for Dutch"
+  },
+  {
+    "name": "glibc-langpack-nn",
+    "summary": "Locale data for Norwegian Nynorsk"
+  },
+  {
+    "name": "glibc-langpack-nr",
+    "summary": "Locale data for South Ndebele"
+  },
+  {
+    "name": "glibc-langpack-nso",
+    "summary": "Locale data for Northern Sotho"
+  },
+  {
+    "name": "glibc-langpack-oc",
+    "summary": "Locale data for Occitan"
+  },
+  {
+    "name": "glibc-langpack-om",
+    "summary": "Locale data for Oromo"
+  },
+  {
+    "name": "glibc-langpack-or",
+    "summary": "Locale data for Odia"
+  },
+  {
+    "name": "glibc-langpack-os",
+    "summary": "Locale data for Ossetic"
+  },
+  {
+    "name": "glibc-langpack-pa",
+    "summary": "Locale data for Punjabi"
+  },
+  {
+    "name": "glibc-langpack-pap",
+    "summary": "Locale data for Papiamento"
+  },
+  {
+    "name": "glibc-langpack-pl",
+    "summary": "Locale data for Polish"
+  },
+  {
+    "name": "glibc-langpack-ps",
+    "summary": "Locale data for Pashto"
+  },
+  {
+    "name": "glibc-langpack-pt",
+    "summary": "Locale data for Portuguese"
+  },
+  {
+    "name": "glibc-langpack-quz",
+    "summary": "Locale data for Cusco Quechua"
+  },
+  {
+    "name": "glibc-langpack-raj",
+    "summary": "Locale data for Rajasthani"
+  },
+  {
+    "name": "glibc-langpack-ro",
+    "summary": "Locale data for Romanian"
+  },
+  {
+    "name": "glibc-langpack-ru",
+    "summary": "Locale data for Russian"
+  },
+  {
+    "name": "glibc-langpack-rw",
+    "summary": "Locale data for Kinyarwanda"
+  },
+  {
+    "name": "glibc-langpack-sa",
+    "summary": "Locale data for Sanskrit"
+  },
+  {
+    "name": "glibc-langpack-sah",
+    "summary": "Locale data for Sakha"
+  },
+  {
+    "name": "glibc-langpack-sat",
+    "summary": "Locale data for Santali"
+  },
+  {
+    "name": "glibc-langpack-sc",
+    "summary": "Locale data for Sardinian"
+  },
+  {
+    "name": "glibc-langpack-sd",
+    "summary": "Locale data for Sindhi"
+  },
+  {
+    "name": "glibc-langpack-se",
+    "summary": "Locale data for Northern Sami"
+  },
+  {
+    "name": "glibc-langpack-sgs",
+    "summary": "Locale data for Samogitian"
+  },
+  {
+    "name": "glibc-langpack-shn",
+    "summary": "Locale data for Shan"
+  },
+  {
+    "name": "glibc-langpack-shs",
+    "summary": "Locale data for Shuswap"
+  },
+  {
+    "name": "glibc-langpack-si",
+    "summary": "Locale data for Sinhala"
+  },
+  {
+    "name": "glibc-langpack-sid",
+    "summary": "Locale data for Sidamo"
+  },
+  {
+    "name": "glibc-langpack-sk",
+    "summary": "Locale data for Slovak"
+  },
+  {
+    "name": "glibc-langpack-sl",
+    "summary": "Locale data for Slovenian"
+  },
+  {
+    "name": "glibc-langpack-sm",
+    "summary": "Locale data for Samoan"
+  },
+  {
+    "name": "glibc-langpack-so",
+    "summary": "Locale data for Somali"
+  },
+  {
+    "name": "glibc-langpack-sq",
+    "summary": "Locale data for Albanian"
+  },
+  {
+    "name": "glibc-langpack-sr",
+    "summary": "Locale data for Serbian"
+  },
+  {
+    "name": "glibc-langpack-ss",
+    "summary": "Locale data for Swati"
+  },
+  {
+    "name": "glibc-langpack-st",
+    "summary": "Locale data for Southern Sotho"
+  },
+  {
+    "name": "glibc-langpack-sv",
+    "summary": "Locale data for Swedish"
+  },
+  {
+    "name": "glibc-langpack-sw",
+    "summary": "Locale data for Swahili"
+  },
+  {
+    "name": "glibc-langpack-szl",
+    "summary": "Locale data for Silesian"
+  },
+  {
+    "name": "glibc-langpack-ta",
+    "summary": "Locale data for Tamil"
+  },
+  {
+    "name": "glibc-langpack-tcy",
+    "summary": "Locale data for Tulu"
+  },
+  {
+    "name": "glibc-langpack-te",
+    "summary": "Locale data for Telugu"
+  },
+  {
+    "name": "glibc-langpack-tg",
+    "summary": "Locale data for Tajik"
+  },
+  {
+    "name": "glibc-langpack-th",
+    "summary": "Locale data for Thai"
+  },
+  {
+    "name": "glibc-langpack-the",
+    "summary": "Locale data for Chitwania Tharu"
+  },
+  {
+    "name": "glibc-langpack-ti",
+    "summary": "Locale data for Tigrinya"
+  },
+  {
+    "name": "glibc-langpack-tig",
+    "summary": "Locale data for Tigre"
+  },
+  {
+    "name": "glibc-langpack-tk",
+    "summary": "Locale data for Turkmen"
+  },
+  {
+    "name": "glibc-langpack-tl",
+    "summary": "Locale data for Tagalog"
+  },
+  {
+    "name": "glibc-langpack-tn",
+    "summary": "Locale data for Tswana"
+  },
+  {
+    "name": "glibc-langpack-to",
+    "summary": "Locale data for Tongan"
+  },
+  {
+    "name": "glibc-langpack-tpi",
+    "summary": "Locale data for Tok Pisin"
+  },
+  {
+    "name": "glibc-langpack-tr",
+    "summary": "Locale data for Turkish"
+  },
+  {
+    "name": "glibc-langpack-ts",
+    "summary": "Locale data for Tsonga"
+  },
+  {
+    "name": "glibc-langpack-tt",
+    "summary": "Locale data for Tatar"
+  },
+  {
+    "name": "glibc-langpack-ug",
+    "summary": "Locale data for Uyghur"
+  },
+  {
+    "name": "glibc-langpack-uk",
+    "summary": "Locale data for Ukrainian"
+  },
+  {
+    "name": "glibc-langpack-unm",
+    "summary": "Locale data for Unami language"
+  },
+  {
+    "name": "glibc-langpack-ur",
+    "summary": "Locale data for Urdu"
+  },
+  {
+    "name": "glibc-langpack-uz",
+    "summary": "Locale data for Uzbek"
+  },
+  {
+    "name": "glibc-langpack-ve",
+    "summary": "Locale data for Venda"
+  },
+  {
+    "name": "glibc-langpack-vi",
+    "summary": "Locale data for Vietnamese"
+  },
+  {
+    "name": "glibc-langpack-wa",
+    "summary": "Locale data for Walloon"
+  },
+  {
+    "name": "glibc-langpack-wae",
+    "summary": "Locale data for Walser"
+  },
+  {
+    "name": "glibc-langpack-wal",
+    "summary": "Locale data for Wolaytta"
+  },
+  {
+    "name": "glibc-langpack-wo",
+    "summary": "Locale data for Wolof"
+  },
+  {
+    "name": "glibc-langpack-xh",
+    "summary": "Locale data for Xhosa"
+  },
+  {
+    "name": "glibc-langpack-yi",
+    "summary": "Locale data for Yiddish"
+  },
+  {
+    "name": "glibc-langpack-yo",
+    "summary": "Locale data for Yoruba"
+  },
+  {
+    "name": "glibc-langpack-yue",
+    "summary": "Locale data for Cantonese"
+  },
+  {
+    "name": "glibc-langpack-yuw",
+    "summary": "Locale data for Yau"
+  },
+  {
+    "name": "glibc-langpack-zh",
+    "summary": "Locale data for Mandarin Chinese"
+  },
+  {
+    "name": "glibc-langpack-zu",
+    "summary": "Locale data for Zulu"
+  },
+  {
+    "name": "glibc-minimal-langpack",
+    "summary": "Minimal language packs for glibc."
+  },
+  {
+    "name": "gmp",
+    "summary": "A GNU arbitrary precision library"
+  },
+  {
+    "name": "gnupg2",
+    "summary": "Utility for secure communication and data storage"
+  },
+  {
+    "name": "gnutls",
+    "summary": "A TLS protocol implementation"
+  },
+  {
+    "name": "gobject-introspection",
+    "summary": "Introspection system for GObject-based libraries"
+  },
+  {
+    "name": "gpgme",
+    "summary": "GnuPG Made Easy - high level crypto API"
+  },
+  {
+    "name": "graphite2",
+    "summary": "Font rendering capabilities for complex non-Roman writing systems"
+  },
+  {
+    "name": "grep",
+    "summary": "Pattern matching utilities"
+  },
+  {
+    "name": "groff-base",
+    "summary": "Parts of the groff formatting system required to display manual pages"
+  },
+  {
+    "name": "grub2-common",
+    "summary": "grub2 common layout"
+  },
+  {
+    "name": "grub2-efi-aa64",
+    "summary": "GRUB for EFI systems."
+  },
+  {
+    "name": "grub2-efi-aa64-cdboot",
+    "summary": "Files used to boot removeable media with EFI"
+  },
+  {
+    "name": "grub2-efi-aa64-modules",
+    "summary": "Modules used to build custom grub.efi images"
+  },
+  {
+    "name": "grub2-efi-x64-modules",
+    "summary": "Modules used to build custom grub.efi images"
+  },
+  {
+    "name": "grub2-tools",
+    "summary": "Support tools for GRUB."
+  },
+  {
+    "name": "grub2-tools-extra",
+    "summary": "Support tools for GRUB."
+  },
+  {
+    "name": "grub2-tools-minimal",
+    "summary": "Support tools for GRUB."
+  },
+  {
+    "name": "grubby",
+    "summary": "Command line tool for updating bootloader configs"
+  },
+  {
+    "name": "gsettings-desktop-schemas",
+    "summary": "A collection of GSettings schemas"
+  },
+  {
+    "name": "gssproxy",
+    "summary": "GSSAPI Proxy"
+  },
+  {
+    "name": "gzip",
+    "summary": "The GNU data compression program"
+  },
+  {
+    "name": "harfbuzz",
+    "summary": "Text shaping library"
+  },
+  {
+    "name": "hdparm",
+    "summary": "A utility for displaying and/or setting hard disk parameters"
+  },
+  {
+    "name": "hostname",
+    "summary": "Utility to set/show the host name or domain name"
+  },
+  {
+    "name": "hwdata",
+    "summary": "Hardware identification and configuration data"
+  },
+  {
+    "name": "hwloc",
+    "summary": "Portable Hardware Locality - portable abstraction of hierarchical architectures"
+  },
+  {
+    "name": "hwloc-libs",
+    "summary": "Run time libraries for the hwloc"
+  },
+  {
+    "name": "ibacm",
+    "summary": "InfiniBand Communication Manager Assistant"
+  },
+  {
+    "name": "ima-evm-utils",
+    "summary": "IMA/EVM support utilities"
+  },
+  {
+    "name": "info",
+    "summary": "A stand-alone TTY-based reader for GNU texinfo documentation"
+  },
+  {
+    "name": "inih",
+    "summary": "Simple INI file parser library"
+  },
+  {
+    "name": "initscripts",
+    "summary": "Basic support for legacy System V init scripts"
+  },
+  {
+    "name": "initscripts-rename-device",
+    "summary": "Udev helper utility that provides network interface naming"
+  },
+  {
+    "name": "initscripts-service",
+    "summary": "Support for service command"
+  },
+  {
+    "name": "integritysetup",
+    "summary": "A utility for setting up dm-integrity volumes"
+  },
+  {
+    "name": "iotop",
+    "summary": "Top like utility for I/O"
+  },
+  {
+    "name": "ipcalc",
+    "summary": "IP network address calculator"
+  },
+  {
+    "name": "iproute",
+    "summary": "Advanced IP routing and network device configuration tools"
+  },
+  {
+    "name": "iproute-tc",
+    "summary": "Linux Traffic Control utility"
+  },
+  {
+    "name": "iprutils",
+    "summary": "Utilities for the IBM Power Linux RAID adapters"
+  },
+  {
+    "name": "ipset",
+    "summary": "Manage Linux IP sets"
+  },
+  {
+    "name": "ipset-libs",
+    "summary": "Shared library providing the IP sets functionality"
+  },
+  {
+    "name": "iptables-libs",
+    "summary": "libxtables and iptables extensions userspace support"
+  },
+  {
+    "name": "iptables-nft",
+    "summary": "nftables compatibility for iptables, arptables and ebtables"
+  },
+  {
+    "name": "iptables-utils",
+    "summary": "iptables and ip6tables misc utilities"
+  },
+  {
+    "name": "iptraf-ng",
+    "summary": "A console-based network monitoring utility"
+  },
+  {
+    "name": "iputils",
+    "summary": "Network monitoring tools including ping"
+  },
+  {
+    "name": "irqbalance",
+    "summary": "IRQ balancing daemon"
+  },
+  {
+    "name": "iscsi-initiator-utils",
+    "summary": "iSCSI daemon and utility programs"
+  },
+  {
+    "name": "iscsi-initiator-utils-iscsiuio",
+    "summary": "Userspace configuration daemon required for some iSCSI hardware"
+  },
+  {
+    "name": "isns-utils",
+    "summary": "The iSNS daemon and utility programs"
+  },
+  {
+    "name": "isns-utils-libs",
+    "summary": "Shared library files for iSNS"
+  },
+  {
+    "name": "iw",
+    "summary": "A nl80211 based wireless configuration tool"
+  },
+  {
+    "name": "iwl100-firmware",
+    "summary": "Firmware for Intel(R) Wireless WiFi Link 100 Series Adapters"
+  },
+  {
+    "name": "iwl1000-firmware",
+    "summary": "Firmware for Intel\u00ae PRO/Wireless 1000 B/G/N network adaptors"
+  },
+  {
+    "name": "iwl105-firmware",
+    "summary": "Firmware for Intel(R) Centrino Wireless-N 105 Series Adapters"
+  },
+  {
+    "name": "iwl135-firmware",
+    "summary": "Firmware for Intel(R) Centrino Wireless-N 135 Series Adapters"
+  },
+  {
+    "name": "iwl2000-firmware",
+    "summary": "Firmware for Intel(R) Centrino Wireless-N 2000 Series Adapters"
+  },
+  {
+    "name": "iwl2030-firmware",
+    "summary": "Firmware for Intel(R) Centrino Wireless-N 2030 Series Adapters"
+  },
+  {
+    "name": "iwl3160-firmware",
+    "summary": "Firmware for Intel(R) Wireless WiFi Link 3160 Series Adapters"
+  },
+  {
+    "name": "iwl5000-firmware",
+    "summary": "Firmware for Intel\u00ae PRO/Wireless 5000 A/G/N network adaptors"
+  },
+  {
+    "name": "iwl5150-firmware",
+    "summary": "Firmware for Intel\u00ae PRO/Wireless 5150 A/G/N network adaptors"
+  },
+  {
+    "name": "iwl6000g2a-firmware",
+    "summary": "Firmware for Intel(R) Wireless WiFi Link 6005 Series Adapters"
+  },
+  {
+    "name": "iwl6000g2b-firmware",
+    "summary": "Firmware for Intel(R) Wireless WiFi Link 6030 Series Adapters"
+  },
+  {
+    "name": "iwl6050-firmware",
+    "summary": "Firmware for Intel(R) Wireless WiFi Link 6050 Series Adapters"
+  },
+  {
+    "name": "iwl7260-firmware",
+    "summary": "Firmware for Intel(R) Wireless WiFi Link 726x/8000/9000/AX200/AX201 Series Adapters"
+  },
+  {
+    "name": "iwpmd",
+    "summary": "iWarp Port Mapper userspace daemon"
+  },
+  {
+    "name": "jansson",
+    "summary": "C library for encoding, decoding and manipulating JSON data"
+  },
+  {
+    "name": "jitterentropy",
+    "summary": "Library implementing the jitter entropy source"
+  },
+  {
+    "name": "jq",
+    "summary": "Command-line JSON processor"
+  },
+  {
+    "name": "json-c",
+    "summary": "JSON implementation in C"
+  },
+  {
+    "name": "json-glib",
+    "summary": "Library for JavaScript Object Notation format"
+  },
+  {
+    "name": "kbd",
+    "summary": "Tools for configuring the console (keyboard, virtual terminals, etc.)"
+  },
+  {
+    "name": "kbd-legacy",
+    "summary": "Legacy data for kbd package"
+  },
+  {
+    "name": "kbd-misc",
+    "summary": "Data for kbd package"
+  },
+  {
+    "name": "kernel",
+    "summary": "The Linux kernel"
+  },
+  {
+    "name": "kernel-64k",
+    "summary": "kernel meta-package for the 64k kernel"
+  },
+  {
+    "name": "kernel-64k-core",
+    "summary": "The Linux kernel compiled for 64k pagesize usage"
+  },
+  {
+    "name": "kernel-64k-debug",
+    "summary": "kernel meta-package for the 64k-debug kernel"
+  },
+  {
+    "name": "kernel-64k-debug-core",
+    "summary": "The Linux kernel compiled with extra debugging enabled"
+  },
+  {
+    "name": "kernel-64k-debug-modules",
+    "summary": "kernel modules to match the core kernel"
+  },
+  {
+    "name": "kernel-64k-debug-modules-core",
+    "summary": "Core kernel modules to match the core kernel"
+  },
+  {
+    "name": "kernel-64k-debug-modules-extra",
+    "summary": "Extra kernel modules to match the kernel"
+  },
+  {
+    "name": "kernel-64k-modules",
+    "summary": "kernel modules to match the core kernel"
+  },
+  {
+    "name": "kernel-64k-modules-core",
+    "summary": "Core kernel modules to match the core kernel"
+  },
+  {
+    "name": "kernel-64k-modules-extra",
+    "summary": "Extra kernel modules to match the kernel"
+  },
+  {
+    "name": "kernel-abi-stablelists",
+    "summary": "The Red Hat Enterprise Linux kernel ABI symbol stablelists"
+  },
+  {
+    "name": "kernel-core",
+    "summary": "The Linux kernel"
+  },
+  {
+    "name": "kernel-debug",
+    "summary": "kernel meta-package for the debug kernel"
+  },
+  {
+    "name": "kernel-debug-core",
+    "summary": "The Linux kernel compiled with extra debugging enabled"
+  },
+  {
+    "name": "kernel-debug-modules",
+    "summary": "kernel modules to match the core kernel"
+  },
+  {
+    "name": "kernel-debug-modules-core",
+    "summary": "Core kernel modules to match the core kernel"
+  },
+  {
+    "name": "kernel-debug-modules-extra",
+    "summary": "Extra kernel modules to match the kernel"
+  },
+  {
+    "name": "kernel-modules",
+    "summary": "kernel modules to match the core kernel"
+  },
+  {
+    "name": "kernel-modules-core",
+    "summary": "Core kernel modules to match the core kernel"
+  },
+  {
+    "name": "kernel-modules-extra",
+    "summary": "Extra kernel modules to match the kernel"
+  },
+  {
+    "name": "kernel-tools",
+    "summary": "Assortment of tools for the Linux kernel"
+  },
+  {
+    "name": "kernel-tools-libs",
+    "summary": "Libraries for the kernels-tools"
+  },
+  {
+    "name": "kexec-tools",
+    "summary": "The kexec/kdump userspace component"
+  },
+  {
+    "name": "keyutils",
+    "summary": "Linux Key Management Utilities"
+  },
+  {
+    "name": "keyutils-libs",
+    "summary": "Key utilities library"
+  },
+  {
+    "name": "kmod",
+    "summary": "Linux kernel module management utilities"
+  },
+  {
+    "name": "kmod-kvdo",
+    "summary": "Kernel Modules for Virtual Data Optimizer"
+  },
+  {
+    "name": "kmod-libs",
+    "summary": "Libraries to handle kernel module loading and unloading"
+  },
+  {
+    "name": "kpartx",
+    "summary": "Partition device manager for device-mapper devices"
+  },
+  {
+    "name": "kpatch",
+    "summary": "Dynamic kernel patch manager"
+  },
+  {
+    "name": "kpatch-dnf",
+    "summary": "kpatch-patch manager plugin for DNF"
+  },
+  {
+    "name": "krb5-libs",
+    "summary": "The non-admin shared libraries used by Kerberos 5"
+  },
+  {
+    "name": "krb5-pkinit",
+    "summary": "The PKINIT module for Kerberos 5"
+  },
+  {
+    "name": "krb5-server",
+    "summary": "The KDC and related programs for Kerberos 5"
+  },
+  {
+    "name": "krb5-server-ldap",
+    "summary": "The LDAP storage plugin for the Kerberos 5 KDC"
+  },
+  {
+    "name": "krb5-workstation",
+    "summary": "Kerberos 5 programs for use on workstations"
+  },
+  {
+    "name": "ktls-utils",
+    "summary": "TLS handshake agent for kernel sockets"
+  },
+  {
+    "name": "ldb-tools",
+    "summary": "Tools to manage LDB files"
+  },
+  {
+    "name": "ledmon",
+    "summary": "Enclosure LED Utilities"
+  },
+  {
+    "name": "ledmon-libs",
+    "summary": "Runtime library files for ledmon"
+  },
+  {
+    "name": "less",
+    "summary": "A text file browser similar to more, but better"
+  },
+  {
+    "name": "libacl",
+    "summary": "Dynamic library for access control list support"
+  },
+  {
+    "name": "libaio",
+    "summary": "Linux-native asynchronous I/O access library"
+  },
+  {
+    "name": "libarchive",
+    "summary": "A library for handling streaming archive formats"
+  },
+  {
+    "name": "libassuan",
+    "summary": "GnuPG IPC library"
+  },
+  {
+    "name": "libatomic",
+    "summary": "The GNU Atomic library"
+  },
+  {
+    "name": "libattr",
+    "summary": "Dynamic library for extended attribute support"
+  },
+  {
+    "name": "libbasicobjects",
+    "summary": "Basic object types for C"
+  },
+  {
+    "name": "libblkid",
+    "summary": "Block device ID library"
+  },
+  {
+    "name": "libbpf",
+    "summary": "Libbpf library"
+  },
+  {
+    "name": "libbrotli",
+    "summary": "Library for brotli lossless compression algorithm"
+  },
+  {
+    "name": "libcap",
+    "summary": "Library for getting and setting POSIX.1e capabilities"
+  },
+  {
+    "name": "libcap-ng",
+    "summary": "Alternate posix capabilities library"
+  },
+  {
+    "name": "libcap-ng-utils",
+    "summary": "Utilities for analyzing and setting file capabilities"
+  },
+  {
+    "name": "libcbor",
+    "summary": "A CBOR parsing library"
+  },
+  {
+    "name": "libcollection",
+    "summary": "Collection data-type for C"
+  },
+  {
+    "name": "libcom_err",
+    "summary": "Common error description library"
+  },
+  {
+    "name": "libcomps",
+    "summary": "Comps XML file manipulation library"
+  },
+  {
+    "name": "libconfig",
+    "summary": "C/C++ configuration file library"
+  },
+  {
+    "name": "libcurl",
+    "summary": "A library for getting files from web servers"
+  },
+  {
+    "name": "libcurl-minimal",
+    "summary": "Conservatively configured build of libcurl for minimal installations"
+  },
+  {
+    "name": "libdaemon",
+    "summary": "Library for writing UNIX daemons"
+  },
+  {
+    "name": "libdb",
+    "summary": "The Berkeley DB database library for C"
+  },
+  {
+    "name": "libdhash",
+    "summary": "Dynamic hash table"
+  },
+  {
+    "name": "libdnf",
+    "summary": "Library providing simplified C and Python API to libsolv"
+  },
+  {
+    "name": "libdnf-plugin-subscription-manager",
+    "summary": "Subscription Manager plugin for libdnf"
+  },
+  {
+    "name": "libeconf",
+    "summary": "Enhanced config file parser library"
+  },
+  {
+    "name": "libedit",
+    "summary": "The NetBSD Editline library"
+  },
+  {
+    "name": "libertas-sd8787-firmware",
+    "summary": "Firmware for Marvell Libertas SD 8787 Network Adapter"
+  },
+  {
+    "name": "libev",
+    "summary": "High-performance event loop/event model with lots of features"
+  },
+  {
+    "name": "libevent",
+    "summary": "Abstract asynchronous event notification library"
+  },
+  {
+    "name": "libfdisk",
+    "summary": "Partitioning library for fdisk-like programs."
+  },
+  {
+    "name": "libffi",
+    "summary": "A portable foreign function interface library"
+  },
+  {
+    "name": "libfido2",
+    "summary": "FIDO2 library"
+  },
+  {
+    "name": "libgcab1",
+    "summary": "Library to create Cabinet archives"
+  },
+  {
+    "name": "libgcc",
+    "summary": "GCC version 11 shared support library"
+  },
+  {
+    "name": "libgcrypt",
+    "summary": "A general-purpose cryptography library"
+  },
+  {
+    "name": "libgfortran",
+    "summary": "Fortran runtime"
+  },
+  {
+    "name": "libgomp",
+    "summary": "GCC OpenMP v4.5 shared support library"
+  },
+  {
+    "name": "libgpg-error",
+    "summary": "Library for error values used by GnuPG components"
+  },
+  {
+    "name": "libgudev",
+    "summary": "GObject-based wrapper library for libudev"
+  },
+  {
+    "name": "libgusb",
+    "summary": "GLib wrapper around libusb1"
+  },
+  {
+    "name": "libibumad",
+    "summary": "OpenFabrics Alliance InfiniBand umad (userspace management datagram) library"
+  },
+  {
+    "name": "libibverbs",
+    "summary": "A library and drivers for direct userspace use of RDMA (InfiniBand/iWARP/RoCE) hardware"
+  },
+  {
+    "name": "libibverbs-utils",
+    "summary": "Examples for the libibverbs library"
+  },
+  {
+    "name": "libicu",
+    "summary": "International Components for Unicode - libraries"
+  },
+  {
+    "name": "libidn2",
+    "summary": "Library to support IDNA2008 internationalized domain names"
+  },
+  {
+    "name": "libini_config",
+    "summary": "INI file parser for C"
+  },
+  {
+    "name": "libipa_hbac",
+    "summary": "FreeIPA HBAC Evaluator library"
+  },
+  {
+    "name": "libjcat",
+    "summary": "Library for reading Jcat files"
+  },
+  {
+    "name": "libkadm5",
+    "summary": "Kerberos 5 Administrative libraries"
+  },
+  {
+    "name": "libkcapi",
+    "summary": "User space interface to the Linux Kernel Crypto API"
+  },
+  {
+    "name": "libkcapi-hmaccalc",
+    "summary": "Drop-in replacements for hmaccalc provided by the libkcapi package"
+  },
+  {
+    "name": "libksba",
+    "summary": "CMS and X.509 library"
+  },
+  {
+    "name": "libldb",
+    "summary": "A schema-less, ldap like, API and database"
+  },
+  {
+    "name": "liblockfile",
+    "summary": "This implements a number of functions found in -lmail on SysV systems"
+  },
+  {
+    "name": "libmbim",
+    "summary": "Support library for the Mobile Broadband Interface Model protocol"
+  },
+  {
+    "name": "libmbim-utils",
+    "summary": "Utilities to use the MBIM protocol from the command line"
+  },
+  {
+    "name": "libmnl",
+    "summary": "A minimalistic Netlink library"
+  },
+  {
+    "name": "libmodulemd",
+    "summary": "Module metadata manipulation library"
+  },
+  {
+    "name": "libmount",
+    "summary": "Device mounting library"
+  },
+  {
+    "name": "libndp",
+    "summary": "Library for Neighbor Discovery Protocol"
+  },
+  {
+    "name": "libnetapi",
+    "summary": "The NETAPI library"
+  },
+  {
+    "name": "libnetfilter_conntrack",
+    "summary": "Netfilter conntrack userspace library"
+  },
+  {
+    "name": "libnfnetlink",
+    "summary": "Netfilter netlink userspace library"
+  },
+  {
+    "name": "libnfsidmap",
+    "summary": "NFSv4 User and Group ID Mapping Library"
+  },
+  {
+    "name": "libnftnl",
+    "summary": "Library for low-level interaction with nftables Netlink's API over libmnl"
+  },
+  {
+    "name": "libnghttp2",
+    "summary": "A library implementing the HTTP/2 protocol"
+  },
+  {
+    "name": "libnl3",
+    "summary": "Convenience library for kernel netlink sockets"
+  },
+  {
+    "name": "libnl3-cli",
+    "summary": "Command line interface utils for libnl3"
+  },
+  {
+    "name": "libnsl",
+    "summary": "Legacy support library for NIS"
+  },
+  {
+    "name": "libnvme",
+    "summary": "Linux-native nvme device management library"
+  },
+  {
+    "name": "libpath_utils",
+    "summary": "Filesystem Path Utilities"
+  },
+  {
+    "name": "libpcap",
+    "summary": "A system-independent interface for user-level packet capture"
+  },
+  {
+    "name": "libpciaccess",
+    "summary": "PCI access library"
+  },
+  {
+    "name": "libpeas",
+    "summary": "Plug-ins implementation convenience library"
+  },
+  {
+    "name": "libpipeline",
+    "summary": "A pipeline manipulation library"
+  },
+  {
+    "name": "libpkgconf",
+    "summary": "Backend library for pkgconf"
+  },
+  {
+    "name": "libpng",
+    "summary": "A library of functions for manipulating PNG image format files"
+  },
+  {
+    "name": "libproxy",
+    "summary": "A library handling all the details of proxy configuration"
+  },
+  {
+    "name": "libpsl",
+    "summary": "C library for the Publix Suffix List"
+  },
+  {
+    "name": "libpwquality",
+    "summary": "A library for password generation and password quality checking"
+  },
+  {
+    "name": "libqmi",
+    "summary": "Support library to use the Qualcomm MSM Interface (QMI) protocol"
+  },
+  {
+    "name": "libqmi-utils",
+    "summary": "Utilities to use the QMI protocol from the command line"
+  },
+  {
+    "name": "libqrtr-glib",
+    "summary": "Support library to use and manage the QRTR (Qualcomm IPC Router) bus."
+  },
+  {
+    "name": "librdmacm",
+    "summary": "Userspace RDMA Connection Manager"
+  },
+  {
+    "name": "librdmacm-utils",
+    "summary": "Examples for the librdmacm library"
+  },
+  {
+    "name": "libref_array",
+    "summary": "A refcounted array for C"
+  },
+  {
+    "name": "librepo",
+    "summary": "Repodata downloading library"
+  },
+  {
+    "name": "libreport-filesystem",
+    "summary": "Filesystem layout for libreport"
+  },
+  {
+    "name": "librhsm",
+    "summary": "Red Hat Subscription Manager library"
+  },
+  {
+    "name": "libseccomp",
+    "summary": "Enhanced seccomp library"
+  },
+  {
+    "name": "libselinux",
+    "summary": "SELinux library and simple utilities"
+  },
+  {
+    "name": "libselinux-utils",
+    "summary": "SELinux libselinux utilities"
+  },
+  {
+    "name": "libsemanage",
+    "summary": "SELinux binary policy manipulation library"
+  },
+  {
+    "name": "libsepol",
+    "summary": "SELinux binary policy manipulation library"
+  },
+  {
+    "name": "libsigsegv",
+    "summary": "Library for handling page faults in user mode"
+  },
+  {
+    "name": "libsmartcols",
+    "summary": "Formatting library for ls-like programs."
+  },
+  {
+    "name": "libsmbclient",
+    "summary": "The SMB client library"
+  },
+  {
+    "name": "libsolv",
+    "summary": "Package dependency solver"
+  },
+  {
+    "name": "libss",
+    "summary": "Command line interface parsing library"
+  },
+  {
+    "name": "libssh",
+    "summary": "A library implementing the SSH protocol"
+  },
+  {
+    "name": "libssh-config",
+    "summary": "Configuration files for libssh"
+  },
+  {
+    "name": "libsss_autofs",
+    "summary": "A library to allow communication between Autofs and SSSD"
+  },
+  {
+    "name": "libsss_certmap",
+    "summary": "SSSD Certificate Mapping Library"
+  },
+  {
+    "name": "libsss_idmap",
+    "summary": "FreeIPA Idmap library"
+  },
+  {
+    "name": "libsss_nss_idmap",
+    "summary": "Library for SID and certificate based lookups"
+  },
+  {
+    "name": "libsss_simpleifp",
+    "summary": "The SSSD D-Bus responder helper library"
+  },
+  {
+    "name": "libsss_sudo",
+    "summary": "A library to allow communication between SUDO and SSSD"
+  },
+  {
+    "name": "libstdc++",
+    "summary": "GNU Standard C++ Library"
+  },
+  {
+    "name": "libsysfs",
+    "summary": "Shared library for interfacing with sysfs"
+  },
+  {
+    "name": "libtalloc",
+    "summary": "The talloc library"
+  },
+  {
+    "name": "libtasn1",
+    "summary": "The ASN.1 library used in GNUTLS"
+  },
+  {
+    "name": "libtdb",
+    "summary": "The tdb library"
+  },
+  {
+    "name": "libteam",
+    "summary": "Library for controlling team network device"
+  },
+  {
+    "name": "libtevent",
+    "summary": "The tevent library"
+  },
+  {
+    "name": "libtirpc",
+    "summary": "Transport Independent RPC Library"
+  },
+  {
+    "name": "libtool-ltdl",
+    "summary": "Runtime libraries for GNU Libtool Dynamic Module Loader"
+  },
+  {
+    "name": "libtracecmd",
+    "summary": "Libraries of trace-cmd"
+  },
+  {
+    "name": "libtraceevent",
+    "summary": "Library to parse raw trace event formats"
+  },
+  {
+    "name": "libtracefs",
+    "summary": "Library for access kernel tracefs"
+  },
+  {
+    "name": "libunistring",
+    "summary": "GNU Unicode string library"
+  },
+  {
+    "name": "libusbx",
+    "summary": "Library for accessing USB devices"
+  },
+  {
+    "name": "libuser",
+    "summary": "A user and group account administration library"
+  },
+  {
+    "name": "libutempter",
+    "summary": "A privileged helper for utmp/wtmp updates"
+  },
+  {
+    "name": "libuuid",
+    "summary": "Universally unique ID library"
+  },
+  {
+    "name": "libverto",
+    "summary": "Main loop abstraction library"
+  },
+  {
+    "name": "libverto-libev",
+    "summary": "libev module for libverto"
+  },
+  {
+    "name": "libwbclient",
+    "summary": "The winbind client library"
+  },
+  {
+    "name": "libxcrypt",
+    "summary": "Extended crypt library for descrypt, md5crypt, bcrypt, and others"
+  },
+  {
+    "name": "libxml2",
+    "summary": "Library providing XML and HTML support"
+  },
+  {
+    "name": "libxmlb",
+    "summary": "Library for querying compressed XML metadata"
+  },
+  {
+    "name": "libyaml",
+    "summary": "YAML 1.1 parser and emitter written in C"
+  },
+  {
+    "name": "libzstd",
+    "summary": "Zstd shared library"
+  },
+  {
+    "name": "linux-firmware",
+    "summary": "Firmware files used by the Linux kernel"
+  },
+  {
+    "name": "linux-firmware-whence",
+    "summary": "WHENCE License file"
+  },
+  {
+    "name": "lksctp-tools",
+    "summary": "User-space access to Linux Kernel SCTP"
+  },
+  {
+    "name": "lldpad",
+    "summary": "Intel LLDP Agent"
+  },
+  {
+    "name": "lmdb-libs",
+    "summary": "Shared libraries for lmdb"
+  },
+  {
+    "name": "lockdev",
+    "summary": "A library for locking devices"
+  },
+  {
+    "name": "logrotate",
+    "summary": "Rotates, compresses, removes and mails system log files"
+  },
+  {
+    "name": "lrzsz",
+    "summary": "The lrz and lsz modem communications programs"
+  },
+  {
+    "name": "lshw",
+    "summary": "Hardware lister"
+  },
+  {
+    "name": "lsof",
+    "summary": "A utility which lists open files on a Linux/UNIX system"
+  },
+  {
+    "name": "lsscsi",
+    "summary": "List SCSI devices (or hosts) and associated information"
+  },
+  {
+    "name": "lua-libs",
+    "summary": "Libraries for lua"
+  },
+  {
+    "name": "lvm2",
+    "summary": "Userland logical volume management tools"
+  },
+  {
+    "name": "lvm2-libs",
+    "summary": "Shared libraries for lvm2"
+  },
+  {
+    "name": "lz4",
+    "summary": "Extremely fast compression algorithm"
+  },
+  {
+    "name": "lz4-libs",
+    "summary": "Libaries for lz4"
+  },
+  {
+    "name": "lzo",
+    "summary": "Data compression library with very fast (de)compression"
+  },
+  {
+    "name": "lzop",
+    "summary": "Real-time file compressor"
+  },
+  {
+    "name": "mailcap",
+    "summary": "Helper application and MIME type associations for file types"
+  },
+  {
+    "name": "make",
+    "summary": "A GNU tool which simplifies the build process for users"
+  },
+  {
+    "name": "man-db",
+    "summary": "Tools for searching and reading man pages"
+  },
+  {
+    "name": "man-pages",
+    "summary": "Linux kernel and C library user-space interface documentation"
+  },
+  {
+    "name": "mcstrans",
+    "summary": "SELinux Translation Daemon"
+  },
+  {
+    "name": "mdadm",
+    "summary": "The mdadm program controls Linux md devices (software RAID arrays)"
+  },
+  {
+    "name": "microdnf",
+    "summary": "Lightweight implementation of DNF in C"
+  },
+  {
+    "name": "minicom",
+    "summary": "A text-based modem control and terminal emulation program"
+  },
+  {
+    "name": "mksh",
+    "summary": "MirBSD enhanced version of the Korn Shell"
+  },
+  {
+    "name": "mlocate",
+    "summary": "An utility for finding files by name"
+  },
+  {
+    "name": "ModemManager",
+    "summary": "Mobile broadband modem management service"
+  },
+  {
+    "name": "ModemManager-glib",
+    "summary": "Libraries for adding ModemManager support to applications that use glib."
+  },
+  {
+    "name": "mokutil",
+    "summary": "Tool to manage UEFI Secure Boot MoK Keys"
+  },
+  {
+    "name": "mpfr",
+    "summary": "C library for multiple-precision floating-point computations"
+  },
+  {
+    "name": "mtools",
+    "summary": "Programs for accessing MS-DOS disks without mounting the disks"
+  },
+  {
+    "name": "mtr",
+    "summary": "Network diagnostic tool combining 'traceroute' and 'ping'"
+  },
+  {
+    "name": "nano",
+    "summary": "A small text editor"
+  },
+  {
+    "name": "ncurses",
+    "summary": "Ncurses support utilities"
+  },
+  {
+    "name": "ncurses-base",
+    "summary": "Descriptions of common terminals"
+  },
+  {
+    "name": "ncurses-libs",
+    "summary": "Ncurses libraries"
+  },
+  {
+    "name": "ndctl",
+    "summary": "Manage \"libnvdimm\" subsystem devices (Non-volatile Memory)"
+  },
+  {
+    "name": "ndctl-libs",
+    "summary": "Management library for \"libnvdimm\" subsystem devices (Non-volatile Memory)"
+  },
+  {
+    "name": "net-tools",
+    "summary": "Basic networking tools"
+  },
+  {
+    "name": "netconsole-service",
+    "summary": "Service for initializing of network console logging"
+  },
+  {
+    "name": "netlabel_tools",
+    "summary": "Tools to manage the Linux NetLabel subsystem"
+  },
+  {
+    "name": "netronome-firmware",
+    "summary": "Firmware for Netronome Smart NICs"
+  },
+  {
+    "name": "nettle",
+    "summary": "A low-level cryptographic library"
+  },
+  {
+    "name": "NetworkManager",
+    "summary": "Network connection manager and user applications"
+  },
+  {
+    "name": "NetworkManager-adsl",
+    "summary": "ADSL device plugin for NetworkManager"
+  },
+  {
+    "name": "NetworkManager-bluetooth",
+    "summary": "Bluetooth device plugin for NetworkManager"
+  },
+  {
+    "name": "NetworkManager-config-server",
+    "summary": "NetworkManager config file for \"server-like\" defaults"
+  },
+  {
+    "name": "NetworkManager-initscripts-updown",
+    "summary": "Legacy ifup/ifdown scripts for NetworkManager that replace initscripts (network-scripts)"
+  },
+  {
+    "name": "NetworkManager-libnm",
+    "summary": "Libraries for adding NetworkManager support to applications."
+  },
+  {
+    "name": "NetworkManager-team",
+    "summary": "Team device plugin for NetworkManager"
+  },
+  {
+    "name": "NetworkManager-tui",
+    "summary": "NetworkManager curses-based UI"
+  },
+  {
+    "name": "NetworkManager-wifi",
+    "summary": "Wifi plugin for NetworkManager"
+  },
+  {
+    "name": "NetworkManager-wwan",
+    "summary": "Mobile broadband device plugin for NetworkManager"
+  },
+  {
+    "name": "newt",
+    "summary": "A library for text mode user interfaces"
+  },
+  {
+    "name": "nfs-utils",
+    "summary": "NFS utilities and supporting clients and daemons for the kernel NFS server"
+  },
+  {
+    "name": "nfs4-acl-tools",
+    "summary": "The nfs4 ACL tools"
+  },
+  {
+    "name": "nftables",
+    "summary": "Netfilter Tables userspace utillites"
+  },
+  {
+    "name": "npth",
+    "summary": "The New GNU Portable Threads library"
+  },
+  {
+    "name": "nscd",
+    "summary": "A Name Service Caching Daemon (nscd)."
+  },
+  {
+    "name": "numactl",
+    "summary": "Library for tuning for Non Uniform Memory Access machines"
+  },
+  {
+    "name": "numactl-libs",
+    "summary": "libnuma libraries"
+  },
+  {
+    "name": "numad",
+    "summary": "NUMA user daemon"
+  },
+  {
+    "name": "nvme-cli",
+    "summary": "NVMe management command line interface"
+  },
+  {
+    "name": "nvmetcli",
+    "summary": "An adminstration shell for NVMe storage targets"
+  },
+  {
+    "name": "oniguruma",
+    "summary": "Regular expressions library"
+  },
+  {
+    "name": "opencryptoki",
+    "summary": "Implementation of the PKCS#11 (Cryptoki) specification v3.0"
+  },
+  {
+    "name": "opencryptoki-icsftok",
+    "summary": "ICSF token support for opencryptoki"
+  },
+  {
+    "name": "opencryptoki-libs",
+    "summary": "The run-time libraries for opencryptoki package"
+  },
+  {
+    "name": "opencryptoki-swtok",
+    "summary": "The software token implementation for opencryptoki"
+  },
+  {
+    "name": "openldap",
+    "summary": "LDAP support libraries"
+  },
+  {
+    "name": "openldap-clients",
+    "summary": "LDAP client utilities"
+  },
+  {
+    "name": "openldap-compat",
+    "summary": "Package providing legacy non-threded libldap"
+  },
+  {
+    "name": "opensc",
+    "summary": "Smart card library and applications"
+  },
+  {
+    "name": "opensm",
+    "summary": "OpenIB InfiniBand Subnet Manager and management utilities"
+  },
+  {
+    "name": "opensm-libs",
+    "summary": "Libraries used by opensm and included utilities"
+  },
+  {
+    "name": "openssh",
+    "summary": "An open source implementation of SSH protocol version 2"
+  },
+  {
+    "name": "openssh-clients",
+    "summary": "An open source SSH client applications"
+  },
+  {
+    "name": "openssh-keycat",
+    "summary": "A mls keycat backend for openssh"
+  },
+  {
+    "name": "openssh-server",
+    "summary": "An open source SSH server daemon"
+  },
+  {
+    "name": "openssl",
+    "summary": "Utilities from the general purpose cryptography library with TLS implementation"
+  },
+  {
+    "name": "openssl-fips-provider",
+    "summary": "FIPS module for OpenSSL"
+  },
+  {
+    "name": "openssl-fips-provider-so",
+    "summary": "FIPS module for OpenSSL"
+  },
+  {
+    "name": "openssl-libs",
+    "summary": "A general purpose cryptography library with TLS implementation"
+  },
+  {
+    "name": "openssl-pkcs11",
+    "summary": "A PKCS#11 engine for use with OpenSSL"
+  },
+  {
+    "name": "os-prober",
+    "summary": "Probes disks on the system for installed operating systems"
+  },
+  {
+    "name": "p11-kit",
+    "summary": "Library for loading and sharing PKCS#11 modules"
+  },
+  {
+    "name": "p11-kit-trust",
+    "summary": "System trust module from p11-kit"
+  },
+  {
+    "name": "pam",
+    "summary": "An extensible library which provides authentication for applications"
+  },
+  {
+    "name": "parted",
+    "summary": "The GNU disk partition manipulation program"
+  },
+  {
+    "name": "passwd",
+    "summary": "An utility for setting or changing passwords using PAM"
+  },
+  {
+    "name": "pciutils",
+    "summary": "PCI bus related utilities"
+  },
+  {
+    "name": "pciutils-libs",
+    "summary": "Linux PCI library"
+  },
+  {
+    "name": "pcre",
+    "summary": "Perl-compatible regular expression library"
+  },
+  {
+    "name": "pcre2",
+    "summary": "Perl-compatible regular expression library"
+  },
+  {
+    "name": "pcre2-syntax",
+    "summary": "Documentation for PCRE2 regular expressions"
+  },
+  {
+    "name": "pcsc-lite",
+    "summary": "PC/SC Lite smart card framework and applications"
+  },
+  {
+    "name": "pcsc-lite-ccid",
+    "summary": "Generic USB CCID smart card reader driver"
+  },
+  {
+    "name": "pcsc-lite-libs",
+    "summary": "PC/SC Lite libraries"
+  },
+  {
+    "name": "perftest",
+    "summary": "IB Performance Tests"
+  },
+  {
+    "name": "pigz",
+    "summary": "Parallel implementation of gzip"
+  },
+  {
+    "name": "pkgconf",
+    "summary": "Package compiler and linker metadata toolkit"
+  },
+  {
+    "name": "pkgconf-m4",
+    "summary": "m4 macros for pkgconf"
+  },
+  {
+    "name": "pkgconf-pkg-config",
+    "summary": "pkgconf shim to provide /usr/bin/pkg-config"
+  },
+  {
+    "name": "policycoreutils",
+    "summary": "SELinux policy core utilities"
+  },
+  {
+    "name": "policycoreutils-newrole",
+    "summary": "The newrole application for RBAC/MLS"
+  },
+  {
+    "name": "policycoreutils-restorecond",
+    "summary": "SELinux restorecond utilities"
+  },
+  {
+    "name": "polkit",
+    "summary": "An authorization framework"
+  },
+  {
+    "name": "polkit-libs",
+    "summary": "Libraries for polkit"
+  },
+  {
+    "name": "polkit-pkla-compat",
+    "summary": "Rules for polkit to add compatibility with pklocalauthority"
+  },
+  {
+    "name": "popt",
+    "summary": "C library for parsing command line parameters"
+  },
+  {
+    "name": "ppp",
+    "summary": "The Point-to-Point Protocol daemon"
+  },
+  {
+    "name": "prefixdevname",
+    "summary": "Udev helper utility that provides network interface naming using user defined prefix"
+  },
+  {
+    "name": "procps-ng",
+    "summary": "System and process monitoring utilities"
+  },
+  {
+    "name": "procps-ng-i18n",
+    "summary": "Internationalization pack for procps-ng"
+  },
+  {
+    "name": "protobuf-c",
+    "summary": "C bindings for Google's Protocol Buffers"
+  },
+  {
+    "name": "psacct",
+    "summary": "Utilities for monitoring process activities"
+  },
+  {
+    "name": "psmisc",
+    "summary": "Utilities for managing processes on your system"
+  },
+  {
+    "name": "publicsuffix-list-dafsa",
+    "summary": "Cross-vendor public domain suffix database in DAFSA form"
+  },
+  {
+    "name": "python3",
+    "summary": "Python 3.9 interpreter"
+  },
+  {
+    "name": "python3-cffi",
+    "summary": "Foreign Function Interface for Python 3 to call C code"
+  },
+  {
+    "name": "python3-chardet",
+    "summary": "Character encoding auto-detection in Python"
+  },
+  {
+    "name": "python3-cloud-what",
+    "summary": "Python package for detection of public cloud provider"
+  },
+  {
+    "name": "python3-configshell",
+    "summary": "A framework to implement simple but nice CLIs"
+  },
+  {
+    "name": "python3-cryptography",
+    "summary": "PyCA's cryptography library"
+  },
+  {
+    "name": "python3-dateutil",
+    "summary": "Powerful extensions to the standard datetime module"
+  },
+  {
+    "name": "python3-dbus",
+    "summary": "D-Bus bindings for python3"
+  },
+  {
+    "name": "python3-decorator",
+    "summary": "Module to simplify usage of decorators in python3"
+  },
+  {
+    "name": "python3-dnf",
+    "summary": "Python 3 interface to DNF"
+  },
+  {
+    "name": "python3-dnf-plugin-post-transaction-actions",
+    "summary": "Post transaction actions Plugin for DNF"
+  },
+  {
+    "name": "python3-dnf-plugin-versionlock",
+    "summary": "Version Lock Plugin for DNF"
+  },
+  {
+    "name": "python3-dnf-plugins-core",
+    "summary": "Core Plugins for DNF"
+  },
+  {
+    "name": "python3-dns",
+    "summary": "DNS toolkit for Python"
+  },
+  {
+    "name": "python3-ethtool",
+    "summary": "Python module to interface with ethtool"
+  },
+  {
+    "name": "python3-firewall",
+    "summary": "Python3 bindings for firewalld"
+  },
+  {
+    "name": "python3-gobject-base",
+    "summary": "Python 3 bindings for GObject Introspection base package"
+  },
+  {
+    "name": "python3-gobject-base-noarch",
+    "summary": "Python 3 bindings for GObject Introspection base (not architecture dependent)"
+  },
+  {
+    "name": "python3-gpg",
+    "summary": "gpgme bindings for Python 3"
+  },
+  {
+    "name": "python3-hawkey",
+    "summary": "Python 3 bindings for the hawkey library"
+  },
+  {
+    "name": "python3-idna",
+    "summary": "Internationalized Domain Names in Applications (IDNA)"
+  },
+  {
+    "name": "python3-iniparse",
+    "summary": "Python Module for Accessing and Modifying Configuration Data in INI files"
+  },
+  {
+    "name": "python3-inotify",
+    "summary": "Monitor filesystem events with Python under Linux"
+  },
+  {
+    "name": "python3-kmod",
+    "summary": "Python module to work with kernel modules"
+  },
+  {
+    "name": "python3-ldb",
+    "summary": "Python bindings for the LDB library"
+  },
+  {
+    "name": "python3-libcomps",
+    "summary": "Python 3 bindings for libcomps library"
+  },
+  {
+    "name": "python3-libdnf",
+    "summary": "Python 3 bindings for the libdnf library."
+  },
+  {
+    "name": "python3-libipa_hbac",
+    "summary": "Python3 bindings for the FreeIPA HBAC Evaluator library"
+  },
+  {
+    "name": "python3-librepo",
+    "summary": "Python 3 bindings for the librepo library"
+  },
+  {
+    "name": "python3-libs",
+    "summary": "Python runtime libraries"
+  },
+  {
+    "name": "python3-libsss_nss_idmap",
+    "summary": "Python3 bindings for libsss_nss_idmap"
+  },
+  {
+    "name": "python3-libxml2",
+    "summary": "Python 3 bindings for the libxml2 library"
+  },
+  {
+    "name": "python3-linux-procfs",
+    "summary": "Linux /proc abstraction classes"
+  },
+  {
+    "name": "python3-markdown",
+    "summary": "Markdown implementation in Python"
+  },
+  {
+    "name": "python3-nftables",
+    "summary": "Python module providing an interface to libnftables"
+  },
+  {
+    "name": "python3-perf",
+    "summary": "Python bindings for apps which will manipulate perf events"
+  },
+  {
+    "name": "python3-pexpect",
+    "summary": "Unicode-aware Pure Python Expect-like module"
+  },
+  {
+    "name": "python3-pip-wheel",
+    "summary": "The pip wheel"
+  },
+  {
+    "name": "python3-ply",
+    "summary": "Python Lex-Yacc"
+  },
+  {
+    "name": "python3-ptyprocess",
+    "summary": "Run a subprocess in a pseudo terminal"
+  },
+  {
+    "name": "python3-pycparser",
+    "summary": "C parser and AST generator written in Python"
+  },
+  {
+    "name": "python3-pyparsing",
+    "summary": "Python package with an object-oriented approach to text processing"
+  },
+  {
+    "name": "python3-pysocks",
+    "summary": "A Python SOCKS client module"
+  },
+  {
+    "name": "python3-pyudev",
+    "summary": "A libudev binding"
+  },
+  {
+    "name": "python3-pyyaml",
+    "summary": "YAML parser and emitter for Python"
+  },
+  {
+    "name": "python3-requests",
+    "summary": "HTTP library, written in Python, for human beings"
+  },
+  {
+    "name": "python3-rpm",
+    "summary": "Python 3 bindings for apps which will manipulate RPM packages"
+  },
+  {
+    "name": "python3-samba",
+    "summary": "Samba Python3 libraries"
+  },
+  {
+    "name": "python3-samba-dc",
+    "summary": "Samba Python libraries for Samba AD"
+  },
+  {
+    "name": "python3-setools",
+    "summary": "Policy analysis tools for SELinux"
+  },
+  {
+    "name": "python3-setuptools",
+    "summary": "Easily build and distribute Python 3 packages"
+  },
+  {
+    "name": "python3-setuptools-wheel",
+    "summary": "The setuptools wheel"
+  },
+  {
+    "name": "python3-six",
+    "summary": "Python 2 and 3 compatibility utilities"
+  },
+  {
+    "name": "python3-sss",
+    "summary": "Python3 bindings for sssd"
+  },
+  {
+    "name": "python3-sss-murmur",
+    "summary": "Python3 bindings for murmur hash function"
+  },
+  {
+    "name": "python3-sssdconfig",
+    "summary": "SSSD and IPA configuration file manipulation classes and functions"
+  },
+  {
+    "name": "python3-subscription-manager-rhsm",
+    "summary": "A Python library to communicate with a Red Hat Unified Entitlement Platform"
+  },
+  {
+    "name": "python3-systemd",
+    "summary": "Python module wrapping systemd functionality"
+  },
+  {
+    "name": "python3-talloc",
+    "summary": "Python bindings for the Talloc library"
+  },
+  {
+    "name": "python3-tdb",
+    "summary": "Python3 bindings for the Tdb library"
+  },
+  {
+    "name": "python3-tevent",
+    "summary": "Python 3 bindings for the Tevent library"
+  },
+  {
+    "name": "python3-urllib3",
+    "summary": "Python3 HTTP library with thread-safe connection pooling and file post"
+  },
+  {
+    "name": "python3-urwid",
+    "summary": "Console user interface library"
+  },
+  {
+    "name": "quota",
+    "summary": "System administration tools for monitoring users' disk usage"
+  },
+  {
+    "name": "quota-nls",
+    "summary": "Gettext catalogs for disk quota tools"
+  },
+  {
+    "name": "rdma-core",
+    "summary": "RDMA core userspace libraries and daemons"
+  },
+  {
+    "name": "readline",
+    "summary": "A library for editing typed command lines"
+  },
+  {
+    "name": "readonly-root",
+    "summary": "Service for configuring read-only root support"
+  },
+  {
+    "name": "realmd",
+    "summary": "Kerberos realm enrollment service"
+  },
+  {
+    "name": "redhat-release",
+    "summary": "Red Hat Enterprise Linux release file"
+  },
+  {
+    "name": "redhat-release-eula",
+    "summary": "Red Hat Enterprise Linux EULA file"
+  },
+  {
+    "name": "restore",
+    "summary": "Program for restoring ext2/ext3 filesystems"
+  },
+  {
+    "name": "rhel-net-naming-sysattrs",
+    "summary": "RHEL-specific network naming sysattrs"
+  },
+  {
+    "name": "rhsm-icons",
+    "summary": "Icons for Red Hat Subscription Management client tools"
+  },
+  {
+    "name": "rmt",
+    "summary": "Provides certain programs with access to remote tape devices"
+  },
+  {
+    "name": "rng-tools",
+    "summary": "Random number generator related utilities"
+  },
+  {
+    "name": "rootfiles",
+    "summary": "The basic required files for the root user's directory"
+  },
+  {
+    "name": "rpcbind",
+    "summary": "Universal Addresses to RPC Program Number Mapper"
+  },
+  {
+    "name": "rpm",
+    "summary": "The RPM package management system"
+  },
+  {
+    "name": "rpm-build-libs",
+    "summary": "Libraries for building RPM packages"
+  },
+  {
+    "name": "rpm-libs",
+    "summary": "Libraries for manipulating RPM packages"
+  },
+  {
+    "name": "rpm-plugin-audit",
+    "summary": "Rpm plugin for logging audit events on package operations"
+  },
+  {
+    "name": "rpm-plugin-selinux",
+    "summary": "Rpm plugin for SELinux functionality"
+  },
+  {
+    "name": "rpm-sign",
+    "summary": "Package signing support"
+  },
+  {
+    "name": "rpm-sign-libs",
+    "summary": "Libraries for signing RPM packages"
+  },
+  {
+    "name": "rsync",
+    "summary": "A program for synchronizing files over a network"
+  },
+  {
+    "name": "samba",
+    "summary": "Server and Client software to interoperate with Windows machines"
+  },
+  {
+    "name": "samba-client-libs",
+    "summary": "Samba client libraries"
+  },
+  {
+    "name": "samba-common",
+    "summary": "Files used by both Samba servers and clients"
+  },
+  {
+    "name": "samba-common-libs",
+    "summary": "Libraries used by both Samba servers and clients"
+  },
+  {
+    "name": "samba-common-tools",
+    "summary": "Tools for Samba servers and clients"
+  },
+  {
+    "name": "samba-dc-libs",
+    "summary": "Samba AD Domain Controller Libraries"
+  },
+  {
+    "name": "samba-dcerpc",
+    "summary": "DCE RPC binaries"
+  },
+  {
+    "name": "samba-ldb-ldap-modules",
+    "summary": "Samba ldap modules for ldb"
+  },
+  {
+    "name": "samba-libs",
+    "summary": "Samba libraries"
+  },
+  {
+    "name": "samba-tools",
+    "summary": "Tools for Samba servers"
+  },
+  {
+    "name": "samba-usershares",
+    "summary": "Provides support for non-root user shares"
+  },
+  {
+    "name": "samba-winbind",
+    "summary": "Samba winbind"
+  },
+  {
+    "name": "samba-winbind-modules",
+    "summary": "Samba winbind modules"
+  },
+  {
+    "name": "sed",
+    "summary": "A GNU stream text editor"
+  },
+  {
+    "name": "selinux-policy",
+    "summary": "SELinux policy configuration"
+  },
+  {
+    "name": "selinux-policy-doc",
+    "summary": "SELinux policy documentation"
+  },
+  {
+    "name": "selinux-policy-mls",
+    "summary": "SELinux MLS policy"
+  },
+  {
+    "name": "selinux-policy-sandbox",
+    "summary": "SELinux sandbox policy"
+  },
+  {
+    "name": "selinux-policy-targeted",
+    "summary": "SELinux targeted policy"
+  },
+  {
+    "name": "setools-console",
+    "summary": "Policy analysis command-line tools for SELinux"
+  },
+  {
+    "name": "setserial",
+    "summary": "A utility for configuring serial ports"
+  },
+  {
+    "name": "setup",
+    "summary": "A set of system configuration and setup files"
+  },
+  {
+    "name": "sg3_utils",
+    "summary": "Utilities for devices that use SCSI command sets"
+  },
+  {
+    "name": "sg3_utils-libs",
+    "summary": "Shared library for sg3_utils"
+  },
+  {
+    "name": "shadow-utils",
+    "summary": "Utilities for managing accounts and shadow password files"
+  },
+  {
+    "name": "shadow-utils-subid",
+    "summary": "A library to manage subordinate uid and gid ranges"
+  },
+  {
+    "name": "shared-mime-info",
+    "summary": "Shared MIME information database"
+  },
+  {
+    "name": "shim-aa64",
+    "summary": "First-stage UEFI bootloader"
+  },
+  {
+    "name": "slang",
+    "summary": "Shared library for the S-Lang extension language"
+  },
+  {
+    "name": "smartmontools",
+    "summary": "Tools for monitoring SMART capable hard disks"
+  },
+  {
+    "name": "snappy",
+    "summary": "Fast compression and decompression library"
+  },
+  {
+    "name": "sos",
+    "summary": "A set of tools to gather troubleshooting information from a system"
+  },
+  {
+    "name": "sos-audit",
+    "summary": "Audit use of some commands for support purposes"
+  },
+  {
+    "name": "sqlite-libs",
+    "summary": "Shared library for the sqlite3 embeddable SQL database engine."
+  },
+  {
+    "name": "squashfs-tools",
+    "summary": "Utility for the creation of squashfs filesystems"
+  },
+  {
+    "name": "srp_daemon",
+    "summary": "Tools for using the InfiniBand SRP protocol devices"
+  },
+  {
+    "name": "sssd",
+    "summary": "System Security Services Daemon"
+  },
+  {
+    "name": "sssd-ad",
+    "summary": "The AD back end of the SSSD"
+  },
+  {
+    "name": "sssd-client",
+    "summary": "SSSD Client libraries for NSS and PAM"
+  },
+  {
+    "name": "sssd-common",
+    "summary": "Common files for the SSSD"
+  },
+  {
+    "name": "sssd-common-pac",
+    "summary": "Common files needed for supporting PAC processing"
+  },
+  {
+    "name": "sssd-dbus",
+    "summary": "The D-Bus responder of the SSSD"
+  },
+  {
+    "name": "sssd-ipa",
+    "summary": "The IPA back end of the SSSD"
+  },
+  {
+    "name": "sssd-kcm",
+    "summary": "An implementation of a Kerberos KCM server"
+  },
+  {
+    "name": "sssd-krb5",
+    "summary": "The Kerberos authentication back end for the SSSD"
+  },
+  {
+    "name": "sssd-krb5-common",
+    "summary": "SSSD helpers needed for Kerberos and GSSAPI authentication"
+  },
+  {
+    "name": "sssd-ldap",
+    "summary": "The LDAP back end of the SSSD"
+  },
+  {
+    "name": "sssd-nfs-idmap",
+    "summary": "SSSD plug-in for NFSv4 rpc.idmapd"
+  },
+  {
+    "name": "sssd-passkey",
+    "summary": "SSSD helpers and plugins needed for authentication with passkey token"
+  },
+  {
+    "name": "sssd-polkit-rules",
+    "summary": "Rules for polkit integration for SSSD"
+  },
+  {
+    "name": "sssd-proxy",
+    "summary": "The proxy back end of the SSSD"
+  },
+  {
+    "name": "sssd-tools",
+    "summary": "Userspace tools for use with the SSSD"
+  },
+  {
+    "name": "sssd-winbind-idmap",
+    "summary": "SSSD's idmap_sss Backend for Winbind"
+  },
+  {
+    "name": "strace",
+    "summary": "Tracks and displays system calls associated with a running process"
+  },
+  {
+    "name": "stunnel",
+    "summary": "A TLS-encrypting socket wrapper"
+  },
+  {
+    "name": "subscription-manager",
+    "summary": "Tools and libraries for subscription and repository management"
+  },
+  {
+    "name": "subscription-manager-cockpit",
+    "summary": "Subscription Manager Cockpit UI"
+  },
+  {
+    "name": "subscription-manager-plugin-ostree",
+    "summary": "A plugin for handling OSTree content."
+  },
+  {
+    "name": "subscription-manager-rhsm-certificates",
+    "summary": "Certificates required to communicate with a Red Hat Unified Entitlement Platform"
+  },
+  {
+    "name": "sudo",
+    "summary": "Allows restricted root access for specified users"
+  },
+  {
+    "name": "symlinks",
+    "summary": "A utility which maintains a system's symbolic links"
+  },
+  {
+    "name": "systemd",
+    "summary": "System and Service Manager"
+  },
+  {
+    "name": "systemd-container",
+    "summary": "Tools for containers and VMs"
+  },
+  {
+    "name": "systemd-libs",
+    "summary": "systemd libraries"
+  },
+  {
+    "name": "systemd-oomd",
+    "summary": "A userspace out-of-memory (OOM) killer"
+  },
+  {
+    "name": "systemd-pam",
+    "summary": "systemd PAM module"
+  },
+  {
+    "name": "systemd-resolved",
+    "summary": "System daemon that provides network name resolution to local applications"
+  },
+  {
+    "name": "systemd-rpm-macros",
+    "summary": "Macros that define paths and scriptlets related to systemd"
+  },
+  {
+    "name": "systemd-udev",
+    "summary": "Rule-based device node and kernel event manager"
+  },
+  {
+    "name": "tar",
+    "summary": "GNU file archiving program"
+  },
+  {
+    "name": "tcl",
+    "summary": "Tool Command Language, pronounced tickle"
+  },
+  {
+    "name": "tdb-tools",
+    "summary": "Developer tools for the Tdb library"
+  },
+  {
+    "name": "teamd",
+    "summary": "Team network device control daemon"
+  },
+  {
+    "name": "time",
+    "summary": "A GNU utility for monitoring a program's use of system resources"
+  },
+  {
+    "name": "tmux",
+    "summary": "A terminal multiplexer"
+  },
+  {
+    "name": "tpm2-tss",
+    "summary": "TPM2.0 Software Stack"
+  },
+  {
+    "name": "trace-cmd",
+    "summary": "A user interface to Ftrace"
+  },
+  {
+    "name": "traceroute",
+    "summary": "Traces the route taken by packets over an IPv4/IPv6 network"
+  },
+  {
+    "name": "tree",
+    "summary": "File system tree viewer"
+  },
+  {
+    "name": "tuna",
+    "summary": "Application tuning GUI & command line utility"
+  },
+  {
+    "name": "tuned",
+    "summary": "A dynamic adaptive system tuning daemon"
+  },
+  {
+    "name": "tuned-profiles-cpu-partitioning",
+    "summary": "Additional tuned profile(s) optimized for CPU partitioning"
+  },
+  {
+    "name": "tzdata",
+    "summary": "Timezone data"
+  },
+  {
+    "name": "units",
+    "summary": "A utility for converting amounts from one unit to another"
+  },
+  {
+    "name": "unzip",
+    "summary": "A utility for unpacking zip files"
+  },
+  {
+    "name": "usb_modeswitch",
+    "summary": "USB Modeswitch gets mobile broadband cards in operational mode"
+  },
+  {
+    "name": "usb_modeswitch-data",
+    "summary": "USB Modeswitch gets mobile broadband cards in operational mode"
+  },
+  {
+    "name": "usbutils",
+    "summary": "Linux USB utilities"
+  },
+  {
+    "name": "usermode",
+    "summary": "Tools for certain user account management tasks"
+  },
+  {
+    "name": "userspace-rcu",
+    "summary": "RCU (read-copy-update) implementation in user-space"
+  },
+  {
+    "name": "util-linux",
+    "summary": "A collection of basic system utilities"
+  },
+  {
+    "name": "util-linux-core",
+    "summary": "The most essential utilities from the util-linux suite."
+  },
+  {
+    "name": "util-linux-user",
+    "summary": "libuser based util-linux utilities"
+  },
+  {
+    "name": "vdo",
+    "summary": "Management tools for Virtual Data Optimizer"
+  },
+  {
+    "name": "vdo-support",
+    "summary": "Support tools for Virtual Data Optimizer"
+  },
+  {
+    "name": "veritysetup",
+    "summary": "A utility for setting up dm-verity volumes"
+  },
+  {
+    "name": "vim-filesystem",
+    "summary": "VIM filesystem layout"
+  },
+  {
+    "name": "vim-minimal",
+    "summary": "A minimal version of the VIM editor"
+  },
+  {
+    "name": "virt-what",
+    "summary": "Detect if we are running in a virtual machine"
+  },
+  {
+    "name": "which",
+    "summary": "Displays where a particular program in your path is located"
+  },
+  {
+    "name": "wireless-regdb",
+    "summary": "Regulatory database for 802.11 wireless networking"
+  },
+  {
+    "name": "words",
+    "summary": "A dictionary of English words for the /usr/share/dict directory"
+  },
+  {
+    "name": "wpa_supplicant",
+    "summary": "WPA/WPA2/IEEE 802.1X Supplicant"
+  },
+  {
+    "name": "x3270",
+    "summary": "An X Window System based IBM 3278/3279 terminal emulator"
+  },
+  {
+    "name": "x3270-text",
+    "summary": "IBM 3278/3279 terminal emulator for text mode"
+  },
+  {
+    "name": "xfsdump",
+    "summary": "Backup and restore utilities for the XFS filesystem"
+  },
+  {
+    "name": "xfsprogs",
+    "summary": "Utilities for managing the XFS filesystem"
+  },
+  {
+    "name": "xz",
+    "summary": "LZMA compression utilities"
+  },
+  {
+    "name": "xz-libs",
+    "summary": "Libraries for decoding LZMA compression"
+  },
+  {
+    "name": "yum",
+    "summary": "Package manager"
+  },
+  {
+    "name": "yum-utils",
+    "summary": "Yum-utils CLI compatibility layer"
+  },
+  {
+    "name": "zip",
+    "summary": "A file compression and packaging utility compatible with PKZIP"
+  },
+  {
+    "name": "zlib",
+    "summary": "Compression and decompression library"
+  },
+  {
+    "name": "zsh",
+    "summary": "Powerful interactive shell"
+  },
+  {
+    "name": "zstd",
+    "summary": "Zstd compression library"
+  }
+]

--- a/distributions/rhel-9.6/rhel-9.6-x86_64-appstream-packages.json
+++ b/distributions/rhel-9.6/rhel-9.6-x86_64-appstream-packages.json
@@ -1,0 +1,19910 @@
+[
+  {
+    "name": "389-ds-base",
+    "summary": "389 Directory Server (base)"
+  },
+  {
+    "name": "389-ds-base-libs",
+    "summary": "Core libraries for 389 Directory Server"
+  },
+  {
+    "name": "389-ds-base-snmp",
+    "summary": "SNMP Agent for 389 Directory Server"
+  },
+  {
+    "name": "a52dec",
+    "summary": "Small test program for liba52"
+  },
+  {
+    "name": "aajohan-comfortaa-fonts",
+    "summary": "Modern style true type font"
+  },
+  {
+    "name": "aardvark-dns",
+    "summary": "Authoritative DNS server for A/AAAA container records"
+  },
+  {
+    "name": "abattis-cantarell-fonts",
+    "summary": "Humanist sans serif font"
+  },
+  {
+    "name": "accountsservice",
+    "summary": "D-Bus interfaces for querying and manipulating user account information"
+  },
+  {
+    "name": "accountsservice-libs",
+    "summary": "Client-side library to talk to accountsservice"
+  },
+  {
+    "name": "acpid",
+    "summary": "ACPI Event Daemon"
+  },
+  {
+    "name": "adobe-mappings-cmap",
+    "summary": "CMap resources for Adobe's character collections"
+  },
+  {
+    "name": "adobe-mappings-cmap-deprecated",
+    "summary": "Deprecated CMap resources for Adobe's character collections"
+  },
+  {
+    "name": "adobe-mappings-pdf",
+    "summary": "PDF mapping resources from Adobe"
+  },
+  {
+    "name": "adobe-source-code-pro-fonts",
+    "summary": "A set of mono-spaced OpenType fonts designed for coding environments"
+  },
+  {
+    "name": "adwaita-cursor-theme",
+    "summary": "Adwaita cursor theme"
+  },
+  {
+    "name": "adwaita-gtk2-theme",
+    "summary": "Adwaita gtk2 theme"
+  },
+  {
+    "name": "adwaita-icon-theme",
+    "summary": "Adwaita icon theme"
+  },
+  {
+    "name": "adwaita-qt5",
+    "summary": "Adwaita Qt5 theme"
+  },
+  {
+    "name": "afterburn",
+    "summary": "Simple cloud provider agent"
+  },
+  {
+    "name": "afterburn-dracut",
+    "summary": "Dracut modules for afterburn"
+  },
+  {
+    "name": "aide",
+    "summary": "Intrusion detection environment"
+  },
+  {
+    "name": "alsa-firmware",
+    "summary": "Firmware for several ALSA-supported sound cards"
+  },
+  {
+    "name": "alsa-lib",
+    "summary": "The Advanced Linux Sound Architecture (ALSA) library"
+  },
+  {
+    "name": "alsa-lib-devel",
+    "summary": "Development files from the ALSA library"
+  },
+  {
+    "name": "alsa-plugins-arcamav",
+    "summary": "Arcam AV amplifier plugin for ALSA"
+  },
+  {
+    "name": "alsa-plugins-maemo",
+    "summary": "Maemo plugin for ALSA"
+  },
+  {
+    "name": "alsa-plugins-oss",
+    "summary": "Oss PCM output plugin for ALSA"
+  },
+  {
+    "name": "alsa-plugins-pulseaudio",
+    "summary": "Alsa to PulseAudio backend"
+  },
+  {
+    "name": "alsa-plugins-samplerate",
+    "summary": "External rate converter plugin for ALSA"
+  },
+  {
+    "name": "alsa-plugins-speex",
+    "summary": "Rate Converter Plugin Using Speex Resampler"
+  },
+  {
+    "name": "alsa-plugins-upmix",
+    "summary": "Upmixer channel expander plugin for ALSA"
+  },
+  {
+    "name": "alsa-plugins-usbstream",
+    "summary": "USB stream plugin for ALSA"
+  },
+  {
+    "name": "alsa-plugins-vdownmix",
+    "summary": "Downmixer to stereo plugin for ALSA"
+  },
+  {
+    "name": "alsa-sof-firmware",
+    "summary": "Firmware and topology files for Sound Open Firmware project"
+  },
+  {
+    "name": "alsa-tools-firmware",
+    "summary": "ALSA tools for uploading firmware to some soundcards"
+  },
+  {
+    "name": "alsa-ucm",
+    "summary": "ALSA Use Case Manager configuration"
+  },
+  {
+    "name": "alsa-utils",
+    "summary": "Advanced Linux Sound Architecture (ALSA) utilities"
+  },
+  {
+    "name": "anaconda",
+    "summary": "Graphical system installer"
+  },
+  {
+    "name": "anaconda-core",
+    "summary": "Core of the Anaconda installer"
+  },
+  {
+    "name": "anaconda-dracut",
+    "summary": "The anaconda dracut module"
+  },
+  {
+    "name": "anaconda-gui",
+    "summary": "Graphical user interface for the Anaconda installer"
+  },
+  {
+    "name": "anaconda-install-env-deps",
+    "summary": "Installation environment specific dependencies"
+  },
+  {
+    "name": "anaconda-install-img-deps",
+    "summary": "Installation image specific dependencies"
+  },
+  {
+    "name": "anaconda-tui",
+    "summary": "Textual user interface for the Anaconda installer"
+  },
+  {
+    "name": "anaconda-user-help",
+    "summary": "Content for the Anaconda built-in help system"
+  },
+  {
+    "name": "anaconda-widgets",
+    "summary": "A set of custom GTK+ widgets for use with anaconda"
+  },
+  {
+    "name": "annobin",
+    "summary": "Annotate and examine compiled binary files"
+  },
+  {
+    "name": "annobin-annocheck",
+    "summary": "A tool for checking the security hardening status of binaries"
+  },
+  {
+    "name": "ansible-collection-microsoft-sql",
+    "summary": "The Ansible collection for Microsoft SQL Server management"
+  },
+  {
+    "name": "ansible-collection-redhat-rhel_mgmt",
+    "summary": "Ansible Collection of general system management and utility modules and other plugins"
+  },
+  {
+    "name": "ansible-core",
+    "summary": "SSH-based configuration management, deployment, and task execution system"
+  },
+  {
+    "name": "ansible-freeipa",
+    "summary": "Roles and playbooks to deploy FreeIPA servers, replicas and clients"
+  },
+  {
+    "name": "ansible-freeipa-collection",
+    "summary": "freeipa.ansible_freeipa collection"
+  },
+  {
+    "name": "ansible-freeipa-tests",
+    "summary": "ansible-freeipa tests"
+  },
+  {
+    "name": "ansible-pcp",
+    "summary": "Ansible Metric collection for Performance Co-Pilot"
+  },
+  {
+    "name": "ansible-test",
+    "summary": "Tool for testing ansible plugin and module code"
+  },
+  {
+    "name": "ant",
+    "summary": "Java build tool"
+  },
+  {
+    "name": "ant-antlr",
+    "summary": "Optional antlr tasks for ant"
+  },
+  {
+    "name": "ant-apache-bcel",
+    "summary": "Optional apache bcel tasks for ant"
+  },
+  {
+    "name": "ant-apache-bsf",
+    "summary": "Optional apache bsf tasks for ant"
+  },
+  {
+    "name": "ant-apache-oro",
+    "summary": "Optional apache oro tasks for ant"
+  },
+  {
+    "name": "ant-apache-regexp",
+    "summary": "Optional apache regexp tasks for ant"
+  },
+  {
+    "name": "ant-apache-resolver",
+    "summary": "Optional apache resolver tasks for ant"
+  },
+  {
+    "name": "ant-apache-xalan2",
+    "summary": "Optional apache xalan2 tasks for ant"
+  },
+  {
+    "name": "ant-commons-logging",
+    "summary": "Optional commons logging tasks for ant"
+  },
+  {
+    "name": "ant-commons-net",
+    "summary": "Optional commons net tasks for ant"
+  },
+  {
+    "name": "ant-javamail",
+    "summary": "Optional javamail tasks for ant"
+  },
+  {
+    "name": "ant-jdepend",
+    "summary": "Optional jdepend tasks for ant"
+  },
+  {
+    "name": "ant-jmf",
+    "summary": "Optional jmf tasks for ant"
+  },
+  {
+    "name": "ant-jsch",
+    "summary": "Optional jsch tasks for ant"
+  },
+  {
+    "name": "ant-junit",
+    "summary": "Optional junit tasks for ant"
+  },
+  {
+    "name": "ant-junit5",
+    "summary": "Optional junit5 tasks for ant"
+  },
+  {
+    "name": "ant-lib",
+    "summary": "Core part of ant"
+  },
+  {
+    "name": "ant-openjdk11",
+    "summary": "OpenJDK 11 binding for Ant"
+  },
+  {
+    "name": "ant-openjdk17",
+    "summary": "OpenJDK 17 binding for Ant"
+  },
+  {
+    "name": "ant-openjdk21",
+    "summary": "OpenJDK 21 binding for Ant"
+  },
+  {
+    "name": "ant-openjdk8",
+    "summary": "OpenJDK 8 binding for Ant"
+  },
+  {
+    "name": "ant-swing",
+    "summary": "Optional swing tasks for ant"
+  },
+  {
+    "name": "ant-testutil",
+    "summary": "Test utility classes for ant"
+  },
+  {
+    "name": "ant-xz",
+    "summary": "Optional xz tasks for ant"
+  },
+  {
+    "name": "anthy-unicode",
+    "summary": "Japanese character set input library for Unicode"
+  },
+  {
+    "name": "antlr-tool",
+    "summary": "ANother Tool for Language Recognition"
+  },
+  {
+    "name": "apache-commons-cli",
+    "summary": "Command Line Interface Library for Java"
+  },
+  {
+    "name": "apache-commons-codec",
+    "summary": "Implementations of common encoders and decoders"
+  },
+  {
+    "name": "apache-commons-io",
+    "summary": "Utilities to assist with developing IO functionality"
+  },
+  {
+    "name": "apache-commons-lang3",
+    "summary": "Provides a host of helper utilities for the java.lang API"
+  },
+  {
+    "name": "apache-commons-logging",
+    "summary": "Apache Commons Logging"
+  },
+  {
+    "name": "apache-commons-net",
+    "summary": "Internet protocol suite Java library"
+  },
+  {
+    "name": "apcu-panel",
+    "summary": "APCu control panel"
+  },
+  {
+    "name": "appstream",
+    "summary": "Utilities to generate, maintain and access the AppStream database"
+  },
+  {
+    "name": "appstream-data",
+    "summary": "Cached AppStream metadata"
+  },
+  {
+    "name": "apr",
+    "summary": "Apache Portable Runtime library"
+  },
+  {
+    "name": "apr-devel",
+    "summary": "APR library development kit"
+  },
+  {
+    "name": "apr-util",
+    "summary": "Apache Portable Runtime Utility library"
+  },
+  {
+    "name": "apr-util-bdb",
+    "summary": "APR utility library Berkeley DB driver"
+  },
+  {
+    "name": "apr-util-devel",
+    "summary": "APR utility library development kit"
+  },
+  {
+    "name": "apr-util-ldap",
+    "summary": "APR utility library LDAP support"
+  },
+  {
+    "name": "apr-util-mysql",
+    "summary": "APR utility library MySQL DBD driver"
+  },
+  {
+    "name": "apr-util-odbc",
+    "summary": "APR utility library ODBC DBD driver"
+  },
+  {
+    "name": "apr-util-openssl",
+    "summary": "APR utility library OpenSSL crypto support"
+  },
+  {
+    "name": "apr-util-pgsql",
+    "summary": "APR utility library PostgreSQL DBD driver"
+  },
+  {
+    "name": "apr-util-sqlite",
+    "summary": "APR utility library SQLite DBD driver"
+  },
+  {
+    "name": "asciidoc",
+    "summary": "Text based document generation"
+  },
+  {
+    "name": "aspnetcore-runtime-6.0",
+    "summary": "ASP.NET Core 6.0 runtime"
+  },
+  {
+    "name": "aspnetcore-runtime-7.0",
+    "summary": "ASP.NET Core 7.0 runtime"
+  },
+  {
+    "name": "aspnetcore-runtime-8.0",
+    "summary": "ASP.NET Core 8.0 runtime"
+  },
+  {
+    "name": "aspnetcore-runtime-9.0",
+    "summary": "ASP.NET Core 9.0 runtime"
+  },
+  {
+    "name": "aspnetcore-runtime-dbg-8.0",
+    "summary": "Managed debug symbols for the ASP.NET Core 8.0 runtime"
+  },
+  {
+    "name": "aspnetcore-runtime-dbg-9.0",
+    "summary": "Managed debug symbols for the ASP.NET Core 9.0 runtime"
+  },
+  {
+    "name": "aspnetcore-targeting-pack-6.0",
+    "summary": "Targeting Pack for Microsoft.AspNetCore.App 6.0"
+  },
+  {
+    "name": "aspnetcore-targeting-pack-7.0",
+    "summary": "Targeting Pack for Microsoft.AspNetCore.App 7.0"
+  },
+  {
+    "name": "aspnetcore-targeting-pack-8.0",
+    "summary": "Targeting Pack for Microsoft.AspNetCore.App 8.0"
+  },
+  {
+    "name": "aspnetcore-targeting-pack-9.0",
+    "summary": "Targeting Pack for Microsoft.AspNetCore.App 9.0"
+  },
+  {
+    "name": "assertj-core",
+    "summary": "Library of assertions similar to fest-assert"
+  },
+  {
+    "name": "at-spi2-atk",
+    "summary": "A GTK+ module that bridges ATK to D-Bus at-spi"
+  },
+  {
+    "name": "at-spi2-atk-devel",
+    "summary": "A GTK+ module that bridges ATK to D-Bus at-spi"
+  },
+  {
+    "name": "at-spi2-core",
+    "summary": "Protocol definitions and daemon for D-Bus at-spi"
+  },
+  {
+    "name": "at-spi2-core-devel",
+    "summary": "Development files and headers for at-spi2-core"
+  },
+  {
+    "name": "atinject",
+    "summary": "Dependency injection specification for Java (JSR-330)"
+  },
+  {
+    "name": "atk",
+    "summary": "Interfaces for accessibility support"
+  },
+  {
+    "name": "atk-devel",
+    "summary": "Development files for the ATK accessibility toolkit"
+  },
+  {
+    "name": "atkmm",
+    "summary": "C++ interface for the ATK library"
+  },
+  {
+    "name": "atlas-devel",
+    "summary": "Development libraries for ATLAS"
+  },
+  {
+    "name": "audit-libs-devel",
+    "summary": "Header files for libaudit"
+  },
+  {
+    "name": "augeas",
+    "summary": "A library for changing configuration files"
+  },
+  {
+    "name": "augeas-libs",
+    "summary": "Libraries for augeas"
+  },
+  {
+    "name": "authselect-compat",
+    "summary": "Tool to provide minimum backwards compatibility with authconfig"
+  },
+  {
+    "name": "autoconf",
+    "summary": "A GNU tool for automatically configuring source code"
+  },
+  {
+    "name": "autoconf-archive",
+    "summary": "The Autoconf Macro Archive"
+  },
+  {
+    "name": "autoconf-latest",
+    "summary": "Meta package to include latest version of autoconf"
+  },
+  {
+    "name": "autoconf271",
+    "summary": "A GNU tool for automatically configuring source code"
+  },
+  {
+    "name": "autocorr-af",
+    "summary": "Afrikaans auto-correction rules"
+  },
+  {
+    "name": "autocorr-bg",
+    "summary": "Bulgarian auto-correction rules"
+  },
+  {
+    "name": "autocorr-ca",
+    "summary": "Catalan auto-correction rules"
+  },
+  {
+    "name": "autocorr-cs",
+    "summary": "Czech auto-correction rules"
+  },
+  {
+    "name": "autocorr-da",
+    "summary": "Danish auto-correction rules"
+  },
+  {
+    "name": "autocorr-de",
+    "summary": "German auto-correction rules"
+  },
+  {
+    "name": "autocorr-dsb",
+    "summary": "Lower auto-correction rules"
+  },
+  {
+    "name": "autocorr-el",
+    "summary": "Greek auto-correction rules"
+  },
+  {
+    "name": "autocorr-en",
+    "summary": "English auto-correction rules"
+  },
+  {
+    "name": "autocorr-es",
+    "summary": "Spanish auto-correction rules"
+  },
+  {
+    "name": "autocorr-fa",
+    "summary": "Farsi auto-correction rules"
+  },
+  {
+    "name": "autocorr-fi",
+    "summary": "Finnish auto-correction rules"
+  },
+  {
+    "name": "autocorr-fr",
+    "summary": "French auto-correction rules"
+  },
+  {
+    "name": "autocorr-ga",
+    "summary": "Irish auto-correction rules"
+  },
+  {
+    "name": "autocorr-hr",
+    "summary": "Croatian auto-correction rules"
+  },
+  {
+    "name": "autocorr-hsb",
+    "summary": "Upper auto-correction rules"
+  },
+  {
+    "name": "autocorr-hu",
+    "summary": "Hungarian auto-correction rules"
+  },
+  {
+    "name": "autocorr-is",
+    "summary": "Icelandic auto-correction rules"
+  },
+  {
+    "name": "autocorr-it",
+    "summary": "Italian auto-correction rules"
+  },
+  {
+    "name": "autocorr-ja",
+    "summary": "Japanese auto-correction rules"
+  },
+  {
+    "name": "autocorr-ko",
+    "summary": "Korean auto-correction rules"
+  },
+  {
+    "name": "autocorr-lb",
+    "summary": "Luxembourgish auto-correction rules"
+  },
+  {
+    "name": "autocorr-lt",
+    "summary": "Lithuanian auto-correction rules"
+  },
+  {
+    "name": "autocorr-mn",
+    "summary": "Mongolian auto-correction rules"
+  },
+  {
+    "name": "autocorr-nl",
+    "summary": "Dutch auto-correction rules"
+  },
+  {
+    "name": "autocorr-pl",
+    "summary": "Polish auto-correction rules"
+  },
+  {
+    "name": "autocorr-pt",
+    "summary": "Portuguese auto-correction rules"
+  },
+  {
+    "name": "autocorr-ro",
+    "summary": "Romanian auto-correction rules"
+  },
+  {
+    "name": "autocorr-ru",
+    "summary": "Russian auto-correction rules"
+  },
+  {
+    "name": "autocorr-sk",
+    "summary": "Slovak auto-correction rules"
+  },
+  {
+    "name": "autocorr-sl",
+    "summary": "Slovenian auto-correction rules"
+  },
+  {
+    "name": "autocorr-sr",
+    "summary": "Serbian auto-correction rules"
+  },
+  {
+    "name": "autocorr-sv",
+    "summary": "Swedish auto-correction rules"
+  },
+  {
+    "name": "autocorr-tr",
+    "summary": "Turkish auto-correction rules"
+  },
+  {
+    "name": "autocorr-vi",
+    "summary": "Vietnamese auto-correction rules"
+  },
+  {
+    "name": "autocorr-vro",
+    "summary": "V\u00f5ro auto-correction rules"
+  },
+  {
+    "name": "autocorr-zh",
+    "summary": "Chinese auto-correction rules"
+  },
+  {
+    "name": "automake",
+    "summary": "A GNU tool for automatically creating Makefiles"
+  },
+  {
+    "name": "avahi-autoipd",
+    "summary": "Link-local IPv4 address automatic configuration daemon (IPv4LL)"
+  },
+  {
+    "name": "avahi-glib",
+    "summary": "Glib libraries for avahi"
+  },
+  {
+    "name": "avahi-tools",
+    "summary": "Command line tools for mDNS browsing and publishing"
+  },
+  {
+    "name": "awscli2",
+    "summary": "Universal Command Line Environment for AWS, version 2"
+  },
+  {
+    "name": "babel",
+    "summary": "Tools for internationalizing Python applications"
+  },
+  {
+    "name": "babl",
+    "summary": "A dynamic, any to any, pixel format conversion library"
+  },
+  {
+    "name": "bacula-client",
+    "summary": "Bacula backup client"
+  },
+  {
+    "name": "bacula-common",
+    "summary": "Common Bacula files"
+  },
+  {
+    "name": "bacula-console",
+    "summary": "Bacula management console"
+  },
+  {
+    "name": "bacula-director",
+    "summary": "Bacula Director files"
+  },
+  {
+    "name": "bacula-libs",
+    "summary": "Bacula libraries"
+  },
+  {
+    "name": "bacula-libs-sql",
+    "summary": "Bacula SQL libraries"
+  },
+  {
+    "name": "bacula-logwatch",
+    "summary": "Bacula Director logwatch scripts"
+  },
+  {
+    "name": "bacula-storage",
+    "summary": "Bacula storage daemon files"
+  },
+  {
+    "name": "baobab",
+    "summary": "A graphical directory tree analyzer"
+  },
+  {
+    "name": "bcc",
+    "summary": "BPF Compiler Collection (BCC)"
+  },
+  {
+    "name": "bcc-tools",
+    "summary": "Command line tools for BPF Compiler Collection (BCC)"
+  },
+  {
+    "name": "bcel",
+    "summary": "Byte Code Engineering Library"
+  },
+  {
+    "name": "bind",
+    "summary": "The Berkeley Internet Name Domain (BIND) DNS (Domain Name System) server"
+  },
+  {
+    "name": "bind-chroot",
+    "summary": "A chroot runtime environment for the ISC BIND DNS server, named(8)"
+  },
+  {
+    "name": "bind-dnssec-doc",
+    "summary": "Manual pages of DNSSEC utilities"
+  },
+  {
+    "name": "bind-dnssec-utils",
+    "summary": "DNSSEC keys and zones management utilities"
+  },
+  {
+    "name": "bind-dyndb-ldap",
+    "summary": "LDAP back-end plug-in for BIND"
+  },
+  {
+    "name": "bind-libs",
+    "summary": "Libraries used by the BIND DNS packages"
+  },
+  {
+    "name": "bind-license",
+    "summary": "License of the BIND DNS suite"
+  },
+  {
+    "name": "bind-utils",
+    "summary": "Utilities for querying DNS name servers"
+  },
+  {
+    "name": "bind9.18",
+    "summary": "The Berkeley Internet Name Domain (BIND) DNS (Domain Name System) server"
+  },
+  {
+    "name": "bind9.18-chroot",
+    "summary": "A chroot runtime environment for the ISC BIND DNS server, named(8)"
+  },
+  {
+    "name": "bind9.18-dnssec-utils",
+    "summary": "DNSSEC keys and zones management utilities"
+  },
+  {
+    "name": "bind9.18-dyndb-ldap",
+    "summary": "LDAP back-end plug-in for BIND"
+  },
+  {
+    "name": "bind9.18-libs",
+    "summary": "Libraries used by the BIND DNS packages"
+  },
+  {
+    "name": "bind9.18-utils",
+    "summary": "Utilities for querying DNS name servers"
+  },
+  {
+    "name": "binutils-devel",
+    "summary": "BFD and opcodes static and dynamic libraries and header files"
+  },
+  {
+    "name": "bison",
+    "summary": "A GNU general-purpose parser generator"
+  },
+  {
+    "name": "bison-runtime",
+    "summary": "Runtime support files used by Bison-generated parsers"
+  },
+  {
+    "name": "bitmap-fangsongti-fonts",
+    "summary": "Selected CJK bitmap fonts for Anaconda"
+  },
+  {
+    "name": "blas",
+    "summary": "The Basic Linear Algebra Subprograms library"
+  },
+  {
+    "name": "blivet-data",
+    "summary": "Data for the blivet python module."
+  },
+  {
+    "name": "blktrace",
+    "summary": "Utilities for performing block layer IO tracing in the Linux kernel"
+  },
+  {
+    "name": "bluez-cups",
+    "summary": "CUPS printer backend for Bluetooth printers"
+  },
+  {
+    "name": "bluez-obexd",
+    "summary": "Object Exchange daemon for sharing content"
+  },
+  {
+    "name": "bmc-snmp-proxy",
+    "summary": "Reconfigure SNMP to include host SNMP agent within BMC"
+  },
+  {
+    "name": "bogofilter",
+    "summary": "Fast anti-spam filtering by Bayesian statistical analysis"
+  },
+  {
+    "name": "boom-boot",
+    "summary": "A set of libraries and tools for managing boot loader entries"
+  },
+  {
+    "name": "boom-boot-conf",
+    "summary": "A set of libraries and tools for managing boot loader entries"
+  },
+  {
+    "name": "boom-boot-grub2",
+    "summary": "A set of libraries and tools for managing boot loader entries"
+  },
+  {
+    "name": "boost",
+    "summary": "The free peer-reviewed portable C++ source libraries"
+  },
+  {
+    "name": "boost-atomic",
+    "summary": "Run-time component of boost atomic library"
+  },
+  {
+    "name": "boost-chrono",
+    "summary": "Run-time component of boost chrono library"
+  },
+  {
+    "name": "boost-container",
+    "summary": "Run-time component of boost container library"
+  },
+  {
+    "name": "boost-context",
+    "summary": "Run-time component of boost context switching library"
+  },
+  {
+    "name": "boost-contract",
+    "summary": "Run-time component of boost contract library"
+  },
+  {
+    "name": "boost-coroutine",
+    "summary": "Run-time component of boost coroutine library"
+  },
+  {
+    "name": "boost-date-time",
+    "summary": "Run-time component of boost date-time library"
+  },
+  {
+    "name": "boost-devel",
+    "summary": "The Boost C++ headers and shared development libraries"
+  },
+  {
+    "name": "boost-fiber",
+    "summary": "Run-time component of boost fiber library"
+  },
+  {
+    "name": "boost-filesystem",
+    "summary": "Run-time component of boost filesystem library"
+  },
+  {
+    "name": "boost-graph",
+    "summary": "Run-time component of boost graph library"
+  },
+  {
+    "name": "boost-iostreams",
+    "summary": "Run-time component of boost iostreams library"
+  },
+  {
+    "name": "boost-json",
+    "summary": "Run-time component of boost json library"
+  },
+  {
+    "name": "boost-locale",
+    "summary": "Run-time component of boost locale library"
+  },
+  {
+    "name": "boost-log",
+    "summary": "Run-time component of boost logging library"
+  },
+  {
+    "name": "boost-math",
+    "summary": "Math functions for boost TR1 library"
+  },
+  {
+    "name": "boost-nowide",
+    "summary": "Standard library functions with UTF-8 API on Windows"
+  },
+  {
+    "name": "boost-numpy3",
+    "summary": "Run-time component of boost numpy library for Python 3"
+  },
+  {
+    "name": "boost-program-options",
+    "summary": "Run-time component of boost program_options library"
+  },
+  {
+    "name": "boost-python3",
+    "summary": "Run-time component of boost python library for Python 3"
+  },
+  {
+    "name": "boost-random",
+    "summary": "Run-time component of boost random library"
+  },
+  {
+    "name": "boost-regex",
+    "summary": "Run-time component of boost regular expression library"
+  },
+  {
+    "name": "boost-serialization",
+    "summary": "Run-time component of boost serialization library"
+  },
+  {
+    "name": "boost-stacktrace",
+    "summary": "Run-time component of boost stacktrace library"
+  },
+  {
+    "name": "boost-system",
+    "summary": "Run-time component of boost system support library"
+  },
+  {
+    "name": "boost-test",
+    "summary": "Run-time component of boost test library"
+  },
+  {
+    "name": "boost-thread",
+    "summary": "Run-time component of boost thread library"
+  },
+  {
+    "name": "boost-timer",
+    "summary": "Run-time component of boost timer library"
+  },
+  {
+    "name": "boost-type_erasure",
+    "summary": "Run-time component of boost type erasure library"
+  },
+  {
+    "name": "boost-wave",
+    "summary": "Run-time component of boost C99/C++ preprocessing library"
+  },
+  {
+    "name": "bootc",
+    "summary": "Bootable container system"
+  },
+  {
+    "name": "bootupd",
+    "summary": "Bootloader updater"
+  },
+  {
+    "name": "Box2D",
+    "summary": "A 2D Physics Engine for Games"
+  },
+  {
+    "name": "bpftool",
+    "summary": "Inspection and simple manipulation of eBPF programs and maps"
+  },
+  {
+    "name": "bpftrace",
+    "summary": "High-level tracing language for Linux eBPF"
+  },
+  {
+    "name": "brasero",
+    "summary": "Gnome CD/DVD burning application"
+  },
+  {
+    "name": "brasero-libs",
+    "summary": "Libraries for brasero"
+  },
+  {
+    "name": "brasero-nautilus",
+    "summary": "Nautilus extension for brasero"
+  },
+  {
+    "name": "brlapi",
+    "summary": "Application Programming Interface for BRLTTY"
+  },
+  {
+    "name": "brltty",
+    "summary": "Braille display driver for Linux/Unix"
+  },
+  {
+    "name": "brltty-at-spi2",
+    "summary": "AtSpi2 driver for BRLTTY"
+  },
+  {
+    "name": "brltty-docs",
+    "summary": "Documentation for BRLTTY"
+  },
+  {
+    "name": "brltty-dracut",
+    "summary": "brltty module for Dracut"
+  },
+  {
+    "name": "brltty-espeak-ng",
+    "summary": "eSpeak-NG driver for BRLTTY"
+  },
+  {
+    "name": "brltty-xw",
+    "summary": "XWindow driver for BRLTTY"
+  },
+  {
+    "name": "brotli",
+    "summary": "Lossless compression algorithm"
+  },
+  {
+    "name": "brotli-devel",
+    "summary": "Lossless compression algorithm (development files)"
+  },
+  {
+    "name": "bsdtar",
+    "summary": "Manipulate tape archives"
+  },
+  {
+    "name": "bsf",
+    "summary": "Bean Scripting Framework"
+  },
+  {
+    "name": "buildah",
+    "summary": "A command line tool used for creating OCI Images"
+  },
+  {
+    "name": "buildah-tests",
+    "summary": "Tests for buildah"
+  },
+  {
+    "name": "butane",
+    "summary": "Butane config transpiler"
+  },
+  {
+    "name": "byacc",
+    "summary": "Berkeley Yacc, a parser generator"
+  },
+  {
+    "name": "byte-buddy",
+    "summary": "Runtime code generation for the Java virtual machine"
+  },
+  {
+    "name": "byteman",
+    "summary": "Java agent-based bytecode injection tool"
+  },
+  {
+    "name": "byteman-bmunit",
+    "summary": "TestNG and JUnit integration for Byteman."
+  },
+  {
+    "name": "byteman-javadoc",
+    "summary": "Javadoc for byteman"
+  },
+  {
+    "name": "bzip2-devel",
+    "summary": "Libraries and header files for apps which will use bzip2"
+  },
+  {
+    "name": "c-ares-devel",
+    "summary": "Development files for c-ares"
+  },
+  {
+    "name": "c2esp",
+    "summary": "CUPS driver for Kodak AiO printers"
+  },
+  {
+    "name": "cairo",
+    "summary": "A 2D graphics library"
+  },
+  {
+    "name": "cairo-devel",
+    "summary": "Development files for cairo"
+  },
+  {
+    "name": "cairo-gobject",
+    "summary": "GObject bindings for cairo"
+  },
+  {
+    "name": "cairo-gobject-devel",
+    "summary": "Development files for cairo-gobject"
+  },
+  {
+    "name": "cairomm",
+    "summary": "C++ API for the cairo graphics library"
+  },
+  {
+    "name": "capstone",
+    "summary": "A lightweight multi-platform, multi-architecture disassembly framework"
+  },
+  {
+    "name": "cargo",
+    "summary": "Rust's package manager and build tool"
+  },
+  {
+    "name": "cargo-doc",
+    "summary": "Documentation for Cargo"
+  },
+  {
+    "name": "cdi-api",
+    "summary": "CDI API"
+  },
+  {
+    "name": "cdrskin",
+    "summary": "Limited cdrecord compatibility wrapper to ease migration to libburn"
+  },
+  {
+    "name": "cepces",
+    "summary": "Certificate Enrollment through CEP/CES"
+  },
+  {
+    "name": "cepces-certmonger",
+    "summary": "certmonger integration for cepces"
+  },
+  {
+    "name": "cepces-selinux",
+    "summary": "SELinux support for cepces"
+  },
+  {
+    "name": "certmonger",
+    "summary": "Certificate status monitor and PKI enrollment client"
+  },
+  {
+    "name": "chan",
+    "summary": "Pure C implementation of Go channels"
+  },
+  {
+    "name": "check",
+    "summary": "A unit test framework for C"
+  },
+  {
+    "name": "check-devel",
+    "summary": "Libraries and headers for developing programs with check"
+  },
+  {
+    "name": "checkpolicy",
+    "summary": "SELinux policy compiler"
+  },
+  {
+    "name": "cheese",
+    "summary": "Application for taking pictures and movies from a webcam"
+  },
+  {
+    "name": "cheese-libs",
+    "summary": "Webcam display and capture widgets"
+  },
+  {
+    "name": "chrome-gnome-shell",
+    "summary": "Support for managing GNOME Shell Extensions through web browsers"
+  },
+  {
+    "name": "cim-schema",
+    "summary": "Common Information Model (CIM) Schema"
+  },
+  {
+    "name": "cjose",
+    "summary": "C library implementing the Javascript Object Signing and Encryption (JOSE)"
+  },
+  {
+    "name": "clang",
+    "summary": "A C language family front-end for LLVM"
+  },
+  {
+    "name": "clang-analyzer",
+    "summary": "A source code analysis framework"
+  },
+  {
+    "name": "clang-devel",
+    "summary": "Development header files for clang"
+  },
+  {
+    "name": "clang-libs",
+    "summary": "Runtime library for clang"
+  },
+  {
+    "name": "clang-resource-filesystem",
+    "summary": "Filesystem package that owns the clang resource directory"
+  },
+  {
+    "name": "clang-tools-extra",
+    "summary": "Extra tools for clang"
+  },
+  {
+    "name": "cldr-emoji-annotation",
+    "summary": "Emoji annotation files in CLDR"
+  },
+  {
+    "name": "cldr-emoji-annotation-dtd",
+    "summary": "DTD files of CLDR common"
+  },
+  {
+    "name": "clevis",
+    "summary": "Automated decryption framework"
+  },
+  {
+    "name": "clevis-dracut",
+    "summary": "Dracut integration for clevis"
+  },
+  {
+    "name": "clevis-luks",
+    "summary": "LUKS integration for clevis"
+  },
+  {
+    "name": "clevis-pin-pkcs11",
+    "summary": "PKCS#11 for clevis"
+  },
+  {
+    "name": "clevis-pin-tpm2",
+    "summary": "Clevis PIN for unlocking with TPM2 supporting Authorized Policies"
+  },
+  {
+    "name": "clevis-systemd",
+    "summary": "systemd integration for clevis"
+  },
+  {
+    "name": "clevis-udisks2",
+    "summary": "UDisks2/Storaged integration for clevis"
+  },
+  {
+    "name": "clippy",
+    "summary": "Lints to catch common mistakes and improve your Rust code"
+  },
+  {
+    "name": "cloud-init",
+    "summary": "Cloud instance init scripts"
+  },
+  {
+    "name": "cloud-utils-growpart",
+    "summary": "Script for growing a partition"
+  },
+  {
+    "name": "clucene-contribs-lib",
+    "summary": "Language specific text analyzers for clucene"
+  },
+  {
+    "name": "clucene-core",
+    "summary": "Core clucene module"
+  },
+  {
+    "name": "clutter",
+    "summary": "Open Source software library for creating rich graphical user interfaces"
+  },
+  {
+    "name": "clutter-gst3",
+    "summary": "GStreamer integration library for Clutter"
+  },
+  {
+    "name": "clutter-gtk",
+    "summary": "A basic GTK clutter widget"
+  },
+  {
+    "name": "cmake",
+    "summary": "Cross-platform make system"
+  },
+  {
+    "name": "cmake-data",
+    "summary": "Common data-files for cmake"
+  },
+  {
+    "name": "cmake-doc",
+    "summary": "Documentation for cmake"
+  },
+  {
+    "name": "cmake-filesystem",
+    "summary": "Directories used by CMake modules"
+  },
+  {
+    "name": "cmake-gui",
+    "summary": "Qt GUI for cmake"
+  },
+  {
+    "name": "cmake-rpm-macros",
+    "summary": "Common RPM macros for cmake"
+  },
+  {
+    "name": "cockpit-composer",
+    "summary": "Composer GUI for use with Cockpit"
+  },
+  {
+    "name": "cockpit-files",
+    "summary": "A filesystem browser for Cockpit"
+  },
+  {
+    "name": "cockpit-leapp",
+    "summary": "Leapp in-place upgrade Cockpit UI"
+  },
+  {
+    "name": "cockpit-machines",
+    "summary": "Cockpit user interface for virtual machines"
+  },
+  {
+    "name": "cockpit-ostree",
+    "summary": "Cockpit user interface for rpm-ostree"
+  },
+  {
+    "name": "cockpit-packagekit",
+    "summary": "Cockpit user interface for packages"
+  },
+  {
+    "name": "cockpit-pcp",
+    "summary": "Cockpit PCP integration"
+  },
+  {
+    "name": "cockpit-podman",
+    "summary": "Cockpit component for Podman containers"
+  },
+  {
+    "name": "cockpit-session-recording",
+    "summary": "Cockpit Session Recording"
+  },
+  {
+    "name": "cockpit-storaged",
+    "summary": "Cockpit user interface for storage, using udisks"
+  },
+  {
+    "name": "cogl",
+    "summary": "A library for using 3D graphics hardware to draw pretty pictures"
+  },
+  {
+    "name": "color-filesystem",
+    "summary": "Color filesystem layout"
+  },
+  {
+    "name": "colord",
+    "summary": "Color daemon"
+  },
+  {
+    "name": "colord-gtk",
+    "summary": "GTK support library for colord"
+  },
+  {
+    "name": "colord-libs",
+    "summary": "Color daemon library"
+  },
+  {
+    "name": "command-line-assistant",
+    "summary": "A simple wrapper to interact with RAG"
+  },
+  {
+    "name": "command-line-assistant-selinux",
+    "summary": "CLAD SELinux policy"
+  },
+  {
+    "name": "compat-hesiod",
+    "summary": "Development libraries and headers for Hesiod"
+  },
+  {
+    "name": "compat-libgfortran-48",
+    "summary": "Compatibility Fortran runtime library version 4.8.5"
+  },
+  {
+    "name": "compat-openssl11",
+    "summary": "Utilities from the general purpose cryptography library with TLS implementation"
+  },
+  {
+    "name": "compat-paratype-pt-sans-fonts-f33-f34",
+    "summary": "Fedora-33 & 34 compatibility package"
+  },
+  {
+    "name": "compiler-rt",
+    "summary": "LLVM \"compiler-rt\" runtime libraries"
+  },
+  {
+    "name": "composefs",
+    "summary": "Tools to handle creating and mounting composefs images"
+  },
+  {
+    "name": "composefs-libs",
+    "summary": "Libraries for composefs"
+  },
+  {
+    "name": "conmon",
+    "summary": "OCI container runtime monitor"
+  },
+  {
+    "name": "conntrack-tools",
+    "summary": "Manipulate netfilter connection tracking table and run High Availability"
+  },
+  {
+    "name": "console-login-helper-messages",
+    "summary": "Combines motd, issue, profile features to show system information to the user before/on login"
+  },
+  {
+    "name": "console-login-helper-messages-issuegen",
+    "summary": "Issue generator scripts showing SSH keys and IP address"
+  },
+  {
+    "name": "console-login-helper-messages-motdgen",
+    "summary": "Message of the day generator script showing system information"
+  },
+  {
+    "name": "console-login-helper-messages-profile",
+    "summary": "Profile script showing systemd failed units"
+  },
+  {
+    "name": "console-setup",
+    "summary": "Tools for configuring the console using X Window System key maps"
+  },
+  {
+    "name": "container-selinux",
+    "summary": "SELinux policies for container runtimes"
+  },
+  {
+    "name": "container-tools",
+    "summary": "A meta-package witch container tools such as podman, buildah, skopeo, etc."
+  },
+  {
+    "name": "containernetworking-plugins",
+    "summary": "CNI network plugins"
+  },
+  {
+    "name": "containers-common",
+    "summary": "Common configuration and documentation for containers"
+  },
+  {
+    "name": "containers-common-extra",
+    "summary": "Extra dependencies for Podman and Buildah"
+  },
+  {
+    "name": "convmv",
+    "summary": "Convert filename encodings"
+  },
+  {
+    "name": "copy-jdk-configs",
+    "summary": "JDKs configuration files copier"
+  },
+  {
+    "name": "coreos-installer",
+    "summary": "Installer for Fedora CoreOS and RHEL CoreOS"
+  },
+  {
+    "name": "coreos-installer-bootinfra",
+    "summary": "coreos-installer boot-time infrastructure for use on Fedora/RHEL CoreOS"
+  },
+  {
+    "name": "coreos-installer-dracut",
+    "summary": "Dracut module for running coreos-installer in the initrd"
+  },
+  {
+    "name": "corosynclib",
+    "summary": "The Corosync Cluster Engine Libraries"
+  },
+  {
+    "name": "cpp",
+    "summary": "The C Preprocessor"
+  },
+  {
+    "name": "crash",
+    "summary": "Kernel analysis utility for live systems, netdump, diskdump, kdump, LKCD or mcore dumpfiles"
+  },
+  {
+    "name": "crash-gcore-command",
+    "summary": "Gcore extension module for the crash utility"
+  },
+  {
+    "name": "crash-trace-command",
+    "summary": "Trace extension module for the crash utility"
+  },
+  {
+    "name": "createrepo_c",
+    "summary": "Creates a common metadata repository"
+  },
+  {
+    "name": "createrepo_c-libs",
+    "summary": "Library for repodata manipulation"
+  },
+  {
+    "name": "crit",
+    "summary": "CRIU image tool"
+  },
+  {
+    "name": "criu",
+    "summary": "Tool for Checkpoint/Restore in User-space"
+  },
+  {
+    "name": "criu-libs",
+    "summary": "Libraries for criu"
+  },
+  {
+    "name": "crun",
+    "summary": "OCI runtime written in C"
+  },
+  {
+    "name": "cscope",
+    "summary": "C source code tree search and browse tool"
+  },
+  {
+    "name": "culmus-aharoni-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-caladings-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-david-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-drugulin-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-ellinia-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-fonts-common",
+    "summary": "Common files of culmus-fonts"
+  },
+  {
+    "name": "culmus-frank-ruehl-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-hadasim-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-miriam-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-miriam-mono-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-nachlieli-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-simple-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-stamashkenaz-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-stamsefarad-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "culmus-yehuda-clm-fonts",
+    "summary": "Fonts for Hebrew from Culmus project"
+  },
+  {
+    "name": "CUnit",
+    "summary": "Unit testing framework for C"
+  },
+  {
+    "name": "cups",
+    "summary": "CUPS printing system"
+  },
+  {
+    "name": "cups-client",
+    "summary": "CUPS printing system - client programs"
+  },
+  {
+    "name": "cups-devel",
+    "summary": "CUPS printing system - development environment"
+  },
+  {
+    "name": "cups-filesystem",
+    "summary": "CUPS printing system - directory layout"
+  },
+  {
+    "name": "cups-filters",
+    "summary": "OpenPrinting CUPS filters and backends"
+  },
+  {
+    "name": "cups-filters-libs",
+    "summary": "OpenPrinting CUPS filters and backends - cupsfilters and fontembed libraries"
+  },
+  {
+    "name": "cups-ipptool",
+    "summary": "CUPS printing system - tool for performing IPP requests"
+  },
+  {
+    "name": "cups-lpd",
+    "summary": "CUPS printing system - lpd emulation"
+  },
+  {
+    "name": "cups-pk-helper",
+    "summary": "A helper that makes system-config-printer use PolicyKit"
+  },
+  {
+    "name": "cups-printerapp",
+    "summary": "CUPS printing system - tools for printer application"
+  },
+  {
+    "name": "cxl-cli",
+    "summary": "Manage CXL devices"
+  },
+  {
+    "name": "cxl-libs",
+    "summary": "Management library for CXL devices"
+  },
+  {
+    "name": "cyrus-imapd",
+    "summary": "A high-performance email, contacts and calendar server"
+  },
+  {
+    "name": "cyrus-imapd-libs",
+    "summary": "Runtime libraries for cyrus-imapd"
+  },
+  {
+    "name": "cyrus-imapd-utils",
+    "summary": "Cyrus IMAP server administration utilities"
+  },
+  {
+    "name": "cyrus-sasl",
+    "summary": "The Cyrus SASL library"
+  },
+  {
+    "name": "cyrus-sasl-devel",
+    "summary": "Files needed for developing applications with Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-gs2",
+    "summary": "GS2 support for Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-ldap",
+    "summary": "LDAP auxprop support for Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-md5",
+    "summary": "CRAM-MD5 and DIGEST-MD5 authentication support for Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-ntlm",
+    "summary": "NTLM authentication support for Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-sql",
+    "summary": "SQL auxprop support for Cyrus SASL"
+  },
+  {
+    "name": "daxctl",
+    "summary": "Manage Device-DAX instances"
+  },
+  {
+    "name": "daxctl-devel",
+    "summary": "Development files for libdaxctl"
+  },
+  {
+    "name": "daxio",
+    "summary": "Perform I/O on Device DAX devices or zero a Device DAX device"
+  },
+  {
+    "name": "dbus-daemon",
+    "summary": "D-BUS message bus"
+  },
+  {
+    "name": "dbus-devel",
+    "summary": "Development files for D-BUS"
+  },
+  {
+    "name": "dbus-glib",
+    "summary": "GLib bindings for D-Bus"
+  },
+  {
+    "name": "dbus-glib-devel",
+    "summary": "Libraries and headers for the D-Bus GLib bindings"
+  },
+  {
+    "name": "dbus-x11",
+    "summary": "X11-requiring add-ons for D-BUS"
+  },
+  {
+    "name": "dconf",
+    "summary": "A configuration system"
+  },
+  {
+    "name": "dconf-editor",
+    "summary": "Configuration editor for dconf"
+  },
+  {
+    "name": "dcraw",
+    "summary": "Tool for decoding raw image data from digital cameras"
+  },
+  {
+    "name": "ddiskit",
+    "summary": "Tool for Red Hat Enterprise Linux Driver Update Disk creation"
+  },
+  {
+    "name": "debugedit",
+    "summary": "Tools for debuginfo creation"
+  },
+  {
+    "name": "dejavu-lgc-sans-fonts",
+    "summary": "A variable-width Latin-Greek-Cyrillic sans-serif font family"
+  },
+  {
+    "name": "dejavu-lgc-sans-mono-fonts",
+    "summary": "A variable-width Latin-Greek-Cyrillic mono-space font family"
+  },
+  {
+    "name": "dejavu-lgc-serif-fonts",
+    "summary": "A variable-width Latin-Greek-Cyrillic serif font family"
+  },
+  {
+    "name": "delve",
+    "summary": "A debugger for the Go programming language"
+  },
+  {
+    "name": "desktop-file-utils",
+    "summary": "Utilities for manipulating .desktop files"
+  },
+  {
+    "name": "devhelp",
+    "summary": "API documentation browser"
+  },
+  {
+    "name": "devhelp-libs",
+    "summary": "Library to embed Devhelp in other applications"
+  },
+  {
+    "name": "dialog",
+    "summary": "A utility for creating TTY dialog boxes"
+  },
+  {
+    "name": "diffstat",
+    "summary": "A utility which provides statistics based on the output of diff"
+  },
+  {
+    "name": "disruptor",
+    "summary": "Concurrent Programming Framework"
+  },
+  {
+    "name": "dlm-lib",
+    "summary": "Library for dlm"
+  },
+  {
+    "name": "dnf-bootc",
+    "summary": "Package manager - additional bootc dependencies"
+  },
+  {
+    "name": "dnsconfd",
+    "summary": "Local DNS cache configuration daemon"
+  },
+  {
+    "name": "dnsconfd-dracut",
+    "summary": "dnsconfd dracut module"
+  },
+  {
+    "name": "dnsconfd-micro",
+    "summary": "Minimized native implementation of Dnsconfd"
+  },
+  {
+    "name": "dnsconfd-selinux",
+    "summary": "dnsconfd SELinux policy"
+  },
+  {
+    "name": "dnsconfd-unbound",
+    "summary": "dnsconfd unbound module"
+  },
+  {
+    "name": "dnsmasq",
+    "summary": "A lightweight DHCP/caching DNS server"
+  },
+  {
+    "name": "dnsmasq-utils",
+    "summary": "Utilities for manipulating DHCP server leases"
+  },
+  {
+    "name": "docbook-dtds",
+    "summary": "SGML and XML document type definitions for DocBook"
+  },
+  {
+    "name": "docbook-style-xsl",
+    "summary": "Norman Walsh's XSL stylesheets for DocBook XML"
+  },
+  {
+    "name": "docbook5-style-xsl",
+    "summary": "Norman Walsh's XSL stylesheets for DocBook 5.X"
+  },
+  {
+    "name": "docbook5-style-xsl-extensions",
+    "summary": "Norman Walsh's XSL stylesheets extensions for DocBook 5.X"
+  },
+  {
+    "name": "dotconf",
+    "summary": "Libraries to parse configuration files"
+  },
+  {
+    "name": "dotnet-apphost-pack-6.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 6.0"
+  },
+  {
+    "name": "dotnet-apphost-pack-7.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 7.0"
+  },
+  {
+    "name": "dotnet-apphost-pack-8.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 8.0"
+  },
+  {
+    "name": "dotnet-apphost-pack-9.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 9.0"
+  },
+  {
+    "name": "dotnet-host",
+    "summary": ".NET command line launcher"
+  },
+  {
+    "name": "dotnet-hostfxr-6.0",
+    "summary": ".NET command line host resolver"
+  },
+  {
+    "name": "dotnet-hostfxr-7.0",
+    "summary": ".NET command line host resolver"
+  },
+  {
+    "name": "dotnet-hostfxr-8.0",
+    "summary": ".NET command line host resolver"
+  },
+  {
+    "name": "dotnet-hostfxr-9.0",
+    "summary": ".NET command line host resolver"
+  },
+  {
+    "name": "dotnet-runtime-6.0",
+    "summary": "NET 6.0 runtime"
+  },
+  {
+    "name": "dotnet-runtime-7.0",
+    "summary": "NET 7.0 runtime"
+  },
+  {
+    "name": "dotnet-runtime-8.0",
+    "summary": "NET 8.0 runtime"
+  },
+  {
+    "name": "dotnet-runtime-9.0",
+    "summary": "NET 9.0 runtime"
+  },
+  {
+    "name": "dotnet-runtime-dbg-8.0",
+    "summary": "Managed debug symbols NET 8.0 runtime"
+  },
+  {
+    "name": "dotnet-runtime-dbg-9.0",
+    "summary": "Managed debug symbols NET 9.0 runtime"
+  },
+  {
+    "name": "dotnet-sdk-6.0",
+    "summary": ".NET 6.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-7.0",
+    "summary": ".NET 7.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-8.0",
+    "summary": ".NET 8.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-8.0-source-built-artifacts",
+    "summary": "Internal package for building .NET 8.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-9.0",
+    "summary": ".NET 9.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-aot-9.0",
+    "summary": "Ahead-of-Time (AOT) support for the .NET 9.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-dbg-8.0",
+    "summary": "Managed debug symbols for the .NET 8.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-sdk-dbg-9.0",
+    "summary": "Managed debug symbols for the .NET 9.0 Software Development Kit"
+  },
+  {
+    "name": "dotnet-targeting-pack-6.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 6.0"
+  },
+  {
+    "name": "dotnet-targeting-pack-7.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 7.0"
+  },
+  {
+    "name": "dotnet-targeting-pack-8.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 8.0"
+  },
+  {
+    "name": "dotnet-targeting-pack-9.0",
+    "summary": "Targeting Pack for Microsoft.NETCore.App 9.0"
+  },
+  {
+    "name": "dotnet-templates-6.0",
+    "summary": ".NET 6.0 templates"
+  },
+  {
+    "name": "dotnet-templates-7.0",
+    "summary": ".NET 7.0 templates"
+  },
+  {
+    "name": "dotnet-templates-8.0",
+    "summary": ".NET 8.0 templates"
+  },
+  {
+    "name": "dotnet-templates-9.0",
+    "summary": ".NET 9.0 templates"
+  },
+  {
+    "name": "double-conversion",
+    "summary": "Library providing binary-decimal and decimal-binary routines for IEEE doubles"
+  },
+  {
+    "name": "dovecot",
+    "summary": "Secure imap and pop3 server"
+  },
+  {
+    "name": "dovecot-mysql",
+    "summary": "MySQL back end for dovecot"
+  },
+  {
+    "name": "dovecot-pgsql",
+    "summary": "Postgres SQL back end for dovecot"
+  },
+  {
+    "name": "dovecot-pigeonhole",
+    "summary": "Sieve and managesieve plug-in for dovecot"
+  },
+  {
+    "name": "dpdk",
+    "summary": "Set of libraries and drivers for fast packet processing"
+  },
+  {
+    "name": "dpdk-devel",
+    "summary": "Data Plane Development Kit development files"
+  },
+  {
+    "name": "dpdk-doc",
+    "summary": "Data Plane Development Kit API documentation"
+  },
+  {
+    "name": "dpdk-tools",
+    "summary": "Tools for setting up Data Plane Development Kit environment"
+  },
+  {
+    "name": "dracut-caps",
+    "summary": "dracut modules to build a dracut initramfs which drops capabilities"
+  },
+  {
+    "name": "dracut-live",
+    "summary": "dracut modules to build a dracut initramfs with live image capabilities"
+  },
+  {
+    "name": "drgn",
+    "summary": "Programmable debugger"
+  },
+  {
+    "name": "driverctl",
+    "summary": "Device driver control utility"
+  },
+  {
+    "name": "dtc",
+    "summary": "Device Tree Compiler"
+  },
+  {
+    "name": "dwarves",
+    "summary": "Debugging Information Manipulation Tools (pahole & friends)"
+  },
+  {
+    "name": "dwz",
+    "summary": "DWARF optimization and duplicate removal tool"
+  },
+  {
+    "name": "dyninst",
+    "summary": "An API for Run-time Code Generation"
+  },
+  {
+    "name": "e2fsprogs-devel",
+    "summary": "Ext2/3/4 file system specific libraries and headers"
+  },
+  {
+    "name": "ecj",
+    "summary": "Eclipse Compiler for Java"
+  },
+  {
+    "name": "edk2-ovmf",
+    "summary": "UEFI firmware for x86_64 virtual machines"
+  },
+  {
+    "name": "efi-srpm-macros",
+    "summary": "Common SRPM Macros for building EFI-related packages"
+  },
+  {
+    "name": "efivar",
+    "summary": "Tools to manage UEFI variables"
+  },
+  {
+    "name": "egl-utils",
+    "summary": "EGL utilities"
+  },
+  {
+    "name": "egl-wayland",
+    "summary": "Wayland EGL External Platform library"
+  },
+  {
+    "name": "elfutils-debuginfod",
+    "summary": "HTTP ELF/DWARF file server addressed by build-id"
+  },
+  {
+    "name": "elfutils-debuginfod-client-devel",
+    "summary": "Libraries and headers to build debuginfod client applications"
+  },
+  {
+    "name": "elfutils-devel",
+    "summary": "Development libraries to handle compiled objects"
+  },
+  {
+    "name": "elfutils-libelf-devel",
+    "summary": "Development support for libelf"
+  },
+  {
+    "name": "emacs",
+    "summary": "GNU Emacs text editor"
+  },
+  {
+    "name": "emacs-auctex",
+    "summary": "Enhanced TeX modes for Emacs"
+  },
+  {
+    "name": "emacs-common",
+    "summary": "Emacs common files"
+  },
+  {
+    "name": "emacs-filesystem",
+    "summary": "Emacs filesystem layout"
+  },
+  {
+    "name": "emacs-lucid",
+    "summary": "GNU Emacs text editor with LUCID toolkit X support"
+  },
+  {
+    "name": "emacs-nox",
+    "summary": "GNU Emacs text editor without X support"
+  },
+  {
+    "name": "enchant",
+    "summary": "An Enchanting Spell Checking Library"
+  },
+  {
+    "name": "enchant2",
+    "summary": "An Enchanting Spell Checking Library"
+  },
+  {
+    "name": "enscript",
+    "summary": "A plain ASCII to PostScript converter"
+  },
+  {
+    "name": "eog",
+    "summary": "Eye of GNOME image viewer"
+  },
+  {
+    "name": "esc",
+    "summary": "Enterprise Security Client Smart Card Client"
+  },
+  {
+    "name": "espeak-ng",
+    "summary": "eSpeak NG Text-to-Speech"
+  },
+  {
+    "name": "eth-tools-basic",
+    "summary": "Management level tools and scripts"
+  },
+  {
+    "name": "eth-tools-fastfabric",
+    "summary": "Management level tools and scripts"
+  },
+  {
+    "name": "evince",
+    "summary": "Document viewer"
+  },
+  {
+    "name": "evince-libs",
+    "summary": "Libraries for the evince document viewer"
+  },
+  {
+    "name": "evince-nautilus",
+    "summary": "Evince extension for nautilus"
+  },
+  {
+    "name": "evince-previewer",
+    "summary": "Evince previewer"
+  },
+  {
+    "name": "evince-thumbnailer",
+    "summary": "Evince thumbnailer"
+  },
+  {
+    "name": "evolution",
+    "summary": "Mail and calendar client for GNOME"
+  },
+  {
+    "name": "evolution-bogofilter",
+    "summary": "Bogofilter plugin for Evolution"
+  },
+  {
+    "name": "evolution-data-server",
+    "summary": "Backend data server for Evolution"
+  },
+  {
+    "name": "evolution-data-server-devel",
+    "summary": "Development files for building against evolution-data-server"
+  },
+  {
+    "name": "evolution-data-server-doc",
+    "summary": "Documentation files for evolution-data-server"
+  },
+  {
+    "name": "evolution-data-server-langpacks",
+    "summary": "Translations for evolution-data-server"
+  },
+  {
+    "name": "evolution-data-server-perl",
+    "summary": "Supplemental utilities that require Perl"
+  },
+  {
+    "name": "evolution-data-server-tests",
+    "summary": "Tests for the evolution-data-server package"
+  },
+  {
+    "name": "evolution-data-server-ui",
+    "summary": "libedataserverui library from evolution-data-server"
+  },
+  {
+    "name": "evolution-data-server-ui-devel",
+    "summary": "Development files for building against libedataserverui from evolution-data-server"
+  },
+  {
+    "name": "evolution-ews",
+    "summary": "Evolution extension for Exchange Web Services"
+  },
+  {
+    "name": "evolution-ews-langpacks",
+    "summary": "Translations for evolution-ews"
+  },
+  {
+    "name": "evolution-help",
+    "summary": "Help files for evolution"
+  },
+  {
+    "name": "evolution-langpacks",
+    "summary": "Translations for evolution"
+  },
+  {
+    "name": "evolution-mapi",
+    "summary": "Evolution extension for MS Exchange 2007 servers"
+  },
+  {
+    "name": "evolution-mapi-langpacks",
+    "summary": "Translations for evolution-mapi"
+  },
+  {
+    "name": "evolution-pst",
+    "summary": "PST importer plugin for Evolution"
+  },
+  {
+    "name": "evolution-spamassassin",
+    "summary": "SpamAssassin plugin for Evolution"
+  },
+  {
+    "name": "exchange-bmc-os-info",
+    "summary": "Let OS and BMC exchange info"
+  },
+  {
+    "name": "exempi",
+    "summary": "Library for easy parsing of XMP metadata"
+  },
+  {
+    "name": "exiv2",
+    "summary": "Exif and Iptc metadata manipulation library"
+  },
+  {
+    "name": "exiv2-libs",
+    "summary": "Exif and Iptc metadata manipulation library"
+  },
+  {
+    "name": "expat-devel",
+    "summary": "Libraries and header files to develop applications using expat"
+  },
+  {
+    "name": "expect",
+    "summary": "A program-script interaction and testing utility"
+  },
+  {
+    "name": "fabtests",
+    "summary": "Test suite for libfabric API"
+  },
+  {
+    "name": "fapolicyd",
+    "summary": "Application Whitelisting Daemon"
+  },
+  {
+    "name": "fapolicyd-dnf-plugin",
+    "summary": "Fapolicyd dnf plugin"
+  },
+  {
+    "name": "fapolicyd-selinux",
+    "summary": "Fapolicyd selinux"
+  },
+  {
+    "name": "fdk-aac-free",
+    "summary": "Third-Party Modified Version of the Fraunhofer FDK AAC Codec Library for Android"
+  },
+  {
+    "name": "fdo-admin-cli",
+    "summary": "FDO admin tools implementation"
+  },
+  {
+    "name": "fdo-client",
+    "summary": "FDO Client implementation"
+  },
+  {
+    "name": "fdo-init",
+    "summary": "dracut module for device initialization"
+  },
+  {
+    "name": "fdo-manufacturing-server",
+    "summary": "FDO Manufacturing Server implementation"
+  },
+  {
+    "name": "fdo-owner-cli",
+    "summary": "FDO Owner tools implementation"
+  },
+  {
+    "name": "fdo-owner-onboarding-server",
+    "summary": "FDO Owner Onboarding Server implementation"
+  },
+  {
+    "name": "fdo-rendezvous-server",
+    "summary": "FDO Rendezvous Server implementation"
+  },
+  {
+    "name": "fence-agents-aliyun",
+    "summary": "Fence agent for Alibaba Cloud (Aliyun)"
+  },
+  {
+    "name": "fence-agents-all",
+    "summary": "Set of unified programs capable of host isolation (\"fencing\")"
+  },
+  {
+    "name": "fence-agents-amt-ws",
+    "summary": "Fence agent for Intel AMT (WS-Man) devices"
+  },
+  {
+    "name": "fence-agents-apc",
+    "summary": "Fence agent for APC devices"
+  },
+  {
+    "name": "fence-agents-apc-snmp",
+    "summary": "Fence agents for APC devices (SNMP)"
+  },
+  {
+    "name": "fence-agents-aws",
+    "summary": "Fence agent for Amazon AWS"
+  },
+  {
+    "name": "fence-agents-azure-arm",
+    "summary": "Fence agent for Azure Resource Manager"
+  },
+  {
+    "name": "fence-agents-bladecenter",
+    "summary": "Fence agent for IBM BladeCenter"
+  },
+  {
+    "name": "fence-agents-brocade",
+    "summary": "Fence agent for Brocade switches"
+  },
+  {
+    "name": "fence-agents-cisco-mds",
+    "summary": "Fence agent for Cisco MDS 9000 series"
+  },
+  {
+    "name": "fence-agents-cisco-ucs",
+    "summary": "Fence agent for Cisco UCS series"
+  },
+  {
+    "name": "fence-agents-common",
+    "summary": "Common base for Fence Agents"
+  },
+  {
+    "name": "fence-agents-compute",
+    "summary": "Fence agent for Nova compute nodes"
+  },
+  {
+    "name": "fence-agents-drac5",
+    "summary": "Fence agent for Dell DRAC 5"
+  },
+  {
+    "name": "fence-agents-eaton-snmp",
+    "summary": "Fence agent for Eaton network power switches"
+  },
+  {
+    "name": "fence-agents-emerson",
+    "summary": "Fence agent for Emerson devices (SNMP)"
+  },
+  {
+    "name": "fence-agents-eps",
+    "summary": "Fence agent for ePowerSwitch 8M+ power switches"
+  },
+  {
+    "name": "fence-agents-gce",
+    "summary": "Fence agent for GCE (Google Cloud Engine)"
+  },
+  {
+    "name": "fence-agents-heuristics-ping",
+    "summary": "Pseudo fence agent to affect other agents based on ping-heuristics"
+  },
+  {
+    "name": "fence-agents-hpblade",
+    "summary": "Fence agent for HP BladeSystem devices"
+  },
+  {
+    "name": "fence-agents-ibm-powervs",
+    "summary": "Fence agent for IBM PowerVS"
+  },
+  {
+    "name": "fence-agents-ibm-vpc",
+    "summary": "Fence agent for IBM Cloud VPC"
+  },
+  {
+    "name": "fence-agents-ibmblade",
+    "summary": "Fence agent for IBM BladeCenter"
+  },
+  {
+    "name": "fence-agents-ifmib",
+    "summary": "Fence agent for devices with IF-MIB interfaces"
+  },
+  {
+    "name": "fence-agents-ilo-moonshot",
+    "summary": "Fence agent for HP iLO Moonshot devices"
+  },
+  {
+    "name": "fence-agents-ilo-mp",
+    "summary": "Fence agent for HP iLO MP devices"
+  },
+  {
+    "name": "fence-agents-ilo-ssh",
+    "summary": "Fence agents for HP iLO devices over SSH"
+  },
+  {
+    "name": "fence-agents-ilo2",
+    "summary": "Fence agents for HP iLO2 devices"
+  },
+  {
+    "name": "fence-agents-intelmodular",
+    "summary": "Fence agent for devices with Intel Modular interfaces"
+  },
+  {
+    "name": "fence-agents-ipdu",
+    "summary": "Fence agent for IBM iPDU network power switches"
+  },
+  {
+    "name": "fence-agents-ipmilan",
+    "summary": "Fence agents for devices with IPMI interface"
+  },
+  {
+    "name": "fence-agents-kdump",
+    "summary": "Fence agent for use with kdump crash recovery service"
+  },
+  {
+    "name": "fence-agents-kubevirt",
+    "summary": "Fence agent for KubeVirt platform"
+  },
+  {
+    "name": "fence-agents-lpar",
+    "summary": "Fence agent for IBM LPAR"
+  },
+  {
+    "name": "fence-agents-mpath",
+    "summary": "Fence agent for reservations over Device Mapper Multipath"
+  },
+  {
+    "name": "fence-agents-openstack",
+    "summary": "Fence agent for OpenStack's Nova service"
+  },
+  {
+    "name": "fence-agents-redfish",
+    "summary": "Fence agent for Redfish"
+  },
+  {
+    "name": "fence-agents-rhevm",
+    "summary": "Fence agent for RHEV-M"
+  },
+  {
+    "name": "fence-agents-rsa",
+    "summary": "Fence agent for IBM RSA II"
+  },
+  {
+    "name": "fence-agents-rsb",
+    "summary": "Fence agent for Fujitsu RSB"
+  },
+  {
+    "name": "fence-agents-sbd",
+    "summary": "Fence agent for SBD (storage-based death)"
+  },
+  {
+    "name": "fence-agents-scsi",
+    "summary": "Fence agent for SCSI persistent reservations"
+  },
+  {
+    "name": "fence-agents-virsh",
+    "summary": "Fence agent for virtual machines based on libvirt"
+  },
+  {
+    "name": "fence-agents-vmware-rest",
+    "summary": "Fence agent for VMWare with REST API"
+  },
+  {
+    "name": "fence-agents-vmware-soap",
+    "summary": "Fence agent for VMWare with SOAP API v4.1+"
+  },
+  {
+    "name": "fence-agents-wti",
+    "summary": "Fence agent for WTI Network power switches"
+  },
+  {
+    "name": "fence-virt",
+    "summary": "A pluggable fencing framework for virtual machines"
+  },
+  {
+    "name": "fence-virtd",
+    "summary": "Daemon which handles requests from fence-virt"
+  },
+  {
+    "name": "fence-virtd-cpg",
+    "summary": "CPG/libvirt backend for fence-virtd"
+  },
+  {
+    "name": "fence-virtd-libvirt",
+    "summary": "Libvirt backend for fence-virtd"
+  },
+  {
+    "name": "fence-virtd-multicast",
+    "summary": "Multicast listener for fence-virtd"
+  },
+  {
+    "name": "fence-virtd-serial",
+    "summary": "Serial VMChannel listener for fence-virtd"
+  },
+  {
+    "name": "fence-virtd-tcp",
+    "summary": "TCP listener for fence-virtd"
+  },
+  {
+    "name": "festival",
+    "summary": "Speech synthesis and text-to-speech system"
+  },
+  {
+    "name": "festival-data",
+    "summary": "Data files for the Festival speech synthesis system"
+  },
+  {
+    "name": "festvox-slt-arctic-hts",
+    "summary": "US English female speaker \"SLT\" for Festival"
+  },
+  {
+    "name": "fetchmail",
+    "summary": "A remote mail retrieval and forwarding utility"
+  },
+  {
+    "name": "fftw",
+    "summary": "A Fast Fourier Transform library"
+  },
+  {
+    "name": "fftw-devel",
+    "summary": "Headers, libraries and docs for the FFTW library"
+  },
+  {
+    "name": "fftw-libs",
+    "summary": "FFTW run-time library"
+  },
+  {
+    "name": "fftw-libs-double",
+    "summary": "FFTW library, double precision"
+  },
+  {
+    "name": "fftw-libs-long",
+    "summary": "FFTW library, long double precision"
+  },
+  {
+    "name": "fftw-libs-quad",
+    "summary": "FFTW library, quadruple"
+  },
+  {
+    "name": "fftw-libs-single",
+    "summary": "FFTW library, single precision"
+  },
+  {
+    "name": "fftw-openmpi-devel",
+    "summary": "Headers, libraries and docs for the FFTW OpenMPI library"
+  },
+  {
+    "name": "fftw-openmpi-libs",
+    "summary": "FFTW OpenMPI run-time library"
+  },
+  {
+    "name": "fftw-openmpi-libs-double",
+    "summary": "FFTW OpenMPI library, double precision"
+  },
+  {
+    "name": "fftw-openmpi-libs-long",
+    "summary": "FFTW OpenMPI library, long double precision"
+  },
+  {
+    "name": "fftw-openmpi-libs-single",
+    "summary": "FFTW OpenMPI library, single precision"
+  },
+  {
+    "name": "fftw-openmpi-static",
+    "summary": "Static versions of the FFTW OpenMPI libraries"
+  },
+  {
+    "name": "fftw-static",
+    "summary": "Static versions of the FFTW libraries"
+  },
+  {
+    "name": "fido2-tools",
+    "summary": "FIDO2 tools"
+  },
+  {
+    "name": "fio",
+    "summary": "Multithreaded IO generation tool"
+  },
+  {
+    "name": "fio-engine-dev-dax",
+    "summary": "PMDK dev-dax engine for fio."
+  },
+  {
+    "name": "fio-engine-http",
+    "summary": "HTTP engine for fio."
+  },
+  {
+    "name": "fio-engine-libaio",
+    "summary": "Linux libaio engine for fio."
+  },
+  {
+    "name": "fio-engine-libpmem",
+    "summary": "PMDK pmemblk engine for fio."
+  },
+  {
+    "name": "fio-engine-nbd",
+    "summary": "Network Block Device engine for fio."
+  },
+  {
+    "name": "fio-engine-pmemblk",
+    "summary": "PMDK pmemblk engine for fio."
+  },
+  {
+    "name": "fio-engine-rados",
+    "summary": "Rados engine for fio."
+  },
+  {
+    "name": "fio-engine-rbd",
+    "summary": "Rados Block Device engine for fio."
+  },
+  {
+    "name": "fio-engine-rdma",
+    "summary": "RDMA engine for fio."
+  },
+  {
+    "name": "firefox",
+    "summary": "Mozilla Firefox Web browser"
+  },
+  {
+    "name": "firefox-x11",
+    "summary": "Firefox X11 launcher."
+  },
+  {
+    "name": "firewall-applet",
+    "summary": "Firewall panel applet"
+  },
+  {
+    "name": "firewall-config",
+    "summary": "Firewall configuration application"
+  },
+  {
+    "name": "flac-libs",
+    "summary": "Libraries for the Free Lossless Audio Codec"
+  },
+  {
+    "name": "flashrom",
+    "summary": "Simple program for reading/writing flash chips content"
+  },
+  {
+    "name": "flatpak",
+    "summary": "Application deployment framework for desktop apps"
+  },
+  {
+    "name": "flatpak-builder",
+    "summary": "Tool to build flatpaks from source"
+  },
+  {
+    "name": "flatpak-libs",
+    "summary": "Libraries for flatpak"
+  },
+  {
+    "name": "flatpak-selinux",
+    "summary": "SELinux policy module for flatpak"
+  },
+  {
+    "name": "flatpak-session-helper",
+    "summary": "User D-Bus service used by flatpak and others"
+  },
+  {
+    "name": "flatpak-spawn",
+    "summary": "Command-line frontend for the org.freedesktop.Flatpak service"
+  },
+  {
+    "name": "flatpak-xdg-utils",
+    "summary": "Command-line tools for use inside Flatpak sandboxes"
+  },
+  {
+    "name": "flex",
+    "summary": "A tool for generating scanners (text pattern recognizers)"
+  },
+  {
+    "name": "flex-doc",
+    "summary": "Documentation for the flex scanner generator"
+  },
+  {
+    "name": "flexiblas",
+    "summary": "A BLAS/LAPACK wrapper library with runtime exchangeable backends"
+  },
+  {
+    "name": "flexiblas-devel",
+    "summary": "Development headers and libraries for FlexiBLAS"
+  },
+  {
+    "name": "flexiblas-netlib",
+    "summary": "FlexiBLAS wrapper library"
+  },
+  {
+    "name": "flexiblas-netlib64",
+    "summary": "FlexiBLAS wrapper library (64-bit)"
+  },
+  {
+    "name": "flexiblas-openblas-openmp",
+    "summary": "FlexiBLAS wrappers for OpenBLAS"
+  },
+  {
+    "name": "flexiblas-openblas-openmp64",
+    "summary": "FlexiBLAS wrappers for OpenBLAS (64-bit)"
+  },
+  {
+    "name": "flexiblas-openblas-serial",
+    "summary": "FlexiBLAS wrappers for OpenBLAS"
+  },
+  {
+    "name": "flite",
+    "summary": "Small, fast speech synthesis engine (text-to-speech)"
+  },
+  {
+    "name": "fltk",
+    "summary": "C++ user interface toolkit"
+  },
+  {
+    "name": "flute",
+    "summary": "Java CSS parser using SAC"
+  },
+  {
+    "name": "fontawesome-fonts",
+    "summary": "Iconic font set"
+  },
+  {
+    "name": "fontconfig",
+    "summary": "Font configuration and customization library"
+  },
+  {
+    "name": "fontconfig-devel",
+    "summary": "Font configuration and customization library"
+  },
+  {
+    "name": "fonts-srpm-macros",
+    "summary": "Source-stage rpm automation for fonts packages"
+  },
+  {
+    "name": "foomatic",
+    "summary": "Tools for using the foomatic database of printers and printer drivers"
+  },
+  {
+    "name": "foomatic-db",
+    "summary": "Database of printers and printer drivers"
+  },
+  {
+    "name": "foomatic-db-filesystem",
+    "summary": "Directory layout for the foomatic package"
+  },
+  {
+    "name": "foomatic-db-ppds",
+    "summary": "PPDs from printer manufacturers"
+  },
+  {
+    "name": "fprintd",
+    "summary": "D-Bus service for Fingerprint reader access"
+  },
+  {
+    "name": "fprintd-pam",
+    "summary": "PAM module for fingerprint authentication"
+  },
+  {
+    "name": "freeglut",
+    "summary": "A freely licensed alternative to the GLUT library"
+  },
+  {
+    "name": "freeglut-devel",
+    "summary": "Freeglut developmental libraries and header files"
+  },
+  {
+    "name": "freeipmi",
+    "summary": "IPMI remote console and system management software"
+  },
+  {
+    "name": "freeipmi-bmc-watchdog",
+    "summary": "IPMI BMC watchdog"
+  },
+  {
+    "name": "freeipmi-ipmidetectd",
+    "summary": "IPMI node detection monitoring daemon"
+  },
+  {
+    "name": "freeipmi-ipmiseld",
+    "summary": "IPMI SEL syslog logging daemon"
+  },
+  {
+    "name": "freeradius",
+    "summary": "High-performance and highly configurable free RADIUS server"
+  },
+  {
+    "name": "freeradius-devel",
+    "summary": "FreeRADIUS development files"
+  },
+  {
+    "name": "freeradius-doc",
+    "summary": "FreeRADIUS documentation"
+  },
+  {
+    "name": "freeradius-krb5",
+    "summary": "Kerberos 5 support for freeradius"
+  },
+  {
+    "name": "freeradius-ldap",
+    "summary": "LDAP support for freeradius"
+  },
+  {
+    "name": "freeradius-utils",
+    "summary": "FreeRADIUS utilities"
+  },
+  {
+    "name": "freerdp",
+    "summary": "Free implementation of the Remote Desktop Protocol (RDP)"
+  },
+  {
+    "name": "freerdp-libs",
+    "summary": "Core libraries implementing the RDP protocol"
+  },
+  {
+    "name": "freetype-devel",
+    "summary": "FreeType development libraries and header files"
+  },
+  {
+    "name": "fribidi",
+    "summary": "Library implementing the Unicode Bidirectional Algorithm"
+  },
+  {
+    "name": "fribidi-devel",
+    "summary": "Libraries and include files for FriBidi"
+  },
+  {
+    "name": "frr",
+    "summary": "Routing daemon"
+  },
+  {
+    "name": "frr-selinux",
+    "summary": "Selinux policy for FRR"
+  },
+  {
+    "name": "fstrm",
+    "summary": "Frame Streams implementation in C"
+  },
+  {
+    "name": "ftp",
+    "summary": "The standard UNIX FTP (File Transfer Protocol) client"
+  },
+  {
+    "name": "fuse-overlayfs",
+    "summary": "FUSE overlay+shiftfs implementation for rootless containers"
+  },
+  {
+    "name": "fuse3",
+    "summary": "File System in Userspace (FUSE) v3 utilities"
+  },
+  {
+    "name": "fuse3-devel",
+    "summary": "File System in Userspace (FUSE) v3 devel files"
+  },
+  {
+    "name": "fuse3-libs",
+    "summary": "File System in Userspace (FUSE) v3 libraries"
+  },
+  {
+    "name": "fwupd-plugin-flashrom",
+    "summary": "fwupd plugin using flashrom"
+  },
+  {
+    "name": "fxload",
+    "summary": "A helper program to download firmware into FX and FX2 EZ-USB devices"
+  },
+  {
+    "name": "galera",
+    "summary": "Synchronous multi-master wsrep provider (replication engine)"
+  },
+  {
+    "name": "gawk-all-langpacks",
+    "summary": "Additional localisation files for gawk utility"
+  },
+  {
+    "name": "gc",
+    "summary": "A garbage collector for C and C++"
+  },
+  {
+    "name": "gcc",
+    "summary": "Various compilers (C, C++, Objective-C, ...)"
+  },
+  {
+    "name": "gcc-c++",
+    "summary": "C++ support for GCC"
+  },
+  {
+    "name": "gcc-gfortran",
+    "summary": "Fortran support"
+  },
+  {
+    "name": "gcc-offload-nvptx",
+    "summary": "Offloading compiler to NVPTX"
+  },
+  {
+    "name": "gcc-plugin-annobin",
+    "summary": "The annobin plugin for gcc, built by the installed version of gcc"
+  },
+  {
+    "name": "gcc-toolset-12",
+    "summary": "Package that installs gcc-toolset-12"
+  },
+  {
+    "name": "gcc-toolset-12-annobin-annocheck",
+    "summary": "A tool for checking the security hardening status of binaries"
+  },
+  {
+    "name": "gcc-toolset-12-annobin-docs",
+    "summary": "Documentation and shell scripts for use with annobin"
+  },
+  {
+    "name": "gcc-toolset-12-annobin-plugin-gcc",
+    "summary": "annobin gcc plugin"
+  },
+  {
+    "name": "gcc-toolset-12-binutils",
+    "summary": "A GNU collection of binary utilities"
+  },
+  {
+    "name": "gcc-toolset-12-binutils-devel",
+    "summary": "BFD and opcodes static and dynamic libraries and header files"
+  },
+  {
+    "name": "gcc-toolset-12-binutils-gold",
+    "summary": "The GOLD linker, a faster alternative to the BFD linker"
+  },
+  {
+    "name": "gcc-toolset-12-build",
+    "summary": "Package shipping basic build configuration"
+  },
+  {
+    "name": "gcc-toolset-12-dwz",
+    "summary": "DWARF optimization and duplicate removal tool"
+  },
+  {
+    "name": "gcc-toolset-12-gcc",
+    "summary": "GCC version 12"
+  },
+  {
+    "name": "gcc-toolset-12-gcc-c++",
+    "summary": "C++ support for GCC version 12"
+  },
+  {
+    "name": "gcc-toolset-12-gcc-gfortran",
+    "summary": "Fortran support for GCC 12"
+  },
+  {
+    "name": "gcc-toolset-12-gcc-plugin-annobin",
+    "summary": "The annobin plugin for gcc, built by the installed version of gcc"
+  },
+  {
+    "name": "gcc-toolset-12-gcc-plugin-devel",
+    "summary": "Support for compiling GCC plugins"
+  },
+  {
+    "name": "gcc-toolset-12-gdb",
+    "summary": "A GNU source-level debugger for C, C++, Fortran, Go and other languages"
+  },
+  {
+    "name": "gcc-toolset-12-libasan-devel",
+    "summary": "The Address Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-12-libatomic-devel",
+    "summary": "The GNU Atomic static library"
+  },
+  {
+    "name": "gcc-toolset-12-libgccjit",
+    "summary": "Library for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-12-libgccjit-devel",
+    "summary": "Support for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-12-libgccjit-docs",
+    "summary": "Documentation for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-12-libitm-devel",
+    "summary": "The GNU Transactional Memory support"
+  },
+  {
+    "name": "gcc-toolset-12-liblsan-devel",
+    "summary": "The Leak Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-12-libquadmath-devel",
+    "summary": "GCC 12 __float128 support"
+  },
+  {
+    "name": "gcc-toolset-12-libstdc++-devel",
+    "summary": "Header files and libraries for C++ development"
+  },
+  {
+    "name": "gcc-toolset-12-libstdc++-docs",
+    "summary": "Documentation for the GNU standard C++ library"
+  },
+  {
+    "name": "gcc-toolset-12-libtsan-devel",
+    "summary": "The Thread Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-12-libubsan-devel",
+    "summary": "The Undefined Behavior Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-12-offload-nvptx",
+    "summary": "Offloading compiler to NVPTX"
+  },
+  {
+    "name": "gcc-toolset-12-runtime",
+    "summary": "Package that handles gcc-toolset-12 Software Collection."
+  },
+  {
+    "name": "gcc-toolset-13",
+    "summary": "Package that installs gcc-toolset-13"
+  },
+  {
+    "name": "gcc-toolset-13-annobin-annocheck",
+    "summary": "A tool for checking the security hardening status of binaries"
+  },
+  {
+    "name": "gcc-toolset-13-annobin-docs",
+    "summary": "Documentation and shell scripts for use with annobin"
+  },
+  {
+    "name": "gcc-toolset-13-annobin-plugin-gcc",
+    "summary": "annobin gcc plugin"
+  },
+  {
+    "name": "gcc-toolset-13-binutils",
+    "summary": "A GNU collection of binary utilities"
+  },
+  {
+    "name": "gcc-toolset-13-binutils-devel",
+    "summary": "BFD and opcodes static and dynamic libraries and header files"
+  },
+  {
+    "name": "gcc-toolset-13-binutils-gold",
+    "summary": "The GOLD linker, a faster alternative to the BFD linker"
+  },
+  {
+    "name": "gcc-toolset-13-dwz",
+    "summary": "DWARF optimization and duplicate removal tool"
+  },
+  {
+    "name": "gcc-toolset-13-gcc",
+    "summary": "GCC version 13"
+  },
+  {
+    "name": "gcc-toolset-13-gcc-c++",
+    "summary": "C++ support for GCC version 13"
+  },
+  {
+    "name": "gcc-toolset-13-gcc-gfortran",
+    "summary": "Fortran support for GCC 13"
+  },
+  {
+    "name": "gcc-toolset-13-gcc-plugin-annobin",
+    "summary": "The annobin plugin for gcc, built by the installed version of gcc"
+  },
+  {
+    "name": "gcc-toolset-13-gcc-plugin-devel",
+    "summary": "Support for compiling GCC plugins"
+  },
+  {
+    "name": "gcc-toolset-13-gdb",
+    "summary": "A GNU source-level debugger for C, C++, Fortran, Go and other languages"
+  },
+  {
+    "name": "gcc-toolset-13-libasan-devel",
+    "summary": "The Address Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-13-libatomic-devel",
+    "summary": "The GNU Atomic static library"
+  },
+  {
+    "name": "gcc-toolset-13-libgccjit",
+    "summary": "Library for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-13-libgccjit-devel",
+    "summary": "Support for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-13-libitm-devel",
+    "summary": "The GNU Transactional Memory support"
+  },
+  {
+    "name": "gcc-toolset-13-liblsan-devel",
+    "summary": "The Leak Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-13-libquadmath-devel",
+    "summary": "GCC 13 __float128 support"
+  },
+  {
+    "name": "gcc-toolset-13-libstdc++-devel",
+    "summary": "Header files and libraries for C++ development"
+  },
+  {
+    "name": "gcc-toolset-13-libstdc++-docs",
+    "summary": "Documentation for the GNU standard C++ library"
+  },
+  {
+    "name": "gcc-toolset-13-libtsan-devel",
+    "summary": "The Thread Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-13-libubsan-devel",
+    "summary": "The Undefined Behavior Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-13-offload-nvptx",
+    "summary": "Offloading compiler to NVPTX"
+  },
+  {
+    "name": "gcc-toolset-13-runtime",
+    "summary": "Package that handles gcc-toolset-13 Software Collection."
+  },
+  {
+    "name": "gcc-toolset-14",
+    "summary": "Package that installs gcc-toolset-14"
+  },
+  {
+    "name": "gcc-toolset-14-annobin-annocheck",
+    "summary": "A tool for checking the security hardening status of binaries"
+  },
+  {
+    "name": "gcc-toolset-14-annobin-docs",
+    "summary": "Documentation and shell scripts for use with annobin"
+  },
+  {
+    "name": "gcc-toolset-14-annobin-plugin-gcc",
+    "summary": "annobin gcc plugin"
+  },
+  {
+    "name": "gcc-toolset-14-binutils",
+    "summary": "A GNU collection of binary utilities"
+  },
+  {
+    "name": "gcc-toolset-14-binutils-devel",
+    "summary": "BFD and opcodes static and dynamic libraries and header files"
+  },
+  {
+    "name": "gcc-toolset-14-binutils-gold",
+    "summary": "The GOLD linker, a faster alternative to the BFD linker"
+  },
+  {
+    "name": "gcc-toolset-14-binutils-gprofng",
+    "summary": "Next Generating code profiling tool"
+  },
+  {
+    "name": "gcc-toolset-14-dwz",
+    "summary": "DWARF optimization and duplicate removal tool"
+  },
+  {
+    "name": "gcc-toolset-14-gcc",
+    "summary": "GCC version 14"
+  },
+  {
+    "name": "gcc-toolset-14-gcc-c++",
+    "summary": "C++ support for GCC version 14"
+  },
+  {
+    "name": "gcc-toolset-14-gcc-gfortran",
+    "summary": "Fortran support for GCC 14"
+  },
+  {
+    "name": "gcc-toolset-14-gcc-plugin-annobin",
+    "summary": "The annobin plugin for gcc, built by the installed version of gcc"
+  },
+  {
+    "name": "gcc-toolset-14-gcc-plugin-devel",
+    "summary": "Support for compiling GCC plugins"
+  },
+  {
+    "name": "gcc-toolset-14-libasan-devel",
+    "summary": "The Address Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-14-libatomic-devel",
+    "summary": "The GNU Atomic static library"
+  },
+  {
+    "name": "gcc-toolset-14-libgccjit",
+    "summary": "Library for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-14-libgccjit-devel",
+    "summary": "Support for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "gcc-toolset-14-libitm-devel",
+    "summary": "The GNU Transactional Memory support"
+  },
+  {
+    "name": "gcc-toolset-14-liblsan-devel",
+    "summary": "The Leak Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-14-libquadmath-devel",
+    "summary": "GCC 14 __float128 support"
+  },
+  {
+    "name": "gcc-toolset-14-libstdc++-devel",
+    "summary": "Header files and libraries for C++ development"
+  },
+  {
+    "name": "gcc-toolset-14-libstdc++-docs",
+    "summary": "Documentation for the GNU standard C++ library"
+  },
+  {
+    "name": "gcc-toolset-14-libtsan-devel",
+    "summary": "The Thread Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-14-libubsan-devel",
+    "summary": "The Undefined Behavior Sanitizer static library"
+  },
+  {
+    "name": "gcc-toolset-14-offload-nvptx",
+    "summary": "Offloading compiler to NVPTX"
+  },
+  {
+    "name": "gcc-toolset-14-runtime",
+    "summary": "Package that handles gcc-toolset-14 Software Collection."
+  },
+  {
+    "name": "gcr",
+    "summary": "A library for bits of crypto UI and parsing"
+  },
+  {
+    "name": "gcr-base",
+    "summary": "Library files for gcr"
+  },
+  {
+    "name": "gcr-devel",
+    "summary": "Development files for gcr"
+  },
+  {
+    "name": "gd",
+    "summary": "A graphics library for quick creation of PNG or JPEG images"
+  },
+  {
+    "name": "gd-devel",
+    "summary": "The development libraries and header files for gd"
+  },
+  {
+    "name": "gdb",
+    "summary": "A stub package for GNU source-level debugger"
+  },
+  {
+    "name": "gdb-doc",
+    "summary": "Documentation for GDB (the GNU source-level debugger)"
+  },
+  {
+    "name": "gdb-gdbserver",
+    "summary": "A standalone server for GDB (the GNU source-level debugger)"
+  },
+  {
+    "name": "gdb-headless",
+    "summary": "A GNU source-level debugger for C, C++, Fortran, Go and other languages"
+  },
+  {
+    "name": "gdb-minimal",
+    "summary": "A GNU source-level debugger for C, C++, Fortran, Go and other languages (minimal version)"
+  },
+  {
+    "name": "gdisk",
+    "summary": "An fdisk-like partitioning tool for GPT disks"
+  },
+  {
+    "name": "gdk-pixbuf2",
+    "summary": "An image loading library"
+  },
+  {
+    "name": "gdk-pixbuf2-devel",
+    "summary": "Development files for gdk-pixbuf2"
+  },
+  {
+    "name": "gdk-pixbuf2-modules",
+    "summary": "Additional image modules for gdk-pixbuf2"
+  },
+  {
+    "name": "gdm",
+    "summary": "The GNOME Display Manager"
+  },
+  {
+    "name": "gedit",
+    "summary": "Text editor for the GNOME desktop"
+  },
+  {
+    "name": "gedit-plugin-bookmarks",
+    "summary": "gedit bookmarks plugin"
+  },
+  {
+    "name": "gedit-plugin-bracketcompletion",
+    "summary": "gedit bracketcompletion plugin"
+  },
+  {
+    "name": "gedit-plugin-codecomment",
+    "summary": "gedit codecomment plugin"
+  },
+  {
+    "name": "gedit-plugin-colorpicker",
+    "summary": "gedit colorpicker plugin"
+  },
+  {
+    "name": "gedit-plugin-colorschemer",
+    "summary": "gedit colorschemer plugin"
+  },
+  {
+    "name": "gedit-plugin-commander",
+    "summary": "gedit commander plugin"
+  },
+  {
+    "name": "gedit-plugin-drawspaces",
+    "summary": "gedit drawspaces plugin"
+  },
+  {
+    "name": "gedit-plugin-findinfiles",
+    "summary": "gedit findinfiles plugin"
+  },
+  {
+    "name": "gedit-plugin-joinlines",
+    "summary": "gedit joinlines plugin"
+  },
+  {
+    "name": "gedit-plugin-multiedit",
+    "summary": "gedit multiedit plugin"
+  },
+  {
+    "name": "gedit-plugin-sessionsaver",
+    "summary": "gedit sessionsaver plugin"
+  },
+  {
+    "name": "gedit-plugin-smartspaces",
+    "summary": "gedit smartspaces plugin"
+  },
+  {
+    "name": "gedit-plugin-synctex",
+    "summary": "gedit synctex plugin"
+  },
+  {
+    "name": "gedit-plugin-terminal",
+    "summary": "gedit terminal plugin"
+  },
+  {
+    "name": "gedit-plugin-textsize",
+    "summary": "gedit textsize plugin"
+  },
+  {
+    "name": "gedit-plugin-translate",
+    "summary": "gedit translate plugin"
+  },
+  {
+    "name": "gedit-plugin-wordcompletion",
+    "summary": "gedit wordcompletion plugin"
+  },
+  {
+    "name": "gedit-plugins",
+    "summary": "Plugins for gedit"
+  },
+  {
+    "name": "gedit-plugins-data",
+    "summary": "Common data required by plugins"
+  },
+  {
+    "name": "gegl04",
+    "summary": "Graph based image processing framework"
+  },
+  {
+    "name": "gegl04-devel-docs",
+    "summary": "Documentation files for developing with gegl04"
+  },
+  {
+    "name": "gegl04-tools",
+    "summary": "Command line tools for gegl04"
+  },
+  {
+    "name": "geoclue2",
+    "summary": "Geolocation service"
+  },
+  {
+    "name": "geoclue2-libs",
+    "summary": "Geoclue client library"
+  },
+  {
+    "name": "geocode-glib",
+    "summary": "Geocoding helper library"
+  },
+  {
+    "name": "geocode-glib-devel",
+    "summary": "Development files for geocode-glib"
+  },
+  {
+    "name": "geolite2-city",
+    "summary": "Free IP geolocation city database"
+  },
+  {
+    "name": "geolite2-country",
+    "summary": "Free IP geolocation country database"
+  },
+  {
+    "name": "gettext-common-devel",
+    "summary": "Common development files for gettext"
+  },
+  {
+    "name": "gettext-devel",
+    "summary": "Development files for gettext"
+  },
+  {
+    "name": "ghc-srpm-macros",
+    "summary": "RPM macros for building Haskell source packages"
+  },
+  {
+    "name": "ghostscript",
+    "summary": "Interpreter for PostScript language & PDF"
+  },
+  {
+    "name": "ghostscript-doc",
+    "summary": "Documentation files for Ghostscript"
+  },
+  {
+    "name": "ghostscript-tools-dvipdf",
+    "summary": "Ghostscript's 'dvipdf' utility"
+  },
+  {
+    "name": "ghostscript-tools-fonts",
+    "summary": "Ghostscript's font utilities"
+  },
+  {
+    "name": "ghostscript-tools-printing",
+    "summary": "Ghostscript's printing utilities"
+  },
+  {
+    "name": "ghostscript-x11",
+    "summary": "Ghostscript's X11-based driver for document rendering"
+  },
+  {
+    "name": "giflib",
+    "summary": "A library and utilities for processing GIFs"
+  },
+  {
+    "name": "gimp",
+    "summary": "GNU Image Manipulation Program"
+  },
+  {
+    "name": "gimp-libs",
+    "summary": "GIMP libraries"
+  },
+  {
+    "name": "git",
+    "summary": "Fast Version Control System"
+  },
+  {
+    "name": "git-all",
+    "summary": "Meta-package to pull in all git tools"
+  },
+  {
+    "name": "git-clang-format",
+    "summary": "Integration of clang-format for git"
+  },
+  {
+    "name": "git-core",
+    "summary": "Core package of git with minimal functionality"
+  },
+  {
+    "name": "git-core-doc",
+    "summary": "Documentation files for git-core"
+  },
+  {
+    "name": "git-credential-libsecret",
+    "summary": "Git helper for accessing credentials via libsecret"
+  },
+  {
+    "name": "git-daemon",
+    "summary": "Git protocol daemon"
+  },
+  {
+    "name": "git-email",
+    "summary": "Git tools for sending patches via email"
+  },
+  {
+    "name": "git-gui",
+    "summary": "Graphical interface to Git"
+  },
+  {
+    "name": "git-instaweb",
+    "summary": "Repository browser in gitweb"
+  },
+  {
+    "name": "git-lfs",
+    "summary": "Git extension for versioning large files"
+  },
+  {
+    "name": "git-subtree",
+    "summary": "Git tools to merge and split repositories"
+  },
+  {
+    "name": "git-svn",
+    "summary": "Git tools for interacting with Subversion repositories"
+  },
+  {
+    "name": "gitk",
+    "summary": "Git repository browser"
+  },
+  {
+    "name": "gitweb",
+    "summary": "Simple web interface to git repositories"
+  },
+  {
+    "name": "gjs",
+    "summary": "Javascript Bindings for GNOME"
+  },
+  {
+    "name": "gl-manpages",
+    "summary": "OpenGL manpages"
+  },
+  {
+    "name": "glade",
+    "summary": "User Interface Designer for GTK+"
+  },
+  {
+    "name": "glade-libs",
+    "summary": "Widget library for Glade UI designer"
+  },
+  {
+    "name": "glib-networking",
+    "summary": "Networking support for GLib"
+  },
+  {
+    "name": "glib2-devel",
+    "summary": "A library of handy utility functions"
+  },
+  {
+    "name": "glib2-doc",
+    "summary": "A library of handy utility functions"
+  },
+  {
+    "name": "glib2-tests",
+    "summary": "Tests for the glib2 package"
+  },
+  {
+    "name": "glibc-devel",
+    "summary": "Object files for development using standard C libraries."
+  },
+  {
+    "name": "glibc-doc",
+    "summary": "Documentation for GNU libc"
+  },
+  {
+    "name": "glibc-headers",
+    "summary": "Additional internal header files for glibc-devel."
+  },
+  {
+    "name": "glibc-locale-source",
+    "summary": "The sources for the locales"
+  },
+  {
+    "name": "glibc-utils",
+    "summary": "Development utilities from GNU C library"
+  },
+  {
+    "name": "glibmm24",
+    "summary": "C++ interface for the GLib library"
+  },
+  {
+    "name": "glslang",
+    "summary": "OpenGL and OpenGL ES shader front end and validator"
+  },
+  {
+    "name": "glslc",
+    "summary": "A command line compiler for GLSL/HLSL to SPIR-V"
+  },
+  {
+    "name": "glusterfs",
+    "summary": "Distributed File System"
+  },
+  {
+    "name": "glusterfs-api",
+    "summary": "GlusterFS api library"
+  },
+  {
+    "name": "glusterfs-cli",
+    "summary": "GlusterFS CLI"
+  },
+  {
+    "name": "glusterfs-client-xlators",
+    "summary": "GlusterFS client-side translators"
+  },
+  {
+    "name": "glusterfs-cloudsync-plugins",
+    "summary": "Cloudsync Plugins"
+  },
+  {
+    "name": "glusterfs-fuse",
+    "summary": "Fuse client"
+  },
+  {
+    "name": "glusterfs-libs",
+    "summary": "GlusterFS common libraries"
+  },
+  {
+    "name": "glusterfs-rdma",
+    "summary": "GlusterFS rdma support for ib-verbs"
+  },
+  {
+    "name": "glx-utils",
+    "summary": "GLX utilities"
+  },
+  {
+    "name": "gmp-c++",
+    "summary": "C++ bindings for the GNU MP arbitrary precision library"
+  },
+  {
+    "name": "gmp-devel",
+    "summary": "Development tools for the GNU MP arbitrary precision library"
+  },
+  {
+    "name": "gnome-autoar",
+    "summary": "Archive library"
+  },
+  {
+    "name": "gnome-backgrounds",
+    "summary": "Desktop backgrounds packaged with the GNOME desktop"
+  },
+  {
+    "name": "gnome-backgrounds-extras",
+    "summary": "Additional GNOME Backgrounds"
+  },
+  {
+    "name": "gnome-bluetooth",
+    "summary": "Bluetooth graphical utilities"
+  },
+  {
+    "name": "gnome-bluetooth-libs",
+    "summary": "GTK+ Bluetooth device selection widgets"
+  },
+  {
+    "name": "gnome-calculator",
+    "summary": "A desktop calculator"
+  },
+  {
+    "name": "gnome-characters",
+    "summary": "Character map application for GNOME"
+  },
+  {
+    "name": "gnome-classic-session",
+    "summary": "GNOME \"classic\" mode session"
+  },
+  {
+    "name": "gnome-color-manager",
+    "summary": "Color management tools for GNOME"
+  },
+  {
+    "name": "gnome-common",
+    "summary": "Useful things common to building GNOME packages from scratch"
+  },
+  {
+    "name": "gnome-connections",
+    "summary": "A remote desktop client for the GNOME desktop environment"
+  },
+  {
+    "name": "gnome-control-center",
+    "summary": "Utilities to configure the GNOME desktop"
+  },
+  {
+    "name": "gnome-control-center-filesystem",
+    "summary": "GNOME Control Center directories"
+  },
+  {
+    "name": "gnome-desktop3",
+    "summary": "Library with common API for various GNOME modules"
+  },
+  {
+    "name": "gnome-desktop3-devel",
+    "summary": "Libraries and headers for gnome-desktop3"
+  },
+  {
+    "name": "gnome-devel-docs",
+    "summary": "GNOME developer documentation"
+  },
+  {
+    "name": "gnome-disk-utility",
+    "summary": "Disks"
+  },
+  {
+    "name": "gnome-extensions-app",
+    "summary": "Manage GNOME Shell extensions"
+  },
+  {
+    "name": "gnome-font-viewer",
+    "summary": "Utility for previewing fonts for GNOME"
+  },
+  {
+    "name": "gnome-initial-setup",
+    "summary": "Bootstrapping your OS"
+  },
+  {
+    "name": "gnome-keyring",
+    "summary": "Framework for managing passwords and other secrets"
+  },
+  {
+    "name": "gnome-keyring-pam",
+    "summary": "Pam module for unlocking keyrings"
+  },
+  {
+    "name": "gnome-kiosk",
+    "summary": "Window management and application launching for GNOME"
+  },
+  {
+    "name": "gnome-kiosk-script-session",
+    "summary": "Basic session used for running kiosk application from shell script"
+  },
+  {
+    "name": "gnome-kiosk-search-appliance",
+    "summary": "Example search application application that uses GNOME Kiosk"
+  },
+  {
+    "name": "gnome-logs",
+    "summary": "Log viewer for the systemd journal"
+  },
+  {
+    "name": "gnome-menus",
+    "summary": "A menu system for the GNOME project"
+  },
+  {
+    "name": "gnome-online-accounts",
+    "summary": "Single sign-on framework for GNOME"
+  },
+  {
+    "name": "gnome-online-accounts-devel",
+    "summary": "Development files for gnome-online-accounts"
+  },
+  {
+    "name": "gnome-photos",
+    "summary": "Access, organize and share your photos on GNOME"
+  },
+  {
+    "name": "gnome-photos-tests",
+    "summary": "Tests for gnome-photos"
+  },
+  {
+    "name": "gnome-remote-desktop",
+    "summary": "GNOME Remote Desktop screen share service"
+  },
+  {
+    "name": "gnome-screenshot",
+    "summary": "A screenshot utility for GNOME"
+  },
+  {
+    "name": "gnome-session",
+    "summary": "GNOME session manager"
+  },
+  {
+    "name": "gnome-session-wayland-session",
+    "summary": "Desktop file for wayland based gnome session"
+  },
+  {
+    "name": "gnome-session-xsession",
+    "summary": "Desktop file for gnome-session"
+  },
+  {
+    "name": "gnome-settings-daemon",
+    "summary": "The daemon sharing settings from GNOME to GTK+/KDE applications"
+  },
+  {
+    "name": "gnome-shell",
+    "summary": "Window management and application launching for GNOME"
+  },
+  {
+    "name": "gnome-shell-extension-apps-menu",
+    "summary": "Application menu for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-auto-move-windows",
+    "summary": "Assign specific workspaces to applications in GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-background-logo",
+    "summary": "Background logo extension for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-classification-banner",
+    "summary": "Display classification level banner in GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-common",
+    "summary": "Files common to GNOME Shell Extensions"
+  },
+  {
+    "name": "gnome-shell-extension-custom-menu",
+    "summary": "Add a custom menu to the desktop"
+  },
+  {
+    "name": "gnome-shell-extension-dash-to-dock",
+    "summary": "Show the dash outside the activities overview"
+  },
+  {
+    "name": "gnome-shell-extension-dash-to-panel",
+    "summary": "Show the dash in the top bar"
+  },
+  {
+    "name": "gnome-shell-extension-desktop-icons",
+    "summary": "Desktop icons support for the classic experience"
+  },
+  {
+    "name": "gnome-shell-extension-drive-menu",
+    "summary": "Drive status menu for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-gesture-inhibitor",
+    "summary": "Gesture inhibitor"
+  },
+  {
+    "name": "gnome-shell-extension-heads-up-display",
+    "summary": "Display persistent on-screen message"
+  },
+  {
+    "name": "gnome-shell-extension-launch-new-instance",
+    "summary": "Always launch a new application instance for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-move-notifications",
+    "summary": "Move GNOME Shell notifications"
+  },
+  {
+    "name": "gnome-shell-extension-native-window-placement",
+    "summary": "Native window placement for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-panel-favorites",
+    "summary": "Favorite launchers in GNOME Shell's top bar"
+  },
+  {
+    "name": "gnome-shell-extension-places-menu",
+    "summary": "Places status menu for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-screenshot-window-sizer",
+    "summary": "Screenshot window sizer for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-systemMonitor",
+    "summary": "System Monitor for GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-top-icons",
+    "summary": "Show legacy icons on top"
+  },
+  {
+    "name": "gnome-shell-extension-updates-dialog",
+    "summary": "Show a modal dialog when there are software updates"
+  },
+  {
+    "name": "gnome-shell-extension-user-theme",
+    "summary": "Support for custom themes in GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-window-list",
+    "summary": "Display a window list at the bottom of the screen in GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-windowsNavigator",
+    "summary": "Support for keyboard selection of windows and workspaces in GNOME Shell"
+  },
+  {
+    "name": "gnome-shell-extension-workspace-indicator",
+    "summary": "Workspace indicator for GNOME Shell"
+  },
+  {
+    "name": "gnome-software",
+    "summary": "A software center for GNOME"
+  },
+  {
+    "name": "gnome-system-monitor",
+    "summary": "Process and resource monitor"
+  },
+  {
+    "name": "gnome-terminal",
+    "summary": "Terminal emulator for GNOME"
+  },
+  {
+    "name": "gnome-terminal-nautilus",
+    "summary": "GNOME Terminal extension for Nautilus"
+  },
+  {
+    "name": "gnome-themes-extra",
+    "summary": "GNOME Extra Themes"
+  },
+  {
+    "name": "gnome-tour",
+    "summary": "GNOME Tour and Greeter"
+  },
+  {
+    "name": "gnome-tweaks",
+    "summary": "Customize advanced GNOME 3 options"
+  },
+  {
+    "name": "gnome-user-docs",
+    "summary": "GNOME User Documentation"
+  },
+  {
+    "name": "gnome-video-effects",
+    "summary": "Collection of GStreamer video effects"
+  },
+  {
+    "name": "gnu-efi",
+    "summary": "Development Libraries and headers for EFI"
+  },
+  {
+    "name": "gnupg2-smime",
+    "summary": "CMS encryption and signing tool and smart card support for GnuPG"
+  },
+  {
+    "name": "gnutls-c++",
+    "summary": "The C++ interface to GnuTLS"
+  },
+  {
+    "name": "gnutls-dane",
+    "summary": "A DANE protocol implementation for GnuTLS"
+  },
+  {
+    "name": "gnutls-devel",
+    "summary": "Development files for the gnutls package"
+  },
+  {
+    "name": "gnutls-utils",
+    "summary": "Command line tools for TLS protocol"
+  },
+  {
+    "name": "go-filesystem",
+    "summary": "Directories used by Go packages"
+  },
+  {
+    "name": "go-rpm-macros",
+    "summary": "Build-stage rpm automation for Go packages"
+  },
+  {
+    "name": "go-rpm-templates",
+    "summary": "RPM spec templates for Go packages"
+  },
+  {
+    "name": "go-srpm-macros",
+    "summary": "Source-stage rpm automation for Go packages"
+  },
+  {
+    "name": "go-toolset",
+    "summary": "Package that installs go-toolset"
+  },
+  {
+    "name": "golang",
+    "summary": "The Go Programming Language"
+  },
+  {
+    "name": "golang-bin",
+    "summary": "Golang core compiler tools"
+  },
+  {
+    "name": "golang-docs",
+    "summary": "Golang compiler docs"
+  },
+  {
+    "name": "golang-misc",
+    "summary": "Golang compiler miscellaneous sources"
+  },
+  {
+    "name": "golang-race",
+    "summary": "Golang std library with -race enabled"
+  },
+  {
+    "name": "golang-src",
+    "summary": "Golang compiler source tree"
+  },
+  {
+    "name": "golang-tests",
+    "summary": "Golang compiler tests for stdlib"
+  },
+  {
+    "name": "gom",
+    "summary": "GObject to SQLite object mapper library"
+  },
+  {
+    "name": "google-carlito-fonts",
+    "summary": "Carlito, a sans-serif font family metric-compatible with Calibri font family"
+  },
+  {
+    "name": "google-crosextra-caladea-fonts",
+    "summary": "Serif font metric-compatible with Cambria font"
+  },
+  {
+    "name": "google-droid-sans-fonts",
+    "summary": "Droid Sans, a humanist sans-serif font family"
+  },
+  {
+    "name": "google-droid-sans-mono-fonts",
+    "summary": "Droid Sans Mono, a humanist mono-space sans-serif font family"
+  },
+  {
+    "name": "google-droid-serif-fonts",
+    "summary": "Droid Serif, a contemporary serif font family"
+  },
+  {
+    "name": "google-guice",
+    "summary": "Lightweight dependency injection framework for Java 5 and above"
+  },
+  {
+    "name": "google-noto-cjk-fonts-common",
+    "summary": "Common files for Noto CJK fonts"
+  },
+  {
+    "name": "google-noto-emoji-color-fonts",
+    "summary": "Google \u201cNoto Color Emoji\u201d colored emoji font"
+  },
+  {
+    "name": "google-noto-emoji-fonts",
+    "summary": "Google \u201cNoto Emoji\u201d Black-and-White emoji font"
+  },
+  {
+    "name": "google-noto-fonts-common",
+    "summary": "Common files for Noto fonts"
+  },
+  {
+    "name": "google-noto-sans-armenian-fonts",
+    "summary": "Noto Sans Armenian font"
+  },
+  {
+    "name": "google-noto-sans-avestan-fonts",
+    "summary": "Noto Sans Avestan font"
+  },
+  {
+    "name": "google-noto-sans-bengali-fonts",
+    "summary": "Noto Sans Bengali font"
+  },
+  {
+    "name": "google-noto-sans-bengali-ui-fonts",
+    "summary": "Noto Sans Bengali UI font"
+  },
+  {
+    "name": "google-noto-sans-brahmi-fonts",
+    "summary": "Noto Sans Brahmi font"
+  },
+  {
+    "name": "google-noto-sans-carian-fonts",
+    "summary": "Noto Sans Carian font"
+  },
+  {
+    "name": "google-noto-sans-cherokee-fonts",
+    "summary": "Noto Sans Cherokee font"
+  },
+  {
+    "name": "google-noto-sans-cjk-ttc-fonts",
+    "summary": "Sans OTC font files for google-noto-cjk-fonts"
+  },
+  {
+    "name": "google-noto-sans-coptic-fonts",
+    "summary": "Noto Sans Coptic font"
+  },
+  {
+    "name": "google-noto-sans-deseret-fonts",
+    "summary": "Noto Sans Deseret font"
+  },
+  {
+    "name": "google-noto-sans-devanagari-fonts",
+    "summary": "Noto Sans Devanagari font"
+  },
+  {
+    "name": "google-noto-sans-devanagari-ui-fonts",
+    "summary": "Noto Sans Devanagari UI font"
+  },
+  {
+    "name": "google-noto-sans-egyptian-hieroglyphs-fonts",
+    "summary": "Noto Sans Egyptian Hieroglyphs font"
+  },
+  {
+    "name": "google-noto-sans-ethiopic-fonts",
+    "summary": "Noto Sans Ethiopic font"
+  },
+  {
+    "name": "google-noto-sans-fonts",
+    "summary": "Noto Sans font"
+  },
+  {
+    "name": "google-noto-sans-georgian-fonts",
+    "summary": "Noto Sans Georgian font"
+  },
+  {
+    "name": "google-noto-sans-glagolitic-fonts",
+    "summary": "Noto Sans Glagolitic font"
+  },
+  {
+    "name": "google-noto-sans-gujarati-fonts",
+    "summary": "Noto Sans Gujarati font"
+  },
+  {
+    "name": "google-noto-sans-gujarati-ui-fonts",
+    "summary": "Noto Sans Gujarati UI font"
+  },
+  {
+    "name": "google-noto-sans-gurmukhi-fonts",
+    "summary": "Noto Sans Gurmukhi font"
+  },
+  {
+    "name": "google-noto-sans-hebrew-fonts",
+    "summary": "Noto Sans Hebrew font"
+  },
+  {
+    "name": "google-noto-sans-imperial-aramaic-fonts",
+    "summary": "Noto Sans Imperial Aramaic font"
+  },
+  {
+    "name": "google-noto-sans-kaithi-fonts",
+    "summary": "Noto Sans Kaithi font"
+  },
+  {
+    "name": "google-noto-sans-kannada-fonts",
+    "summary": "Noto Sans Kannada font"
+  },
+  {
+    "name": "google-noto-sans-kannada-ui-fonts",
+    "summary": "Noto Sans Kannada UI font"
+  },
+  {
+    "name": "google-noto-sans-kayah-li-fonts",
+    "summary": "Noto Sans Kayah Li font"
+  },
+  {
+    "name": "google-noto-sans-kharoshthi-fonts",
+    "summary": "Noto Sans Kharoshthi font"
+  },
+  {
+    "name": "google-noto-sans-khmer-fonts",
+    "summary": "Noto Sans Khmer font"
+  },
+  {
+    "name": "google-noto-sans-khmer-ui-fonts",
+    "summary": "Noto Sans Khmer UI font"
+  },
+  {
+    "name": "google-noto-sans-lao-fonts",
+    "summary": "Noto Sans Lao font"
+  },
+  {
+    "name": "google-noto-sans-lao-ui-fonts",
+    "summary": "Noto Sans Lao UI font"
+  },
+  {
+    "name": "google-noto-sans-lycian-fonts",
+    "summary": "Noto Sans Lycian font"
+  },
+  {
+    "name": "google-noto-sans-lydian-fonts",
+    "summary": "Noto Sans Lydian font"
+  },
+  {
+    "name": "google-noto-sans-malayalam-fonts",
+    "summary": "Noto Sans Malayalam font"
+  },
+  {
+    "name": "google-noto-sans-malayalam-ui-fonts",
+    "summary": "Noto Sans Malayalam UI font"
+  },
+  {
+    "name": "google-noto-sans-mono-fonts",
+    "summary": "Noto Sans Mono font"
+  },
+  {
+    "name": "google-noto-sans-nko-fonts",
+    "summary": "Noto Sans NKo font"
+  },
+  {
+    "name": "google-noto-sans-old-south-arabian-fonts",
+    "summary": "Noto Sans Old South Arabian font"
+  },
+  {
+    "name": "google-noto-sans-old-turkic-fonts",
+    "summary": "Noto Sans Old Turkic font"
+  },
+  {
+    "name": "google-noto-sans-osmanya-fonts",
+    "summary": "Noto Sans Osmanya font"
+  },
+  {
+    "name": "google-noto-sans-phoenician-fonts",
+    "summary": "Noto Sans Phoenician font"
+  },
+  {
+    "name": "google-noto-sans-shavian-fonts",
+    "summary": "Noto Sans Shavian font"
+  },
+  {
+    "name": "google-noto-sans-sinhala-fonts",
+    "summary": "Noto Sans Sinhala font"
+  },
+  {
+    "name": "google-noto-sans-sinhala-vf-fonts",
+    "summary": "Noto Sans Sinhala variable font"
+  },
+  {
+    "name": "google-noto-sans-symbols-fonts",
+    "summary": "Noto Sans Symbols font"
+  },
+  {
+    "name": "google-noto-sans-tamil-fonts",
+    "summary": "Noto Sans Tamil font"
+  },
+  {
+    "name": "google-noto-sans-tamil-ui-fonts",
+    "summary": "Noto Sans Tamil UI font"
+  },
+  {
+    "name": "google-noto-sans-telugu-fonts",
+    "summary": "Noto Sans Telugu font"
+  },
+  {
+    "name": "google-noto-sans-telugu-ui-fonts",
+    "summary": "Noto Sans Telugu UI font"
+  },
+  {
+    "name": "google-noto-sans-thaana-fonts",
+    "summary": "Noto Sans Thaana font"
+  },
+  {
+    "name": "google-noto-sans-thai-fonts",
+    "summary": "Noto Sans Thai font"
+  },
+  {
+    "name": "google-noto-sans-thai-ui-fonts",
+    "summary": "Noto Sans Thai UI font"
+  },
+  {
+    "name": "google-noto-sans-ugaritic-fonts",
+    "summary": "Noto Sans Ugaritic font"
+  },
+  {
+    "name": "google-noto-sans-vai-fonts",
+    "summary": "Noto Sans Vai font"
+  },
+  {
+    "name": "google-noto-serif-armenian-fonts",
+    "summary": "Noto Serif Armenian font"
+  },
+  {
+    "name": "google-noto-serif-cjk-ttc-fonts",
+    "summary": "Serif OTC font files for google-noto-cjk-fonts"
+  },
+  {
+    "name": "google-noto-serif-fonts",
+    "summary": "Noto Serif font"
+  },
+  {
+    "name": "google-noto-serif-georgian-fonts",
+    "summary": "Noto Serif Georgian font"
+  },
+  {
+    "name": "google-noto-serif-gurmukhi-vf-fonts",
+    "summary": "Noto Serif Gurmukhi variable font"
+  },
+  {
+    "name": "google-noto-serif-khmer-fonts",
+    "summary": "Noto Serif Khmer font"
+  },
+  {
+    "name": "google-noto-serif-lao-fonts",
+    "summary": "Noto Serif Lao font"
+  },
+  {
+    "name": "google-noto-serif-sinhala-vf-fonts",
+    "summary": "Noto Serif Sinhala variable font"
+  },
+  {
+    "name": "google-noto-serif-thai-fonts",
+    "summary": "Noto Serif Thai font"
+  },
+  {
+    "name": "google-roboto-slab-fonts",
+    "summary": "Google Roboto Slab fonts"
+  },
+  {
+    "name": "gperf",
+    "summary": "A perfect hash function generator"
+  },
+  {
+    "name": "gpgmepp",
+    "summary": "C++ bindings/wrapper for GPGME"
+  },
+  {
+    "name": "gpm",
+    "summary": "A mouse server for the Linux console"
+  },
+  {
+    "name": "gpm-devel",
+    "summary": "Development files for the gpm library"
+  },
+  {
+    "name": "gpm-libs",
+    "summary": "Dynamic library for gpm"
+  },
+  {
+    "name": "gpsd-minimal",
+    "summary": "Service daemon for mediating access to a GPS"
+  },
+  {
+    "name": "gpsd-minimal-clients",
+    "summary": "Clients for gpsd"
+  },
+  {
+    "name": "grafana",
+    "summary": "Metrics dashboard and graph editor"
+  },
+  {
+    "name": "grafana-pcp",
+    "summary": "Performance Co-Pilot Grafana Plugin"
+  },
+  {
+    "name": "grafana-selinux",
+    "summary": "SELinux policy module supporting grafana"
+  },
+  {
+    "name": "graphene",
+    "summary": "Thin layer of types for graphic libraries"
+  },
+  {
+    "name": "graphene-devel",
+    "summary": "Development files for graphene"
+  },
+  {
+    "name": "graphite2-devel",
+    "summary": "Files for developing with graphite2"
+  },
+  {
+    "name": "graphviz",
+    "summary": "Graph Visualization Tools"
+  },
+  {
+    "name": "graphviz-doc",
+    "summary": "PDF and HTML documents for graphviz"
+  },
+  {
+    "name": "graphviz-gd",
+    "summary": "Graphviz plugin for renderers based on gd"
+  },
+  {
+    "name": "graphviz-python3",
+    "summary": "Python 3 extension for graphviz"
+  },
+  {
+    "name": "graphviz-ruby",
+    "summary": "Ruby extension for graphviz"
+  },
+  {
+    "name": "greenboot",
+    "summary": "Generic Health Check Framework for systemd"
+  },
+  {
+    "name": "greenboot-default-health-checks",
+    "summary": "Series of optional and curated health checks"
+  },
+  {
+    "name": "grilo",
+    "summary": "Content discovery framework"
+  },
+  {
+    "name": "grilo-plugins",
+    "summary": "Plugins for the Grilo framework"
+  },
+  {
+    "name": "groff",
+    "summary": "A document formatting system"
+  },
+  {
+    "name": "gsettings-desktop-schemas",
+    "summary": "A collection of GSettings schemas"
+  },
+  {
+    "name": "gsettings-desktop-schemas-devel",
+    "summary": "Development files for gsettings-desktop-schemas"
+  },
+  {
+    "name": "gsl",
+    "summary": "The GNU Scientific Library for numerical analysis"
+  },
+  {
+    "name": "gsl-devel",
+    "summary": "Libraries and the header files for GSL development"
+  },
+  {
+    "name": "gsm",
+    "summary": "Shared libraries for GSM speech compressor"
+  },
+  {
+    "name": "gsound",
+    "summary": "Small gobject library for playing system sounds"
+  },
+  {
+    "name": "gspell",
+    "summary": "Spell-checking library for GTK+"
+  },
+  {
+    "name": "gstreamer1",
+    "summary": "GStreamer streaming media framework runtime"
+  },
+  {
+    "name": "gstreamer1-devel",
+    "summary": "Libraries/include files for GStreamer streaming media framework"
+  },
+  {
+    "name": "gstreamer1-plugins-bad-free",
+    "summary": "GStreamer streaming media framework \"bad\" plugins"
+  },
+  {
+    "name": "gstreamer1-plugins-bad-free-libs",
+    "summary": "Runtime libraries for the GStreamer media framework \"bad\" plug-ins"
+  },
+  {
+    "name": "gstreamer1-plugins-base",
+    "summary": "GStreamer streaming media framework base plugins"
+  },
+  {
+    "name": "gstreamer1-plugins-base-devel",
+    "summary": "GStreamer Base Plugins Development files"
+  },
+  {
+    "name": "gstreamer1-plugins-base-tools",
+    "summary": "Tools for GStreamer streaming media framework base plugins"
+  },
+  {
+    "name": "gstreamer1-plugins-good",
+    "summary": "GStreamer plugins with good code and licensing"
+  },
+  {
+    "name": "gstreamer1-plugins-good-gtk",
+    "summary": "GStreamer \"good\" plugins gtk plugin"
+  },
+  {
+    "name": "gstreamer1-plugins-ugly-free",
+    "summary": "GStreamer streaming media framework \"ugly\" plugins"
+  },
+  {
+    "name": "gstreamer1-rtsp-server",
+    "summary": "GStreamer RTSP server library"
+  },
+  {
+    "name": "gtk-update-icon-cache",
+    "summary": "Icon theme caching utility"
+  },
+  {
+    "name": "gtk-vnc2",
+    "summary": "A GTK3 widget for VNC clients"
+  },
+  {
+    "name": "gtk2",
+    "summary": "GTK+ graphical user interface library"
+  },
+  {
+    "name": "gtk2-devel",
+    "summary": "Development files for GTK+"
+  },
+  {
+    "name": "gtk2-devel-docs",
+    "summary": "Developer documentation for GTK+"
+  },
+  {
+    "name": "gtk2-immodule-xim",
+    "summary": "XIM support for GTK+"
+  },
+  {
+    "name": "gtk2-immodules",
+    "summary": "Input methods for GTK+"
+  },
+  {
+    "name": "gtk3",
+    "summary": "GTK+ graphical user interface library"
+  },
+  {
+    "name": "gtk3-devel",
+    "summary": "Development files for GTK+"
+  },
+  {
+    "name": "gtk3-immodule-xim",
+    "summary": "XIM support for GTK+"
+  },
+  {
+    "name": "gtk4",
+    "summary": "GTK graphical user interface library"
+  },
+  {
+    "name": "gtk4-devel",
+    "summary": "Development files for GTK"
+  },
+  {
+    "name": "gtkmm30",
+    "summary": "C++ interface for the GTK+ library"
+  },
+  {
+    "name": "gtksourceview4",
+    "summary": "Source code editing widget"
+  },
+  {
+    "name": "guava",
+    "summary": "Google Core Libraries for Java"
+  },
+  {
+    "name": "gubbi-fonts",
+    "summary": "Free Kannada Opentype serif font"
+  },
+  {
+    "name": "guestfs-tools",
+    "summary": "Tools to access and modify virtual machine disk images"
+  },
+  {
+    "name": "gutenprint",
+    "summary": "Printer Drivers Package"
+  },
+  {
+    "name": "gutenprint-cups",
+    "summary": "CUPS drivers for Canon, Epson, HP and compatible printers"
+  },
+  {
+    "name": "gutenprint-doc",
+    "summary": "Documentation for gutenprint"
+  },
+  {
+    "name": "gutenprint-libs",
+    "summary": "libgutenprint library"
+  },
+  {
+    "name": "gvfs",
+    "summary": "Backends for the gio framework in GLib"
+  },
+  {
+    "name": "gvfs-client",
+    "summary": "Client modules of backends for the gio framework in GLib"
+  },
+  {
+    "name": "gvfs-devel",
+    "summary": "Development files for gvfs"
+  },
+  {
+    "name": "gvfs-fuse",
+    "summary": "FUSE support for gvfs"
+  },
+  {
+    "name": "gvfs-goa",
+    "summary": "GOA support for gvfs"
+  },
+  {
+    "name": "gvfs-gphoto2",
+    "summary": "gphoto2 support for gvfs"
+  },
+  {
+    "name": "gvfs-mtp",
+    "summary": "MTP support for gvfs"
+  },
+  {
+    "name": "gvfs-smb",
+    "summary": "Windows fileshare support for gvfs"
+  },
+  {
+    "name": "gvisor-tap-vsock",
+    "summary": "Go replacement for libslirp and VPNKit"
+  },
+  {
+    "name": "gvisor-tap-vsock-gvforwarder",
+    "summary": "Forward traffic from a tap interface over vsock"
+  },
+  {
+    "name": "gvnc",
+    "summary": "A GObject for VNC connections"
+  },
+  {
+    "name": "ha-cloud-support",
+    "summary": "Support libraries for HA Cloud agents"
+  },
+  {
+    "name": "ha-openstack-support",
+    "summary": "Support libraries for OpenStack agents"
+  },
+  {
+    "name": "hamcrest",
+    "summary": "Library of matchers for building test expressions"
+  },
+  {
+    "name": "haproxy",
+    "summary": "HAProxy reverse proxy for high availability environments"
+  },
+  {
+    "name": "harfbuzz-devel",
+    "summary": "Development files for harfbuzz"
+  },
+  {
+    "name": "harfbuzz-icu",
+    "summary": "Harfbuzz ICU support library"
+  },
+  {
+    "name": "HdrHistogram_c",
+    "summary": "C port of the HdrHistogram"
+  },
+  {
+    "name": "hexchat",
+    "summary": "A popular and easy to use graphical IRC (chat) client"
+  },
+  {
+    "name": "hexedit",
+    "summary": "A hexadecimal file viewer and editor"
+  },
+  {
+    "name": "hicolor-icon-theme",
+    "summary": "Basic requirement for icon themes"
+  },
+  {
+    "name": "highcontrast-icon-theme",
+    "summary": "HighContrast icon theme"
+  },
+  {
+    "name": "highlight",
+    "summary": "Universal source code to formatted text converter"
+  },
+  {
+    "name": "hivex",
+    "summary": "Read and write Windows Registry binary hive files"
+  },
+  {
+    "name": "hivex-libs",
+    "summary": "Library for hivex"
+  },
+  {
+    "name": "hostapd",
+    "summary": "IEEE 802.11 AP, IEEE 802.1X/WPA/WPA2/EAP/RADIUS Authenticator"
+  },
+  {
+    "name": "hplip",
+    "summary": "HP Linux Imaging and Printing Project"
+  },
+  {
+    "name": "hplip-common",
+    "summary": "Files needed by the HPLIP printer and scanner drivers"
+  },
+  {
+    "name": "hplip-libs",
+    "summary": "HPLIP libraries"
+  },
+  {
+    "name": "ht-caladea-fonts",
+    "summary": "Caladea, a serif font family metric-compatible with Cambria font family"
+  },
+  {
+    "name": "http-parser",
+    "summary": "HTTP request/response parser for C"
+  },
+  {
+    "name": "httpcomponents-client",
+    "summary": "HTTP agent implementation based on httpcomponents HttpCore"
+  },
+  {
+    "name": "httpcomponents-core",
+    "summary": "Set of low level Java HTTP transport components for HTTP services"
+  },
+  {
+    "name": "httpd",
+    "summary": "Apache HTTP Server"
+  },
+  {
+    "name": "httpd-core",
+    "summary": "httpd minimal core"
+  },
+  {
+    "name": "httpd-devel",
+    "summary": "Development interfaces for the Apache HTTP Server"
+  },
+  {
+    "name": "httpd-filesystem",
+    "summary": "The basic directory layout for the Apache HTTP Server"
+  },
+  {
+    "name": "httpd-manual",
+    "summary": "Documentation for the Apache HTTP Server"
+  },
+  {
+    "name": "httpd-tools",
+    "summary": "Tools for use with the Apache HTTP Server"
+  },
+  {
+    "name": "hunspell",
+    "summary": "A spell checker and morphological analyzer library"
+  },
+  {
+    "name": "hunspell-af",
+    "summary": "Afrikaans hunspell dictionary"
+  },
+  {
+    "name": "hunspell-ak",
+    "summary": "Akan hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-am",
+    "summary": "Amharic hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ar",
+    "summary": "Arabic hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-as",
+    "summary": "Assamese hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ast",
+    "summary": "Asturian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-az",
+    "summary": "Azerbaijani hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-be",
+    "summary": "Belarusian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ber",
+    "summary": "Amazigh hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-bg",
+    "summary": "Bulgarian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-bn",
+    "summary": "Bengali hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-br",
+    "summary": "Breton hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ca",
+    "summary": "Catalan hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-cop",
+    "summary": "Coptic hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-cs",
+    "summary": "Czech hunspell dictionary"
+  },
+  {
+    "name": "hunspell-csb",
+    "summary": "Kashubian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-cv",
+    "summary": "Chuvash hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-cy",
+    "summary": "Welsh hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-da",
+    "summary": "Danish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-de",
+    "summary": "German hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-devel",
+    "summary": "Files for developing with hunspell"
+  },
+  {
+    "name": "hunspell-dsb",
+    "summary": "Lower Sorbian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-el",
+    "summary": "Greek hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-en",
+    "summary": "English hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-en-GB",
+    "summary": "UK English hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-en-US",
+    "summary": "US English hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-eo",
+    "summary": "Esperanto hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-es",
+    "summary": "Spanish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-es-AR",
+    "summary": "Argentine Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-BO",
+    "summary": "Bolivian Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-CL",
+    "summary": "Chilean Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-CO",
+    "summary": "Colombian Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-CR",
+    "summary": "Costa Rican Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-CU",
+    "summary": "Cuban Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-DO",
+    "summary": "Dominican Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-EC",
+    "summary": "Ecuadorian Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-ES",
+    "summary": "European Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-GT",
+    "summary": "Guatemalan Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-HN",
+    "summary": "Honduran Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-MX",
+    "summary": "Mexican Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-NI",
+    "summary": "Nicaraguan Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-PA",
+    "summary": "Panamanian Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-PE",
+    "summary": "Peruvian Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-PR",
+    "summary": "Puerto Rican Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-PY",
+    "summary": "Paraguayan Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-SV",
+    "summary": "Salvadoran Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-US",
+    "summary": "US Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-UY",
+    "summary": "Uruguayan Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-es-VE",
+    "summary": "Venezuelan Spanish hunspell dictionary"
+  },
+  {
+    "name": "hunspell-et",
+    "summary": "Estonian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-eu",
+    "summary": "Basque hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-fa",
+    "summary": "Farsi hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-filesystem",
+    "summary": "Hunspell filesystem layout"
+  },
+  {
+    "name": "hunspell-fj",
+    "summary": "Fijian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-fo",
+    "summary": "Faroese hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-fr",
+    "summary": "French hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-fur",
+    "summary": "Friulian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-fy",
+    "summary": "Frisian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ga",
+    "summary": "Irish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-gd",
+    "summary": "Scots Gaelic hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-gl",
+    "summary": "Galician hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-grc",
+    "summary": "Ancient Greek hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-gu",
+    "summary": "Gujarati hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-gv",
+    "summary": "Manx hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-haw",
+    "summary": "Hawaiian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-he",
+    "summary": "Hebrew hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-hi",
+    "summary": "Hindi hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-hil",
+    "summary": "Hiligaynon hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-hr",
+    "summary": "Croatian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-hsb",
+    "summary": "Upper Sorbian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ht",
+    "summary": "Haitian Creole hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-hu",
+    "summary": "Hungarian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-hy",
+    "summary": "Armenian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ia",
+    "summary": "Interlingua hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-id",
+    "summary": "Indonesian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-is",
+    "summary": "Icelandic hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-it",
+    "summary": "Italian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-kk",
+    "summary": "Kazakh hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-km",
+    "summary": "Khmer hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-kn",
+    "summary": "Kannada hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ko",
+    "summary": "Korean hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ku",
+    "summary": "Kurdish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ky",
+    "summary": "Kirghiz hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-la",
+    "summary": "Latin hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-lb",
+    "summary": "Luxembourgish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ln",
+    "summary": "Lingala hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-lt",
+    "summary": "Lithuanian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-lv",
+    "summary": "Latvian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mai",
+    "summary": "Maithili hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mg",
+    "summary": "Malagasy hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mi",
+    "summary": "Maori hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mk",
+    "summary": "Macedonian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ml",
+    "summary": "Malayalam hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mn",
+    "summary": "Mongolian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mos",
+    "summary": "Mossi hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mr",
+    "summary": "Marathi hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ms",
+    "summary": "Malay hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-mt",
+    "summary": "Maltese hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-nb",
+    "summary": "Bokmaal hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-nds",
+    "summary": "Lowlands Saxon hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ne",
+    "summary": "Nepali hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-nl",
+    "summary": "Dutch hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-nn",
+    "summary": "Nynorsk hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-nr",
+    "summary": "Southern Ndebele hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-nso",
+    "summary": "Northern Sotho hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ny",
+    "summary": "Chichewa hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-oc",
+    "summary": "Occitan hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-om",
+    "summary": "Oromo hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-or",
+    "summary": "Odia hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-pa",
+    "summary": "Punjabi hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-pl",
+    "summary": "Polish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-pt",
+    "summary": "Portuguese hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-qu",
+    "summary": "Quechua Ecuador hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-quh",
+    "summary": "Quechua, South Bolivia hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ro",
+    "summary": "Romanian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ru",
+    "summary": "Russian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-rw",
+    "summary": "Kinyarwanda hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sc",
+    "summary": "Sardinian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-se",
+    "summary": "Northern Saami hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-shs",
+    "summary": "Shuswap hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-si",
+    "summary": "Sinhala hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sk",
+    "summary": "Slovak hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sl",
+    "summary": "Slovenian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-smj",
+    "summary": "Lule Saami hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-so",
+    "summary": "Somali hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sq",
+    "summary": "Albanian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sr",
+    "summary": "Serbian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ss",
+    "summary": "Swati hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-st",
+    "summary": "Southern Sotho hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sv",
+    "summary": "Swedish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-sw",
+    "summary": "Swahili hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ta",
+    "summary": "Tamil hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-te",
+    "summary": "Telugu hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-tet",
+    "summary": "Tetum hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-th",
+    "summary": "Thai hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ti",
+    "summary": "Tigrigna hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-tk",
+    "summary": "Turkmen hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-tl",
+    "summary": "Tagalog hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-tn",
+    "summary": "Tswana hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-tpi",
+    "summary": "Tok Pisin hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ts",
+    "summary": "Tsonga hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-uk",
+    "summary": "Ukrainian hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ur",
+    "summary": "Urdu hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-uz",
+    "summary": "Uzbek hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-ve",
+    "summary": "Venda hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-vi",
+    "summary": "Vietnamese hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-wa",
+    "summary": "Walloon hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-xh",
+    "summary": "Xhosa hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-yi",
+    "summary": "Yiddish hunspell dictionaries"
+  },
+  {
+    "name": "hunspell-zu",
+    "summary": "Zulu hunspell dictionaries"
+  },
+  {
+    "name": "hwloc-devel",
+    "summary": "Headers and shared development libraries for hwloc"
+  },
+  {
+    "name": "hwloc-gui",
+    "summary": "The gui-based hwloc program(s)"
+  },
+  {
+    "name": "hyperv-daemons",
+    "summary": "Hyper-V daemons suite"
+  },
+  {
+    "name": "hyperv-daemons-license",
+    "summary": "License of the Hyper-V daemons suite"
+  },
+  {
+    "name": "hyperv-tools",
+    "summary": "Tools for Hyper-V guests"
+  },
+  {
+    "name": "hypervfcopyd",
+    "summary": "Hyper-V FCOPY daemon"
+  },
+  {
+    "name": "hypervkvpd",
+    "summary": "Hyper-V key value pair (KVP) daemon"
+  },
+  {
+    "name": "hypervvssd",
+    "summary": "Hyper-V VSS daemon"
+  },
+  {
+    "name": "hyphen",
+    "summary": "A text hyphenation library"
+  },
+  {
+    "name": "hyphen-af",
+    "summary": "Afrikaans hyphenation rules"
+  },
+  {
+    "name": "hyphen-as",
+    "summary": "Assamese hyphenation rules"
+  },
+  {
+    "name": "hyphen-be",
+    "summary": "Belarusian hyphenation rules"
+  },
+  {
+    "name": "hyphen-bg",
+    "summary": "Bulgarian hyphenation rules"
+  },
+  {
+    "name": "hyphen-bn",
+    "summary": "Bengali hyphenation rules"
+  },
+  {
+    "name": "hyphen-ca",
+    "summary": "Catalan hyphenation rules"
+  },
+  {
+    "name": "hyphen-cs",
+    "summary": "Czech hyphenation rules"
+  },
+  {
+    "name": "hyphen-cy",
+    "summary": "Welsh hyphenation rules"
+  },
+  {
+    "name": "hyphen-da",
+    "summary": "Danish hyphenation rules"
+  },
+  {
+    "name": "hyphen-de",
+    "summary": "German hyphenation rules"
+  },
+  {
+    "name": "hyphen-devel",
+    "summary": "Files for developing with hyphen"
+  },
+  {
+    "name": "hyphen-el",
+    "summary": "Greek hyphenation rules"
+  },
+  {
+    "name": "hyphen-en",
+    "summary": "English hyphenation rules"
+  },
+  {
+    "name": "hyphen-eo",
+    "summary": "Esperanto hyphen rules"
+  },
+  {
+    "name": "hyphen-es",
+    "summary": "Spanish hyphenation rules"
+  },
+  {
+    "name": "hyphen-et",
+    "summary": "Estonian hyphenation rules"
+  },
+  {
+    "name": "hyphen-eu",
+    "summary": "Basque hyphenation rules"
+  },
+  {
+    "name": "hyphen-fa",
+    "summary": "Farsi hyphenation rules"
+  },
+  {
+    "name": "hyphen-fr",
+    "summary": "French hyphenation rules"
+  },
+  {
+    "name": "hyphen-ga",
+    "summary": "Irish hyphenation rules"
+  },
+  {
+    "name": "hyphen-gl",
+    "summary": "Galician hyphenation rules"
+  },
+  {
+    "name": "hyphen-gu",
+    "summary": "Gujarati hyphenation rules"
+  },
+  {
+    "name": "hyphen-hi",
+    "summary": "Hindi hyphenation rules"
+  },
+  {
+    "name": "hyphen-hr",
+    "summary": "Croatian hyphenation rules"
+  },
+  {
+    "name": "hyphen-hu",
+    "summary": "Hungarian hyphenation rules"
+  },
+  {
+    "name": "hyphen-id",
+    "summary": "Indonesian hyphenation rules"
+  },
+  {
+    "name": "hyphen-it",
+    "summary": "Italian hyphenation rules"
+  },
+  {
+    "name": "hyphen-kn",
+    "summary": "Kannada hyphenation rules"
+  },
+  {
+    "name": "hyphen-lt",
+    "summary": "Lithuanian hyphenation rules"
+  },
+  {
+    "name": "hyphen-lv",
+    "summary": "Latvian hyphenation rules"
+  },
+  {
+    "name": "hyphen-ml",
+    "summary": "Malayalam hyphenation rules"
+  },
+  {
+    "name": "hyphen-mr",
+    "summary": "Marathi hyphenation rules"
+  },
+  {
+    "name": "hyphen-nb",
+    "summary": "Bokmaal hyphenation rules"
+  },
+  {
+    "name": "hyphen-nl",
+    "summary": "Dutch hyphenation rules"
+  },
+  {
+    "name": "hyphen-nn",
+    "summary": "Nynorsk hyphenation rules"
+  },
+  {
+    "name": "hyphen-or",
+    "summary": "Odia hyphenation rules"
+  },
+  {
+    "name": "hyphen-pa",
+    "summary": "Punjabi hyphenation rules"
+  },
+  {
+    "name": "hyphen-pl",
+    "summary": "Polish hyphenation rules"
+  },
+  {
+    "name": "hyphen-pt",
+    "summary": "Portuguese hyphenation rules"
+  },
+  {
+    "name": "hyphen-ro",
+    "summary": "Romanian hyphenation rules"
+  },
+  {
+    "name": "hyphen-ru",
+    "summary": "Russian hyphenation rules"
+  },
+  {
+    "name": "hyphen-sk",
+    "summary": "Slovak hyphenation rules"
+  },
+  {
+    "name": "hyphen-sl",
+    "summary": "Slovenian hyphenation rules"
+  },
+  {
+    "name": "hyphen-sr",
+    "summary": "Serbian hyphenation rules"
+  },
+  {
+    "name": "hyphen-sv",
+    "summary": "Swedish hyphenation rules"
+  },
+  {
+    "name": "hyphen-ta",
+    "summary": "Tamil hyphenation rules"
+  },
+  {
+    "name": "hyphen-te",
+    "summary": "Telugu hyphenation rules"
+  },
+  {
+    "name": "hyphen-uk",
+    "summary": "Ukrainian hyphenation rules"
+  },
+  {
+    "name": "hyphen-zu",
+    "summary": "Zulu hyphenation rules"
+  },
+  {
+    "name": "i2c-tools",
+    "summary": "A heterogeneous set of I2C tools for Linux"
+  },
+  {
+    "name": "i2c-tools-perl",
+    "summary": "i2c tools written in Perl"
+  },
+  {
+    "name": "ibacm",
+    "summary": "InfiniBand Communication Manager Assistant"
+  },
+  {
+    "name": "ibus",
+    "summary": "Intelligent Input Bus for Linux OS"
+  },
+  {
+    "name": "ibus-anthy",
+    "summary": "The Anthy engine for IBus input platform"
+  },
+  {
+    "name": "ibus-anthy-python",
+    "summary": "Anthy Python files for IBus"
+  },
+  {
+    "name": "ibus-gtk2",
+    "summary": "IBus IM module for GTK2"
+  },
+  {
+    "name": "ibus-gtk3",
+    "summary": "IBus IM module for GTK3"
+  },
+  {
+    "name": "ibus-hangul",
+    "summary": "The Hangul engine for IBus input platform"
+  },
+  {
+    "name": "ibus-libpinyin",
+    "summary": "Intelligent Pinyin engine based on libpinyin for IBus"
+  },
+  {
+    "name": "ibus-libs",
+    "summary": "IBus libraries"
+  },
+  {
+    "name": "ibus-libzhuyin",
+    "summary": "New Zhuyin engine based on libzhuyin for IBus"
+  },
+  {
+    "name": "ibus-m17n",
+    "summary": "The M17N engine for IBus platform"
+  },
+  {
+    "name": "ibus-setup",
+    "summary": "IBus setup utility"
+  },
+  {
+    "name": "ibus-table",
+    "summary": "The Table engine for IBus platform"
+  },
+  {
+    "name": "ibus-table-chinese",
+    "summary": "Chinese input tables for IBus"
+  },
+  {
+    "name": "ibus-table-chinese-array",
+    "summary": "Array input methods"
+  },
+  {
+    "name": "ibus-table-chinese-cangjie",
+    "summary": "Cangjie based input methods"
+  },
+  {
+    "name": "ibus-table-chinese-cantonese",
+    "summary": "Cantonese input methods"
+  },
+  {
+    "name": "ibus-table-chinese-easy",
+    "summary": "Easy input method"
+  },
+  {
+    "name": "ibus-table-chinese-erbi",
+    "summary": "Erbi input method"
+  },
+  {
+    "name": "ibus-table-chinese-quick",
+    "summary": "Quick-to-learn input methods"
+  },
+  {
+    "name": "ibus-table-chinese-scj",
+    "summary": "Smart Cangjie"
+  },
+  {
+    "name": "ibus-table-chinese-stroke5",
+    "summary": "Stroke 5 input method"
+  },
+  {
+    "name": "ibus-table-chinese-wu",
+    "summary": "Wu pronunciation input method"
+  },
+  {
+    "name": "ibus-table-chinese-wubi-haifeng",
+    "summary": "Haifeng Wubi input method"
+  },
+  {
+    "name": "ibus-table-chinese-wubi-jidian",
+    "summary": "Jidian Wubi 86 input method, JiShuang 6.0"
+  },
+  {
+    "name": "ibus-table-chinese-yong",
+    "summary": "YongMa input method"
+  },
+  {
+    "name": "ibus-typing-booster",
+    "summary": "A completion input method"
+  },
+  {
+    "name": "ibus-wayland",
+    "summary": "IBus IM module for Wayland"
+  },
+  {
+    "name": "icoutils",
+    "summary": "Utility for extracting and converting Microsoft icon and cursor files"
+  },
+  {
+    "name": "icu",
+    "summary": "International Components for Unicode"
+  },
+  {
+    "name": "idm-jss",
+    "summary": "Java Security Services (JSS)"
+  },
+  {
+    "name": "idm-jss-tomcat",
+    "summary": "Java Security Services (JSS) Connector for Tomcat"
+  },
+  {
+    "name": "idm-ldapjdk",
+    "summary": "LDAP SDK"
+  },
+  {
+    "name": "idm-pki-acme",
+    "summary": "IDM PKI ACME Package"
+  },
+  {
+    "name": "idm-pki-base",
+    "summary": "IDM PKI Base Package"
+  },
+  {
+    "name": "idm-pki-ca",
+    "summary": "IDM PKI CA Package"
+  },
+  {
+    "name": "idm-pki-est",
+    "summary": "IDM PKI EST Package"
+  },
+  {
+    "name": "idm-pki-java",
+    "summary": "IDM PKI Base Java Package"
+  },
+  {
+    "name": "idm-pki-kra",
+    "summary": "IDM PKI KRA Package"
+  },
+  {
+    "name": "idm-pki-server",
+    "summary": "IDM PKI Server Package"
+  },
+  {
+    "name": "idm-pki-tools",
+    "summary": "IDM PKI Tools Package"
+  },
+  {
+    "name": "idm-tomcatjss",
+    "summary": "JSS Connector for Apache Tomcat"
+  },
+  {
+    "name": "idn2",
+    "summary": "IDNA2008 internationalized domain names conversion tool"
+  },
+  {
+    "name": "ignition",
+    "summary": "First boot installer and configuration tool"
+  },
+  {
+    "name": "ignition-edge",
+    "summary": "Enablement glue for Ignition on IoT/Edge systems"
+  },
+  {
+    "name": "ignition-grub",
+    "summary": "Enablement glue for bootupd's grub2 config"
+  },
+  {
+    "name": "ignition-validate",
+    "summary": "Validation tool for Ignition configs"
+  },
+  {
+    "name": "iio-sensor-proxy",
+    "summary": "IIO accelerometer sensor to input device proxy"
+  },
+  {
+    "name": "imath",
+    "summary": "Library of 2D and 3D vector, matrix, and math operations for computer graphics"
+  },
+  {
+    "name": "infiniband-diags",
+    "summary": "InfiniBand Diagnostic Tools"
+  },
+  {
+    "name": "initial-setup",
+    "summary": "Initial system configuration utility"
+  },
+  {
+    "name": "initial-setup-gui",
+    "summary": "Graphical user interface for the initial-setup utility"
+  },
+  {
+    "name": "inkscape",
+    "summary": "Vector-based drawing program using SVG"
+  },
+  {
+    "name": "inkscape-docs",
+    "summary": "Documentation for Inkscape"
+  },
+  {
+    "name": "inkscape-view",
+    "summary": "Viewing program for SVG files"
+  },
+  {
+    "name": "insights-client",
+    "summary": "Uploads Insights information to Red Hat on a periodic basis"
+  },
+  {
+    "name": "insights-client-ros",
+    "summary": "The subpackage for Insights resource optimization service"
+  },
+  {
+    "name": "intel-lpmd",
+    "summary": "Intel Low Power Mode Daemon"
+  },
+  {
+    "name": "intltool",
+    "summary": "Utility for internationalizing various kinds of data files"
+  },
+  {
+    "name": "iowatcher",
+    "summary": "Utility for visualizing block layer IO patterns and performance"
+  },
+  {
+    "name": "ipa-client",
+    "summary": "IPA authentication for use on clients"
+  },
+  {
+    "name": "ipa-client-common",
+    "summary": "Common files used by IPA client"
+  },
+  {
+    "name": "ipa-client-encrypted-dns",
+    "summary": "Enable encrypted DNS support for clients"
+  },
+  {
+    "name": "ipa-client-epn",
+    "summary": "Tools to configure Expiring Password Notification in IPA"
+  },
+  {
+    "name": "ipa-client-samba",
+    "summary": "Tools to configure Samba on IPA client"
+  },
+  {
+    "name": "ipa-common",
+    "summary": "Common files used by IPA"
+  },
+  {
+    "name": "ipa-healthcheck",
+    "summary": "Health check tool for IPA"
+  },
+  {
+    "name": "ipa-healthcheck-core",
+    "summary": "Core plugin system for healthcheck"
+  },
+  {
+    "name": "ipa-selinux",
+    "summary": "FreeIPA SELinux policy"
+  },
+  {
+    "name": "ipa-selinux-luna",
+    "summary": "FreeIPA SELinux policy for Thales Luna HSMs"
+  },
+  {
+    "name": "ipa-selinux-nfast",
+    "summary": "FreeIPA SELinux policy for nCipher nfast HSMs"
+  },
+  {
+    "name": "ipa-server",
+    "summary": "The IPA authentication server"
+  },
+  {
+    "name": "ipa-server-common",
+    "summary": "Common files used by IPA server"
+  },
+  {
+    "name": "ipa-server-dns",
+    "summary": "IPA integrated DNS server with support for automatic DNSSEC signing"
+  },
+  {
+    "name": "ipa-server-encrypted-dns",
+    "summary": "support for encrypted DNS in IPA integrated DNS server"
+  },
+  {
+    "name": "ipa-server-trust-ad",
+    "summary": "Virtual package to install packages required for Active Directory trusts"
+  },
+  {
+    "name": "iperf3",
+    "summary": "Measurement tool for TCP/UDP bandwidth performance"
+  },
+  {
+    "name": "ipmievd",
+    "summary": "IPMI event daemon for sending events to syslog"
+  },
+  {
+    "name": "ipmitool",
+    "summary": "Utility for IPMI control"
+  },
+  {
+    "name": "ipset-service",
+    "summary": "ipset service for ipsets"
+  },
+  {
+    "name": "iptables-devel",
+    "summary": "Development package for iptables"
+  },
+  {
+    "name": "iptables-nft-services",
+    "summary": "Services for nft-variants of iptables, ebtables and arptables"
+  },
+  {
+    "name": "iputils-ninfod",
+    "summary": "Node Information Query Daemon"
+  },
+  {
+    "name": "ipvsadm",
+    "summary": "Utility to administer the Linux Virtual Server"
+  },
+  {
+    "name": "ipxe-bootimgs-aarch64",
+    "summary": "AArch64 Network boot loader images in bootable USB and GRUB formats"
+  },
+  {
+    "name": "ipxe-bootimgs-x86",
+    "summary": "X86 Network boot loader images in bootable USB, CD, floppy and GRUB formats"
+  },
+  {
+    "name": "ipxe-roms",
+    "summary": "Network boot loader roms in .rom format"
+  },
+  {
+    "name": "ipxe-roms-qemu",
+    "summary": "Network boot loader roms supported by QEMU, .rom format"
+  },
+  {
+    "name": "irssi",
+    "summary": "Modular text mode IRC client with Perl scripting"
+  },
+  {
+    "name": "iso-codes",
+    "summary": "ISO code lists and translations"
+  },
+  {
+    "name": "iso-codes-devel",
+    "summary": "Files for development using iso-codes"
+  },
+  {
+    "name": "isomd5sum",
+    "summary": "Utilities for working with md5sum implanted in ISO images"
+  },
+  {
+    "name": "itstool",
+    "summary": "ITS-based XML translation tool"
+  },
+  {
+    "name": "jakarta-activation",
+    "summary": "Jakarta Activation Specification and Implementation"
+  },
+  {
+    "name": "jakarta-activation2",
+    "summary": "Jakarta Activation API"
+  },
+  {
+    "name": "jakarta-annotations",
+    "summary": "Jakarta Annotations"
+  },
+  {
+    "name": "jakarta-mail",
+    "summary": "Jakarta Mail API"
+  },
+  {
+    "name": "jakarta-oro",
+    "summary": "Full regular expressions API"
+  },
+  {
+    "name": "jansi",
+    "summary": "Generate and interpret ANSI escape sequences in Java"
+  },
+  {
+    "name": "jasper",
+    "summary": "Implementation of the JPEG-2000 standard, Part 1"
+  },
+  {
+    "name": "jasper-libs",
+    "summary": "Runtime libraries for jasper"
+  },
+  {
+    "name": "jasper-utils",
+    "summary": "Nonessential utilities for jasper"
+  },
+  {
+    "name": "java-1.8.0-openjdk",
+    "summary": "OpenJDK 8 Runtime Environment"
+  },
+  {
+    "name": "java-1.8.0-openjdk-demo",
+    "summary": "OpenJDK 8 Demos"
+  },
+  {
+    "name": "java-1.8.0-openjdk-devel",
+    "summary": "OpenJDK 8 Development Environment"
+  },
+  {
+    "name": "java-1.8.0-openjdk-headless",
+    "summary": "OpenJDK 8 Headless Runtime Environment"
+  },
+  {
+    "name": "java-1.8.0-openjdk-javadoc",
+    "summary": "OpenJDK 8 API documentation"
+  },
+  {
+    "name": "java-1.8.0-openjdk-javadoc-zip",
+    "summary": "OpenJDK 8 API documentation compressed in a single archive"
+  },
+  {
+    "name": "java-1.8.0-openjdk-src",
+    "summary": "OpenJDK 8 Source Bundle"
+  },
+  {
+    "name": "java-11-openjdk",
+    "summary": "OpenJDK 11 Runtime Environment"
+  },
+  {
+    "name": "java-11-openjdk-demo",
+    "summary": "OpenJDK 11 Demos"
+  },
+  {
+    "name": "java-11-openjdk-devel",
+    "summary": "OpenJDK 11 Development Environment"
+  },
+  {
+    "name": "java-11-openjdk-headless",
+    "summary": "OpenJDK 11 Headless Runtime Environment"
+  },
+  {
+    "name": "java-11-openjdk-javadoc",
+    "summary": "OpenJDK 11 API documentation"
+  },
+  {
+    "name": "java-11-openjdk-javadoc-zip",
+    "summary": "OpenJDK 11 API documentation compressed in a single archive"
+  },
+  {
+    "name": "java-11-openjdk-jmods",
+    "summary": "JMods for OpenJDK 11"
+  },
+  {
+    "name": "java-11-openjdk-src",
+    "summary": "OpenJDK 11 Source Bundle"
+  },
+  {
+    "name": "java-11-openjdk-static-libs",
+    "summary": "OpenJDK 11 libraries for static linking"
+  },
+  {
+    "name": "java-17-openjdk",
+    "summary": "OpenJDK 17 Runtime Environment"
+  },
+  {
+    "name": "java-17-openjdk-demo",
+    "summary": "OpenJDK 17 Demos"
+  },
+  {
+    "name": "java-17-openjdk-devel",
+    "summary": "OpenJDK 17 Development Environment"
+  },
+  {
+    "name": "java-17-openjdk-headless",
+    "summary": "OpenJDK 17 Headless Runtime Environment"
+  },
+  {
+    "name": "java-17-openjdk-javadoc",
+    "summary": "OpenJDK 17 API documentation"
+  },
+  {
+    "name": "java-17-openjdk-javadoc-zip",
+    "summary": "OpenJDK 17 API documentation compressed in a single archive"
+  },
+  {
+    "name": "java-17-openjdk-jmods",
+    "summary": "JMods for OpenJDK 17"
+  },
+  {
+    "name": "java-17-openjdk-src",
+    "summary": "OpenJDK 17 Source Bundle"
+  },
+  {
+    "name": "java-17-openjdk-static-libs",
+    "summary": "OpenJDK 17 libraries for static linking"
+  },
+  {
+    "name": "java-21-openjdk",
+    "summary": "OpenJDK 21 Runtime Environment"
+  },
+  {
+    "name": "java-21-openjdk-demo",
+    "summary": "OpenJDK 21 Demos"
+  },
+  {
+    "name": "java-21-openjdk-devel",
+    "summary": "OpenJDK 21 Development Environment"
+  },
+  {
+    "name": "java-21-openjdk-headless",
+    "summary": "OpenJDK 21 Headless Runtime Environment"
+  },
+  {
+    "name": "java-21-openjdk-javadoc",
+    "summary": "OpenJDK 21 API documentation"
+  },
+  {
+    "name": "java-21-openjdk-javadoc-zip",
+    "summary": "OpenJDK 21 API documentation compressed in a single archive"
+  },
+  {
+    "name": "java-21-openjdk-jmods",
+    "summary": "JMods for OpenJDK 21"
+  },
+  {
+    "name": "java-21-openjdk-src",
+    "summary": "OpenJDK 21 Source Bundle"
+  },
+  {
+    "name": "java-21-openjdk-static-libs",
+    "summary": "OpenJDK 21 libraries for static linking"
+  },
+  {
+    "name": "javapackages-filesystem",
+    "summary": "Java packages filesystem layout"
+  },
+  {
+    "name": "javapackages-tools",
+    "summary": "Macros and scripts for Java packaging support"
+  },
+  {
+    "name": "jaxb-api",
+    "summary": "Jakarta XML Binding API"
+  },
+  {
+    "name": "jaxb-api4",
+    "summary": "Jakarta XML Binding API"
+  },
+  {
+    "name": "jaxb-codemodel",
+    "summary": "Codemodel Core"
+  },
+  {
+    "name": "jaxb-core",
+    "summary": "JAXB Core"
+  },
+  {
+    "name": "jaxb-dtd-parser",
+    "summary": "SAX-like API for parsing XML DTDs"
+  },
+  {
+    "name": "jaxb-istack-commons-runtime",
+    "summary": "istack-commons runtime"
+  },
+  {
+    "name": "jaxb-istack-commons-tools",
+    "summary": "istack-commons tools"
+  },
+  {
+    "name": "jaxb-relaxng-datatype",
+    "summary": "RelaxNG Datatype"
+  },
+  {
+    "name": "jaxb-rngom",
+    "summary": "RELAX NG Object Model/Parser"
+  },
+  {
+    "name": "jaxb-runtime",
+    "summary": "JAXB Runtime"
+  },
+  {
+    "name": "jaxb-txw2",
+    "summary": "TXW2 Runtime"
+  },
+  {
+    "name": "jaxb-xjc",
+    "summary": "JAXB XJC"
+  },
+  {
+    "name": "jaxb-xsom",
+    "summary": "XML Schema Object Model"
+  },
+  {
+    "name": "jbig2dec-libs",
+    "summary": "A decoder implementation of the JBIG2 image compression format"
+  },
+  {
+    "name": "jbigkit",
+    "summary": "JBIG1 lossless image compression tools"
+  },
+  {
+    "name": "jbigkit-libs",
+    "summary": "JBIG1 lossless image compression library"
+  },
+  {
+    "name": "jboss-jaxrs-2.0-api",
+    "summary": "JAX-RS 2.0: The Java API for RESTful Web Services"
+  },
+  {
+    "name": "jboss-logging",
+    "summary": "The JBoss Logging Framework"
+  },
+  {
+    "name": "jboss-logging-tools",
+    "summary": "JBoss Logging I18n Annotation Processor"
+  },
+  {
+    "name": "jcl-over-slf4j",
+    "summary": "JCL 1.1.1 implemented over SLF4J"
+  },
+  {
+    "name": "jctools",
+    "summary": "Java Concurrency Tools for the JVM"
+  },
+  {
+    "name": "jdeparser",
+    "summary": "Source generator library for Java"
+  },
+  {
+    "name": "jdepend",
+    "summary": "Java Design Quality Metrics"
+  },
+  {
+    "name": "jigawatts",
+    "summary": "Java CRIU helper"
+  },
+  {
+    "name": "jigawatts-javadoc",
+    "summary": "Javadoc for jigawatts"
+  },
+  {
+    "name": "jmc-core",
+    "summary": "Core API for JDK Mission Control"
+  },
+  {
+    "name": "jna",
+    "summary": "Pure Java access to native libraries"
+  },
+  {
+    "name": "jna-contrib",
+    "summary": "Contrib for jna"
+  },
+  {
+    "name": "jomolhari-fonts",
+    "summary": "Jomolhari a Bhutanese style font for Tibetan and Dzongkha"
+  },
+  {
+    "name": "jose",
+    "summary": "Tools for JSON Object Signing and Encryption (JOSE)"
+  },
+  {
+    "name": "jq",
+    "summary": "Command-line JSON processor"
+  },
+  {
+    "name": "js-d3-flame-graph",
+    "summary": "A D3.js plugin that produces flame graphs"
+  },
+  {
+    "name": "jsch",
+    "summary": "Pure Java implementation of SSH2"
+  },
+  {
+    "name": "json-glib-devel",
+    "summary": "Development files for json-glib"
+  },
+  {
+    "name": "jsoup",
+    "summary": "Java library for working with real-world HTML"
+  },
+  {
+    "name": "jsr-305",
+    "summary": "Correctness annotations for Java code"
+  },
+  {
+    "name": "jss",
+    "summary": "Java Security Services (JSS)"
+  },
+  {
+    "name": "Judy",
+    "summary": "General purpose dynamic array"
+  },
+  {
+    "name": "julietaula-montserrat-fonts",
+    "summary": "Sans-serif typeface inspired from Montserrat area"
+  },
+  {
+    "name": "junit",
+    "summary": "Java regression test package"
+  },
+  {
+    "name": "junit5",
+    "summary": "Java regression testing framework"
+  },
+  {
+    "name": "jzlib",
+    "summary": "Re-implementation of zlib in pure Java"
+  },
+  {
+    "name": "kabi-dw",
+    "summary": "Detect changes in the ABI between kernel builds"
+  },
+  {
+    "name": "kacst-art-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-book-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-decorative-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-digital-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-farsi-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-fonts-common",
+    "summary": "Common files for kacst-fonts"
+  },
+  {
+    "name": "kacst-letter-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-naskh-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-office-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-one-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-pen-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-poster-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-qurn-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-screen-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-title-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kacst-titlel-fonts",
+    "summary": "Fonts for arabic from arabeyes project"
+  },
+  {
+    "name": "kasumi-common",
+    "summary": "Anthy dictionary management common files between kasumi and kasumi-unicode"
+  },
+  {
+    "name": "kasumi-unicode",
+    "summary": "An anthy-unicode dictionary management tool"
+  },
+  {
+    "name": "kbd-legacy",
+    "summary": "Legacy data for kbd package"
+  },
+  {
+    "name": "kdump-anaconda-addon",
+    "summary": "Kdump configuration anaconda addon"
+  },
+  {
+    "name": "keepalived",
+    "summary": "High Availability monitor built upon LVS, VRRP and service pollers"
+  },
+  {
+    "name": "kernel-debug-devel",
+    "summary": "Development package for building kernel modules to match the kernel"
+  },
+  {
+    "name": "kernel-debug-devel-matched",
+    "summary": "Meta package to install matching core and devel packages for a given kernel"
+  },
+  {
+    "name": "kernel-devel",
+    "summary": "Development package for building kernel modules to match the kernel"
+  },
+  {
+    "name": "kernel-devel-matched",
+    "summary": "Meta package to install matching core and devel packages for a given kernel"
+  },
+  {
+    "name": "kernel-doc",
+    "summary": "Various documentation bits found in the kernel source"
+  },
+  {
+    "name": "kernel-headers",
+    "summary": "Header files for the Linux kernel for use by glibc"
+  },
+  {
+    "name": "kernel-rpm-macros",
+    "summary": "Macros and scripts for building kernel module packages"
+  },
+  {
+    "name": "kernel-srpm-macros",
+    "summary": "RPM macros that list arches the full kernel is built on"
+  },
+  {
+    "name": "kernelshark",
+    "summary": "GUI analysis for Ftrace data captured by trace-cmd"
+  },
+  {
+    "name": "keybinder3",
+    "summary": "A library for registering global keyboard shortcuts"
+  },
+  {
+    "name": "keycloak-httpd-client-install",
+    "summary": "Tools to configure Apache HTTPD as Keycloak client"
+  },
+  {
+    "name": "keylime",
+    "summary": "Open source TPM software for Bootstrapping and Maintaining Trust"
+  },
+  {
+    "name": "keylime-agent-rust",
+    "summary": "Rust agent for Keylime"
+  },
+  {
+    "name": "keylime-base",
+    "summary": "The base package contains the default configuration"
+  },
+  {
+    "name": "keylime-registrar",
+    "summary": "The Keylime Registrar component"
+  },
+  {
+    "name": "keylime-selinux",
+    "summary": "keylime SELinux policy"
+  },
+  {
+    "name": "keylime-tenant",
+    "summary": "The Python Keylime Tenant"
+  },
+  {
+    "name": "keylime-verifier",
+    "summary": "The Python Keylime Verifier component"
+  },
+  {
+    "name": "keyutils-libs-devel",
+    "summary": "Development package for building Linux key management utilities"
+  },
+  {
+    "name": "khmer-os-battambang-fonts",
+    "summary": "Battambang font"
+  },
+  {
+    "name": "khmer-os-bokor-fonts",
+    "summary": "Bokor font"
+  },
+  {
+    "name": "khmer-os-content-fonts",
+    "summary": "Content font family"
+  },
+  {
+    "name": "khmer-os-fasthand-fonts",
+    "summary": "Fasthand font family"
+  },
+  {
+    "name": "khmer-os-freehand-fonts",
+    "summary": "Freehand font family"
+  },
+  {
+    "name": "khmer-os-handwritten-fonts",
+    "summary": "All the handwritten font family packages"
+  },
+  {
+    "name": "khmer-os-metal-chrieng-fonts",
+    "summary": "Metal Chrieng font"
+  },
+  {
+    "name": "khmer-os-muol-fonts",
+    "summary": "Muol normal and Muol Light font family"
+  },
+  {
+    "name": "khmer-os-muol-fonts-all",
+    "summary": "All the Muol font family packages"
+  },
+  {
+    "name": "khmer-os-muol-pali-fonts",
+    "summary": "Muol Pali font"
+  },
+  {
+    "name": "khmer-os-siemreap-fonts",
+    "summary": "Siemreap font"
+  },
+  {
+    "name": "khmer-os-system-fonts",
+    "summary": "System font"
+  },
+  {
+    "name": "krb5-devel",
+    "summary": "Development files needed to compile Kerberos 5 programs"
+  },
+  {
+    "name": "ksh",
+    "summary": "The Original ATT Korn Shell"
+  },
+  {
+    "name": "ksmtuned",
+    "summary": "Kernel Samepage Merging services"
+  },
+  {
+    "name": "ktls-utils",
+    "summary": "TLS handshake agent for kernel sockets"
+  },
+  {
+    "name": "lame",
+    "summary": "Free MP3 audio compressor"
+  },
+  {
+    "name": "lame-libs",
+    "summary": "LAME MP3 encoding library"
+  },
+  {
+    "name": "langpacks-af",
+    "summary": "Afrikaans langpacks meta-package"
+  },
+  {
+    "name": "langpacks-am",
+    "summary": "Amharic langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ar",
+    "summary": "Arabic langpacks meta-package"
+  },
+  {
+    "name": "langpacks-as",
+    "summary": "Assamese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ast",
+    "summary": "Asturian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-be",
+    "summary": "Belarusian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-bg",
+    "summary": "Bulgarian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-bn",
+    "summary": "Bengali langpacks meta-package"
+  },
+  {
+    "name": "langpacks-bo",
+    "summary": "Tibetan langpacks meta-package"
+  },
+  {
+    "name": "langpacks-br",
+    "summary": "Breton langpacks meta-package"
+  },
+  {
+    "name": "langpacks-bs",
+    "summary": "Bosnian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ca",
+    "summary": "Catalan langpacks meta-package"
+  },
+  {
+    "name": "langpacks-core-af",
+    "summary": "Afrikaans langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-am",
+    "summary": "Amharic langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ar",
+    "summary": "Arabic langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-as",
+    "summary": "Assamese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ast",
+    "summary": "Asturian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-be",
+    "summary": "Belarusian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-bg",
+    "summary": "Bulgarian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-bn",
+    "summary": "Bengali langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-bo",
+    "summary": "Tibetan langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-br",
+    "summary": "Breton langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-bs",
+    "summary": "Bosnian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ca",
+    "summary": "Catalan langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-cs",
+    "summary": "Czech langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-cy",
+    "summary": "Welsh langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-da",
+    "summary": "Danish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-de",
+    "summary": "German langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-dz",
+    "summary": "Bhutanese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-el",
+    "summary": "Greek langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-en",
+    "summary": "English langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-en_GB",
+    "summary": "English (United Kingdom) langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-eo",
+    "summary": "Esperanto langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-es",
+    "summary": "Spanish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-et",
+    "summary": "Estonian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-eu",
+    "summary": "Basque langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-fa",
+    "summary": "Persian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-fi",
+    "summary": "Finnish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-font-af",
+    "summary": "Afrikaans core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-am",
+    "summary": "Amharic core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ar",
+    "summary": "Arabic core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-as",
+    "summary": "Assamese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ast",
+    "summary": "Asturian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-be",
+    "summary": "Belarusian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-bg",
+    "summary": "Bulgarian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-bn",
+    "summary": "Bengali core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-bo",
+    "summary": "Tibetan core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-br",
+    "summary": "Breton core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-bs",
+    "summary": "Bosnian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ca",
+    "summary": "Catalan core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-cs",
+    "summary": "Czech core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-cy",
+    "summary": "Welsh core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-da",
+    "summary": "Danish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-de",
+    "summary": "German core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-dz",
+    "summary": "Bhutanese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-el",
+    "summary": "Greek core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-en",
+    "summary": "English core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-eo",
+    "summary": "Esperanto core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-es",
+    "summary": "Spanish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-et",
+    "summary": "Estonian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-eu",
+    "summary": "Basque core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-fa",
+    "summary": "Persian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-fi",
+    "summary": "Finnish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-fr",
+    "summary": "French core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ga",
+    "summary": "Irish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-gl",
+    "summary": "Galician core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-gu",
+    "summary": "Gujarati core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-he",
+    "summary": "Hebrew core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-hi",
+    "summary": "Hindi core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-hr",
+    "summary": "Croatian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-hu",
+    "summary": "Hungarian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ia",
+    "summary": "Interlingua core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-id",
+    "summary": "Indonesian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-is",
+    "summary": "Icelandic core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-it",
+    "summary": "Italian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ja",
+    "summary": "Japanese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ka",
+    "summary": "Georgian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-kk",
+    "summary": "Kazakh core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-km",
+    "summary": "Khmer core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-kn",
+    "summary": "Kannada core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ko",
+    "summary": "Korean core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ku",
+    "summary": "Kurdish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-lt",
+    "summary": "Lithuanian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-lv",
+    "summary": "Latvian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-mai",
+    "summary": "Maithili core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-mk",
+    "summary": "Macedonian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ml",
+    "summary": "Malayalam core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-mr",
+    "summary": "Marathi core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ms",
+    "summary": "Malay core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-my",
+    "summary": "Burmese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-nb",
+    "summary": "Norwegian Bokm\u00e5l core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ne",
+    "summary": "Nepali core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-nl",
+    "summary": "Dutch core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-nn",
+    "summary": "Nynorsk core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-nr",
+    "summary": "Southern Ndebele core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-nso",
+    "summary": "Northern Sotho core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-or",
+    "summary": "Odia core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-pa",
+    "summary": "Punjabi core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-pl",
+    "summary": "Polish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-pt",
+    "summary": "Portuguese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ro",
+    "summary": "Romanian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ru",
+    "summary": "Russian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-si",
+    "summary": "Sinhala core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-sk",
+    "summary": "Slovak core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-sl",
+    "summary": "Slovenian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-sq",
+    "summary": "Albanian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-sr",
+    "summary": "Serbian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ss",
+    "summary": "Swati core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-sv",
+    "summary": "Swedish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ta",
+    "summary": "Tamil core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-te",
+    "summary": "Telugu core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-th",
+    "summary": "Thai core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-tn",
+    "summary": "Tswana core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-tr",
+    "summary": "Turkish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ts",
+    "summary": "Tsonga core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-uk",
+    "summary": "Ukrainian core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ur",
+    "summary": "Urdu core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-ve",
+    "summary": "Venda core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-vi",
+    "summary": "Vietnamese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-xh",
+    "summary": "Xhosa core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-yi",
+    "summary": "Yiddish core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-zh_CN",
+    "summary": "Simplified Chinese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-zh_HK",
+    "summary": "Hong Kong Traditional Chinese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-zh_TW",
+    "summary": "Taiwan Traditional Chinese core font meta-package"
+  },
+  {
+    "name": "langpacks-core-font-zu",
+    "summary": "Zulu core font meta-package"
+  },
+  {
+    "name": "langpacks-core-fr",
+    "summary": "French langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ga",
+    "summary": "Irish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-gl",
+    "summary": "Galician langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-gu",
+    "summary": "Gujarati langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-he",
+    "summary": "Hebrew langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-hi",
+    "summary": "Hindi langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-hr",
+    "summary": "Croatian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-hu",
+    "summary": "Hungarian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ia",
+    "summary": "Interlingua langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-id",
+    "summary": "Indonesian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-is",
+    "summary": "Icelandic langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-it",
+    "summary": "Italian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ja",
+    "summary": "Japanese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ka",
+    "summary": "Georgian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-kk",
+    "summary": "Kazakh langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-km",
+    "summary": "Khmer langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-kn",
+    "summary": "Kannada langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ko",
+    "summary": "Korean langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ku",
+    "summary": "Kurdish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-lt",
+    "summary": "Lithuanian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-lv",
+    "summary": "Latvian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-mai",
+    "summary": "Maithili langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-mk",
+    "summary": "Macedonian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ml",
+    "summary": "Malayalam langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-mr",
+    "summary": "Marathi langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ms",
+    "summary": "Malay langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-my",
+    "summary": "Burmese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-nb",
+    "summary": "Norwegian Bokm\u00e5l langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ne",
+    "summary": "Nepali langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-nl",
+    "summary": "Dutch langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-nn",
+    "summary": "Nynorsk langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-nr",
+    "summary": "Southern Ndebele langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-nso",
+    "summary": "Northern Sotho langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-or",
+    "summary": "Odia langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-pa",
+    "summary": "Punjabi langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-pl",
+    "summary": "Polish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-pt",
+    "summary": "Portuguese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-pt_BR",
+    "summary": "Portuguese (Brazil) langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ro",
+    "summary": "Romanian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ru",
+    "summary": "Russian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-si",
+    "summary": "Sinhala langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-sk",
+    "summary": "Slovak langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-sl",
+    "summary": "Slovenian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-sq",
+    "summary": "Albanian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-sr",
+    "summary": "Serbian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ss",
+    "summary": "Swati langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-sv",
+    "summary": "Swedish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ta",
+    "summary": "Tamil langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-te",
+    "summary": "Telugu langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-th",
+    "summary": "Thai langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-tn",
+    "summary": "Tswana langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-tr",
+    "summary": "Turkish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ts",
+    "summary": "Tsonga langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-uk",
+    "summary": "Ukrainian langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ur",
+    "summary": "Urdu langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-ve",
+    "summary": "Venda langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-vi",
+    "summary": "Vietnamese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-xh",
+    "summary": "Xhosa langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-yi",
+    "summary": "Yiddish langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-zh_CN",
+    "summary": "Simplified Chinese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-zh_HK",
+    "summary": "Hong Kong Traditional Chinese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-zh_TW",
+    "summary": "Taiwan Traditional Chinese langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-core-zu",
+    "summary": "Zulu langpacks core meta-package"
+  },
+  {
+    "name": "langpacks-cs",
+    "summary": "Czech langpacks meta-package"
+  },
+  {
+    "name": "langpacks-cy",
+    "summary": "Welsh langpacks meta-package"
+  },
+  {
+    "name": "langpacks-da",
+    "summary": "Danish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-de",
+    "summary": "German langpacks meta-package"
+  },
+  {
+    "name": "langpacks-dz",
+    "summary": "Bhutanese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-el",
+    "summary": "Greek langpacks meta-package"
+  },
+  {
+    "name": "langpacks-en",
+    "summary": "English langpacks meta-package"
+  },
+  {
+    "name": "langpacks-en_GB",
+    "summary": "English (United Kingdom) langpacks meta-package"
+  },
+  {
+    "name": "langpacks-eo",
+    "summary": "Esperanto langpacks meta-package"
+  },
+  {
+    "name": "langpacks-es",
+    "summary": "Spanish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-et",
+    "summary": "Estonian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-eu",
+    "summary": "Basque langpacks meta-package"
+  },
+  {
+    "name": "langpacks-fa",
+    "summary": "Persian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-fi",
+    "summary": "Finnish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-fr",
+    "summary": "French langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ga",
+    "summary": "Irish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-gl",
+    "summary": "Galician langpacks meta-package"
+  },
+  {
+    "name": "langpacks-gu",
+    "summary": "Gujarati langpacks meta-package"
+  },
+  {
+    "name": "langpacks-he",
+    "summary": "Hebrew langpacks meta-package"
+  },
+  {
+    "name": "langpacks-hi",
+    "summary": "Hindi langpacks meta-package"
+  },
+  {
+    "name": "langpacks-hr",
+    "summary": "Croatian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-hu",
+    "summary": "Hungarian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ia",
+    "summary": "Interlingua langpacks meta-package"
+  },
+  {
+    "name": "langpacks-id",
+    "summary": "Indonesian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-is",
+    "summary": "Icelandic langpacks meta-package"
+  },
+  {
+    "name": "langpacks-it",
+    "summary": "Italian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ja",
+    "summary": "Japanese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ka",
+    "summary": "Georgian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-kk",
+    "summary": "Kazakh langpacks meta-package"
+  },
+  {
+    "name": "langpacks-km",
+    "summary": "Khmer langpacks meta-package"
+  },
+  {
+    "name": "langpacks-kn",
+    "summary": "Kannada langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ko",
+    "summary": "Korean langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ku",
+    "summary": "Kurdish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-lt",
+    "summary": "Lithuanian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-lv",
+    "summary": "Latvian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-mai",
+    "summary": "Maithili langpacks meta-package"
+  },
+  {
+    "name": "langpacks-mk",
+    "summary": "Macedonian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ml",
+    "summary": "Malayalam langpacks meta-package"
+  },
+  {
+    "name": "langpacks-mr",
+    "summary": "Marathi langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ms",
+    "summary": "Malay langpacks meta-package"
+  },
+  {
+    "name": "langpacks-my",
+    "summary": "Burmese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-nb",
+    "summary": "Norwegian Bokm\u00e5l langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ne",
+    "summary": "Nepali langpacks meta-package"
+  },
+  {
+    "name": "langpacks-nl",
+    "summary": "Dutch langpacks meta-package"
+  },
+  {
+    "name": "langpacks-nn",
+    "summary": "Nynorsk langpacks meta-package"
+  },
+  {
+    "name": "langpacks-nr",
+    "summary": "Southern Ndebele langpacks meta-package"
+  },
+  {
+    "name": "langpacks-nso",
+    "summary": "Northern Sotho langpacks meta-package"
+  },
+  {
+    "name": "langpacks-or",
+    "summary": "Odia langpacks meta-package"
+  },
+  {
+    "name": "langpacks-pa",
+    "summary": "Punjabi langpacks meta-package"
+  },
+  {
+    "name": "langpacks-pl",
+    "summary": "Polish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-pt",
+    "summary": "Portuguese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-pt_BR",
+    "summary": "Portuguese (Brazil) langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ro",
+    "summary": "Romanian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ru",
+    "summary": "Russian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-si",
+    "summary": "Sinhala langpacks meta-package"
+  },
+  {
+    "name": "langpacks-sk",
+    "summary": "Slovak langpacks meta-package"
+  },
+  {
+    "name": "langpacks-sl",
+    "summary": "Slovenian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-sq",
+    "summary": "Albanian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-sr",
+    "summary": "Serbian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ss",
+    "summary": "Swati langpacks meta-package"
+  },
+  {
+    "name": "langpacks-sv",
+    "summary": "Swedish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ta",
+    "summary": "Tamil langpacks meta-package"
+  },
+  {
+    "name": "langpacks-te",
+    "summary": "Telugu langpacks meta-package"
+  },
+  {
+    "name": "langpacks-th",
+    "summary": "Thai langpacks meta-package"
+  },
+  {
+    "name": "langpacks-tn",
+    "summary": "Tswana langpacks meta-package"
+  },
+  {
+    "name": "langpacks-tr",
+    "summary": "Turkish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ts",
+    "summary": "Tsonga langpacks meta-package"
+  },
+  {
+    "name": "langpacks-uk",
+    "summary": "Ukrainian langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ur",
+    "summary": "Urdu langpacks meta-package"
+  },
+  {
+    "name": "langpacks-ve",
+    "summary": "Venda langpacks meta-package"
+  },
+  {
+    "name": "langpacks-vi",
+    "summary": "Vietnamese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-xh",
+    "summary": "Xhosa langpacks meta-package"
+  },
+  {
+    "name": "langpacks-yi",
+    "summary": "Yiddish langpacks meta-package"
+  },
+  {
+    "name": "langpacks-zh_CN",
+    "summary": "Simplified Chinese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-zh_HK",
+    "summary": "Hong Kong Traditional Chinese langpacks meta-package"
+  },
+  {
+    "name": "langpacks-zh_TW",
+    "summary": "Taiwan langpacks meta-package"
+  },
+  {
+    "name": "langpacks-zu",
+    "summary": "Zulu langpacks meta-package"
+  },
+  {
+    "name": "langtable",
+    "summary": "Guessing reasonable defaults for locale, keyboard layout, territory, and language."
+  },
+  {
+    "name": "lapack",
+    "summary": "Numerical linear algebra package libraries"
+  },
+  {
+    "name": "lasso",
+    "summary": "Liberty Alliance Single Sign On"
+  },
+  {
+    "name": "lato-fonts",
+    "summary": "A sanserif typeface family"
+  },
+  {
+    "name": "lcms2",
+    "summary": "Color Management Engine"
+  },
+  {
+    "name": "lcms2-devel",
+    "summary": "Development files for LittleCMS"
+  },
+  {
+    "name": "ldapjdk",
+    "summary": "LDAP SDK"
+  },
+  {
+    "name": "ldns",
+    "summary": "Low-level DNS(SEC) library with API"
+  },
+  {
+    "name": "leapp",
+    "summary": "OS & Application modernization framework"
+  },
+  {
+    "name": "leapp-deps",
+    "summary": "Meta-package with system dependencies of leapp package"
+  },
+  {
+    "name": "leapp-upgrade-el9toel10",
+    "summary": "Leapp repositories for the in-place upgrade"
+  },
+  {
+    "name": "leapp-upgrade-el9toel10-deps",
+    "summary": "Meta-package with system dependencies of leapp-upgrade-el9toel10 package"
+  },
+  {
+    "name": "leptonica",
+    "summary": "C library for efficient image processing and image analysis operations"
+  },
+  {
+    "name": "lftp",
+    "summary": "A sophisticated file transfer program"
+  },
+  {
+    "name": "liba52",
+    "summary": "A free ATSC A/52 stream decoder, also known as AC-3 or AC3"
+  },
+  {
+    "name": "libabw",
+    "summary": "A library for import of AbiWord files"
+  },
+  {
+    "name": "libacl-devel",
+    "summary": "Files needed for building programs with libacl"
+  },
+  {
+    "name": "libadwaita",
+    "summary": "Building blocks for modern GNOME applications"
+  },
+  {
+    "name": "libadwaita-qt5",
+    "summary": "Adwaita Qt5 library"
+  },
+  {
+    "name": "libaio-devel",
+    "summary": "Development files for Linux-native asynchronous I/O access"
+  },
+  {
+    "name": "libao",
+    "summary": "Cross Platform Audio Output Library"
+  },
+  {
+    "name": "libappstream-glib",
+    "summary": "Library for AppStream metadata"
+  },
+  {
+    "name": "libarchive-devel",
+    "summary": "Development files for libarchive"
+  },
+  {
+    "name": "libasan",
+    "summary": "The Address Sanitizer runtime library"
+  },
+  {
+    "name": "libasan8",
+    "summary": "The Address Sanitizer runtime library from GCC 12"
+  },
+  {
+    "name": "libasyncns",
+    "summary": "Asynchronous Name Service Library"
+  },
+  {
+    "name": "libatasmart",
+    "summary": "ATA S.M.A.R.T. Disk Health Monitoring Library"
+  },
+  {
+    "name": "libattr-devel",
+    "summary": "Files needed for building programs with libattr"
+  },
+  {
+    "name": "libbabeltrace",
+    "summary": "Common Trace Format Babel Tower"
+  },
+  {
+    "name": "libbase",
+    "summary": "JFree Base Services"
+  },
+  {
+    "name": "libblkid-devel",
+    "summary": "Block device ID library"
+  },
+  {
+    "name": "libblkio",
+    "summary": "Block device I/O library"
+  },
+  {
+    "name": "libblockdev",
+    "summary": "A library for low-level manipulation with block devices"
+  },
+  {
+    "name": "libblockdev-crypto",
+    "summary": "The crypto plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-dm",
+    "summary": "The Device Mapper plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-fs",
+    "summary": "The FS plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-kbd",
+    "summary": "The KBD plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-loop",
+    "summary": "The loop plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-lvm",
+    "summary": "The LVM plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-lvm-dbus",
+    "summary": "The LVM plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-mdraid",
+    "summary": "The MD RAID plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-mpath",
+    "summary": "The multipath plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-nvdimm",
+    "summary": "The NVDIMM plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-nvme",
+    "summary": "The NVMe plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-part",
+    "summary": "The partitioning plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-plugins-all",
+    "summary": "Meta-package that pulls all the libblockdev plugins as dependencies"
+  },
+  {
+    "name": "libblockdev-swap",
+    "summary": "The swap plugin for the libblockdev library"
+  },
+  {
+    "name": "libblockdev-tools",
+    "summary": "Various nice tools based on libblockdev"
+  },
+  {
+    "name": "libblockdev-utils",
+    "summary": "A library with utility functions for the libblockdev library"
+  },
+  {
+    "name": "libbpf-tools",
+    "summary": "Command line libbpf tools for BPF Compiler Collection (BCC)"
+  },
+  {
+    "name": "libburn",
+    "summary": "Library for reading, mastering and writing optical discs"
+  },
+  {
+    "name": "libburn-doc",
+    "summary": "Documentation files for libburn"
+  },
+  {
+    "name": "libbytesize",
+    "summary": "A library for working with sizes in bytes"
+  },
+  {
+    "name": "libcanberra",
+    "summary": "Portable Sound Event Library"
+  },
+  {
+    "name": "libcanberra-devel",
+    "summary": "Development Files for libcanberra Client Development"
+  },
+  {
+    "name": "libcanberra-gtk2",
+    "summary": "Gtk+ 2.x Bindings for libcanberra"
+  },
+  {
+    "name": "libcanberra-gtk3",
+    "summary": "Gtk+ 3.x Bindings for libcanberra"
+  },
+  {
+    "name": "libcap-devel",
+    "summary": "Development files for libcap"
+  },
+  {
+    "name": "libcap-ng-devel",
+    "summary": "Header files for libcap-ng library"
+  },
+  {
+    "name": "libcap-ng-python3",
+    "summary": "Python3 bindings for libcap-ng library"
+  },
+  {
+    "name": "libcdio",
+    "summary": "CD-ROM input and control library"
+  },
+  {
+    "name": "libcdio-paranoia",
+    "summary": "CD paranoia on top of libcdio"
+  },
+  {
+    "name": "libcdr",
+    "summary": "A library for import of CorelDRAW drawings"
+  },
+  {
+    "name": "libcmis",
+    "summary": "A C/C++ client library for CM interfaces"
+  },
+  {
+    "name": "libcmpiCppImpl0",
+    "summary": "CMPI C++ wrapper library"
+  },
+  {
+    "name": "libcom_err-devel",
+    "summary": "Common error description library"
+  },
+  {
+    "name": "libcurl-devel",
+    "summary": "Files needed for building applications with libcurl"
+  },
+  {
+    "name": "libdatrie",
+    "summary": "Implementation of Double-Array structure for representing trie"
+  },
+  {
+    "name": "libdatrie-devel",
+    "summary": "Development files for libdatrie"
+  },
+  {
+    "name": "libdazzle",
+    "summary": "Experimental new features for GTK+ and GLib"
+  },
+  {
+    "name": "libdb-devel",
+    "summary": "C development files for the Berkeley DB library"
+  },
+  {
+    "name": "libdb-utils",
+    "summary": "Command line tools for managing Berkeley DB databases"
+  },
+  {
+    "name": "libdecor",
+    "summary": "Wayland client side decoration library"
+  },
+  {
+    "name": "libdmx",
+    "summary": "X.Org X11 DMX runtime library"
+  },
+  {
+    "name": "libdrm",
+    "summary": "Direct Rendering Manager runtime library"
+  },
+  {
+    "name": "libdrm-devel",
+    "summary": "Direct Rendering Manager development package"
+  },
+  {
+    "name": "libdvdnav",
+    "summary": "A library for reading DVD video discs based on Ogle code"
+  },
+  {
+    "name": "libdvdread",
+    "summary": "A library for reading DVD video discs based on Ogle code"
+  },
+  {
+    "name": "libdwarves1",
+    "summary": "Debugging information  processing library"
+  },
+  {
+    "name": "libecap",
+    "summary": "Squid interface for embedded adaptation modules"
+  },
+  {
+    "name": "libecap-devel",
+    "summary": "Libraries and header files for the libecap library"
+  },
+  {
+    "name": "libecpg",
+    "summary": "ECPG - Embedded SQL in C"
+  },
+  {
+    "name": "libedit-devel",
+    "summary": "Development files for libedit"
+  },
+  {
+    "name": "libell",
+    "summary": "Embedded Linux library"
+  },
+  {
+    "name": "libepoxy",
+    "summary": "epoxy runtime library"
+  },
+  {
+    "name": "libepoxy-devel",
+    "summary": "Development files for libepoxy"
+  },
+  {
+    "name": "libepubgen",
+    "summary": "An EPUB generator library"
+  },
+  {
+    "name": "liberation-fonts",
+    "summary": "Fonts to replace commonly used Microsoft Windows fonts"
+  },
+  {
+    "name": "liberation-fonts-common",
+    "summary": "Shared common files of Liberation font families"
+  },
+  {
+    "name": "liberation-mono-fonts",
+    "summary": "Monospace fonts to replace commonly used Microsoft Courier New"
+  },
+  {
+    "name": "liberation-narrow-fonts",
+    "summary": "Sans-serif Narrow fonts to replace commonly used Microsoft Arial Narrow"
+  },
+  {
+    "name": "liberation-sans-fonts",
+    "summary": "Sans-serif fonts to replace commonly used Microsoft Arial"
+  },
+  {
+    "name": "liberation-serif-fonts",
+    "summary": "Serif fonts to replace commonly used Microsoft Times New Roman"
+  },
+  {
+    "name": "libestr",
+    "summary": "String handling essentials library"
+  },
+  {
+    "name": "libetonyek",
+    "summary": "A library for import of Apple iWork documents"
+  },
+  {
+    "name": "libevdev",
+    "summary": "Kernel Evdev Device Wrapper Library"
+  },
+  {
+    "name": "libevent-devel",
+    "summary": "Development files for libevent"
+  },
+  {
+    "name": "libevent-doc",
+    "summary": "Development documentation for libevent"
+  },
+  {
+    "name": "libexif",
+    "summary": "Library for extracting extra information from image files"
+  },
+  {
+    "name": "libexttextcat",
+    "summary": "Text categorization library"
+  },
+  {
+    "name": "libfabric",
+    "summary": "Open Fabric Interfaces"
+  },
+  {
+    "name": "libfastjson",
+    "summary": "A JSON implementation in C"
+  },
+  {
+    "name": "libfdt",
+    "summary": "Device tree library"
+  },
+  {
+    "name": "libffi-devel",
+    "summary": "Development files for libffi"
+  },
+  {
+    "name": "libfontenc",
+    "summary": "X.Org X11 libfontenc runtime library"
+  },
+  {
+    "name": "libfonts",
+    "summary": "TrueType Font Layouting"
+  },
+  {
+    "name": "libformula",
+    "summary": "Formula Parser"
+  },
+  {
+    "name": "libfprint",
+    "summary": "Toolkit for fingerprint scanner"
+  },
+  {
+    "name": "libfreehand",
+    "summary": "A library for import of Macromedia/Adobe FreeHand documents"
+  },
+  {
+    "name": "libgccjit",
+    "summary": "Library for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "libgccjit-devel",
+    "summary": "Support for embedding GCC inside programs and libraries"
+  },
+  {
+    "name": "libgcrypt-devel",
+    "summary": "Development files for the libgcrypt package"
+  },
+  {
+    "name": "libgdata",
+    "summary": "Library for the GData protocol"
+  },
+  {
+    "name": "libgdata-devel",
+    "summary": "Development files for libgdata"
+  },
+  {
+    "name": "libgee",
+    "summary": "GObject collection library"
+  },
+  {
+    "name": "libgexiv2",
+    "summary": "Gexiv2 is a GObject-based wrapper around the Exiv2 library"
+  },
+  {
+    "name": "libglvnd",
+    "summary": "The GL Vendor-Neutral Dispatch library"
+  },
+  {
+    "name": "libglvnd-core-devel",
+    "summary": "Core development files for libglvnd"
+  },
+  {
+    "name": "libglvnd-devel",
+    "summary": "Development files for libglvnd"
+  },
+  {
+    "name": "libglvnd-egl",
+    "summary": "EGL support for libglvnd"
+  },
+  {
+    "name": "libglvnd-gles",
+    "summary": "GLES support for libglvnd"
+  },
+  {
+    "name": "libglvnd-glx",
+    "summary": "GLX support for libglvnd"
+  },
+  {
+    "name": "libglvnd-opengl",
+    "summary": "OpenGL support for libglvnd"
+  },
+  {
+    "name": "libgnomekbd",
+    "summary": "A keyboard configuration library"
+  },
+  {
+    "name": "libgomp-offload-nvptx",
+    "summary": "GCC OpenMP v4.5 plugin for offloading to NVPTX"
+  },
+  {
+    "name": "libgpg-error-devel",
+    "summary": "Development files for the libgpg-error package"
+  },
+  {
+    "name": "libgphoto2",
+    "summary": "Library for accessing digital cameras"
+  },
+  {
+    "name": "libgpiod",
+    "summary": "C library and tools for interacting with linux GPIO char device"
+  },
+  {
+    "name": "libgpiod-c++",
+    "summary": "C++ bindings for libgpiod"
+  },
+  {
+    "name": "libgpiod-devel",
+    "summary": "Development package for libgpiod"
+  },
+  {
+    "name": "libgpiod-utils",
+    "summary": "Utilities for GPIO"
+  },
+  {
+    "name": "libgs",
+    "summary": "Library providing Ghostcript's core functionality"
+  },
+  {
+    "name": "libgsf",
+    "summary": "GNOME Structured File library"
+  },
+  {
+    "name": "libgtop2",
+    "summary": "LibGTop library (version 2)"
+  },
+  {
+    "name": "libgudev-devel",
+    "summary": "Header files for libgudev"
+  },
+  {
+    "name": "libguestfs",
+    "summary": "Access and modify virtual machine disk images"
+  },
+  {
+    "name": "libguestfs-appliance",
+    "summary": "Appliance for libguestfs"
+  },
+  {
+    "name": "libguestfs-bash-completion",
+    "summary": "Bash tab-completion scripts for libguestfs tools"
+  },
+  {
+    "name": "libguestfs-inspect-icons",
+    "summary": "Additional dependencies for inspecting guest icons"
+  },
+  {
+    "name": "libguestfs-rescue",
+    "summary": "virt-rescue shell"
+  },
+  {
+    "name": "libguestfs-rsync",
+    "summary": "rsync support for libguestfs"
+  },
+  {
+    "name": "libguestfs-winsupport",
+    "summary": "Add support for Windows guests to virt-v2v and virt-p2v"
+  },
+  {
+    "name": "libguestfs-xfs",
+    "summary": "XFS support for libguestfs"
+  },
+  {
+    "name": "libgweather",
+    "summary": "A library for weather information"
+  },
+  {
+    "name": "libgweather-devel",
+    "summary": "Development files for libgweather"
+  },
+  {
+    "name": "libgxps",
+    "summary": "GObject based library for handling and rendering XPS documents"
+  },
+  {
+    "name": "libhandy",
+    "summary": "Building blocks for modern adaptive GNOME apps"
+  },
+  {
+    "name": "libhangul",
+    "summary": "Hangul input library"
+  },
+  {
+    "name": "libi2c",
+    "summary": "I2C/SMBus bus access library"
+  },
+  {
+    "name": "libi2cd",
+    "summary": "C library for interacting with linux I2C devices"
+  },
+  {
+    "name": "libi2cd-devel",
+    "summary": "Development package for libi2cd"
+  },
+  {
+    "name": "libical",
+    "summary": "Reference implementation of the iCalendar data type and serialization format"
+  },
+  {
+    "name": "libical-devel",
+    "summary": "Development files for libical"
+  },
+  {
+    "name": "libical-glib",
+    "summary": "GObject wrapper for libical library"
+  },
+  {
+    "name": "libical-glib-devel",
+    "summary": "Development files for building against libical-glib"
+  },
+  {
+    "name": "libICE",
+    "summary": "X.Org X11 ICE runtime library"
+  },
+  {
+    "name": "libICE-devel",
+    "summary": "X.Org X11 ICE development package"
+  },
+  {
+    "name": "libicu-devel",
+    "summary": "Development files for International Components for Unicode"
+  },
+  {
+    "name": "libidn2-devel",
+    "summary": "Development files for libidn2"
+  },
+  {
+    "name": "libieee1284",
+    "summary": "A library for interfacing IEEE 1284-compatible devices"
+  },
+  {
+    "name": "libieee1284-devel",
+    "summary": "Files for developing applications that use libieee1284"
+  },
+  {
+    "name": "libijs",
+    "summary": "IJS Raster Image Transport Protocol Library"
+  },
+  {
+    "name": "libinput",
+    "summary": "Input device library"
+  },
+  {
+    "name": "libinput-utils",
+    "summary": "Utilities and tools for debugging libinput"
+  },
+  {
+    "name": "libipt",
+    "summary": "Intel Processor Trace Decoder Library"
+  },
+  {
+    "name": "libiptcdata",
+    "summary": "IPTC tag library"
+  },
+  {
+    "name": "libiscsi",
+    "summary": "iSCSI client library"
+  },
+  {
+    "name": "libiscsi-utils",
+    "summary": "iSCSI Client Utilities"
+  },
+  {
+    "name": "libisoburn",
+    "summary": "Library to enable creation and expansion of ISO-9660 filesystems"
+  },
+  {
+    "name": "libisoburn-doc",
+    "summary": "Documentation files for libisoburn"
+  },
+  {
+    "name": "libisofs",
+    "summary": "Library to create ISO 9660 disk images"
+  },
+  {
+    "name": "libisofs-doc",
+    "summary": "Documentation files for libisofs"
+  },
+  {
+    "name": "libitm",
+    "summary": "The GNU Transactional Memory library"
+  },
+  {
+    "name": "libitm-devel",
+    "summary": "The GNU Transactional Memory support"
+  },
+  {
+    "name": "libjose",
+    "summary": "Library implementing JSON Object Signing and Encryption"
+  },
+  {
+    "name": "libjpeg-turbo",
+    "summary": "A MMX/SSE2/SIMD accelerated library for manipulating JPEG image files"
+  },
+  {
+    "name": "libjpeg-turbo-devel",
+    "summary": "Headers for the libjpeg-turbo library"
+  },
+  {
+    "name": "libjpeg-turbo-utils",
+    "summary": "Utilities for manipulating JPEG images"
+  },
+  {
+    "name": "libkdumpfile",
+    "summary": "Kernel coredump file access"
+  },
+  {
+    "name": "libkdumpfile-devel",
+    "summary": "Development files for libkdumpfile"
+  },
+  {
+    "name": "libkeepalive",
+    "summary": "Enable TCP keepalive in dynamic binaries"
+  },
+  {
+    "name": "liblangtag",
+    "summary": "An interface library to access tags for identifying languages"
+  },
+  {
+    "name": "liblangtag-data",
+    "summary": "liblangtag data files"
+  },
+  {
+    "name": "liblayout",
+    "summary": "CSS based layouting framework"
+  },
+  {
+    "name": "libldac",
+    "summary": "A lossy audio codec for Bluetooth connections"
+  },
+  {
+    "name": "libloader",
+    "summary": "Resource Loading Framework"
+  },
+  {
+    "name": "liblockfile",
+    "summary": "This implements a number of functions found in -lmail on SysV systems"
+  },
+  {
+    "name": "liblognorm",
+    "summary": "Fast samples-based log normalization library"
+  },
+  {
+    "name": "liblognorm-doc",
+    "summary": "HTML documentation for liblognorm"
+  },
+  {
+    "name": "liblouis",
+    "summary": "Braille translation and back-translation library"
+  },
+  {
+    "name": "liblsan",
+    "summary": "The Leak Sanitizer runtime library"
+  },
+  {
+    "name": "libluksmeta",
+    "summary": "Library for storing small metadata in the LUKSv1 header"
+  },
+  {
+    "name": "libmad",
+    "summary": "MPEG audio decoder library"
+  },
+  {
+    "name": "libmatchbox",
+    "summary": "Libraries for the Matchbox Desktop"
+  },
+  {
+    "name": "libmaxminddb",
+    "summary": "C library for the MaxMind DB file format"
+  },
+  {
+    "name": "libmediaart",
+    "summary": "Library for managing media art caches"
+  },
+  {
+    "name": "libmicrohttpd",
+    "summary": "Lightweight library for embedding a webserver in applications"
+  },
+  {
+    "name": "libmng",
+    "summary": "Library for Multiple-image Network Graphics support"
+  },
+  {
+    "name": "libmount-devel",
+    "summary": "Device mounting library"
+  },
+  {
+    "name": "libmpc",
+    "summary": "C library for multiple precision complex arithmetic"
+  },
+  {
+    "name": "libmpc-devel",
+    "summary": "Headers and shared development libraries for MPC"
+  },
+  {
+    "name": "libmpeg2",
+    "summary": "MPEG-2 decoder libraries"
+  },
+  {
+    "name": "libmspack",
+    "summary": "Library for CAB and related files compression and decompression"
+  },
+  {
+    "name": "libmspub",
+    "summary": "A library for import of Microsoft Publisher documents"
+  },
+  {
+    "name": "libmtp",
+    "summary": "Software library for MTP media players"
+  },
+  {
+    "name": "libmwaw",
+    "summary": "A library for import of many old Mac document formats"
+  },
+  {
+    "name": "libmypaint",
+    "summary": "Library for making brush strokes"
+  },
+  {
+    "name": "libnbd",
+    "summary": "NBD client library in userspace"
+  },
+  {
+    "name": "libnbd-bash-completion",
+    "summary": "Bash tab-completion for libnbd"
+  },
+  {
+    "name": "libnet",
+    "summary": "C library for portable packet creation and injection"
+  },
+  {
+    "name": "libnetfilter_cthelper",
+    "summary": "User-space infrastructure for connection tracking helpers"
+  },
+  {
+    "name": "libnetfilter_cttimeout",
+    "summary": "Timeout policy tuning for Netfilter/conntrack"
+  },
+  {
+    "name": "libnetfilter_queue",
+    "summary": "Netfilter queue userspace library"
+  },
+  {
+    "name": "libnl3-devel",
+    "summary": "Libraries and headers for using libnl3"
+  },
+  {
+    "name": "libnma",
+    "summary": "NetworkManager GUI library"
+  },
+  {
+    "name": "libnotify",
+    "summary": "Desktop notification library"
+  },
+  {
+    "name": "libnotify-devel",
+    "summary": "Development files for libnotify"
+  },
+  {
+    "name": "libnsl2",
+    "summary": "Public client interface library for NIS(YP) and NIS+"
+  },
+  {
+    "name": "libnumbertext",
+    "summary": "Number to number name and money text conversion library"
+  },
+  {
+    "name": "libodfgen",
+    "summary": "An ODF generator library"
+  },
+  {
+    "name": "libogg",
+    "summary": "The Ogg bitstream file format library"
+  },
+  {
+    "name": "libomp",
+    "summary": "OpenMP runtime for clang"
+  },
+  {
+    "name": "libomp-devel",
+    "summary": "OpenMP header files"
+  },
+  {
+    "name": "libomp-test",
+    "summary": "OpenMP regression tests"
+  },
+  {
+    "name": "libopenraw",
+    "summary": "Decode camera RAW files"
+  },
+  {
+    "name": "liborcus",
+    "summary": "Standalone file import filter library for spreadsheet documents"
+  },
+  {
+    "name": "libosinfo",
+    "summary": "A library for managing OS information for virtualization"
+  },
+  {
+    "name": "libotf",
+    "summary": "A Library for handling OpenType Font"
+  },
+  {
+    "name": "libotr",
+    "summary": "Off-The-Record Messaging library and toolkit"
+  },
+  {
+    "name": "libpagemaker",
+    "summary": "A library for import of Adobe PageMaker documents"
+  },
+  {
+    "name": "libpaper",
+    "summary": "Library and tools for handling papersize"
+  },
+  {
+    "name": "libpciaccess-devel",
+    "summary": "PCI access library development package"
+  },
+  {
+    "name": "libpeas-gtk",
+    "summary": "GTK+ plug-ins support for libpeas"
+  },
+  {
+    "name": "libpeas-loader-python3",
+    "summary": "Python 3 loader for libpeas"
+  },
+  {
+    "name": "libpfm",
+    "summary": "Library to encode performance events for use by perf tool"
+  },
+  {
+    "name": "libpfm-devel",
+    "summary": "Development library to encode performance events for perf_events based tools"
+  },
+  {
+    "name": "libpgtypes",
+    "summary": "Map PostgreSQL database types to C equivalents"
+  },
+  {
+    "name": "libpinyin",
+    "summary": "Library to deal with pinyin"
+  },
+  {
+    "name": "libpinyin-data",
+    "summary": "Data files for libpinyin"
+  },
+  {
+    "name": "libpmem",
+    "summary": "Low-level persistent memory support library"
+  },
+  {
+    "name": "libpmem-debug",
+    "summary": "Debug variant of the low-level persistent memory library"
+  },
+  {
+    "name": "libpmem-devel",
+    "summary": "Development files for the low-level persistent memory library"
+  },
+  {
+    "name": "libpmem2",
+    "summary": "Low-level persistent memory support library"
+  },
+  {
+    "name": "libpmem2-debug",
+    "summary": "Debug variant of the low-level persistent memory library"
+  },
+  {
+    "name": "libpmem2-devel",
+    "summary": "Development files for the low-level persistent memory library"
+  },
+  {
+    "name": "libpmemblk",
+    "summary": "Persistent Memory Resident Array of Blocks library"
+  },
+  {
+    "name": "libpmemblk-debug",
+    "summary": "Debug variant of the Persistent Memory Resident Array of Blocks library"
+  },
+  {
+    "name": "libpmemblk-devel",
+    "summary": "Development files for the Persistent Memory Resident Array of Blocks library"
+  },
+  {
+    "name": "libpmemlog",
+    "summary": "Persistent Memory Resident Log File library"
+  },
+  {
+    "name": "libpmemlog-debug",
+    "summary": "Debug variant of the Persistent Memory Resident Log File library"
+  },
+  {
+    "name": "libpmemlog-devel",
+    "summary": "Development files for the Persistent Memory Resident Log File library"
+  },
+  {
+    "name": "libpmemobj",
+    "summary": "Persistent Memory Transactional Object Store library"
+  },
+  {
+    "name": "libpmemobj++-devel",
+    "summary": "C++ bindings for Persistent Memory Transactional Object Store library"
+  },
+  {
+    "name": "libpmemobj++-doc",
+    "summary": "HTML documentation for libpmemobj++"
+  },
+  {
+    "name": "libpmemobj-debug",
+    "summary": "Debug variant of the Persistent Memory Transactional Object Store library"
+  },
+  {
+    "name": "libpmemobj-devel",
+    "summary": "Development files for the Persistent Memory Transactional Object Store library"
+  },
+  {
+    "name": "libpmempool",
+    "summary": "Persistent Memory pool management library"
+  },
+  {
+    "name": "libpmempool-debug",
+    "summary": "Debug variant of the Persistent Memory pool management library"
+  },
+  {
+    "name": "libpmempool-devel",
+    "summary": "Development files for Persistent Memory pool management library"
+  },
+  {
+    "name": "libpng-devel",
+    "summary": "Development tools for programs to manipulate PNG image format files"
+  },
+  {
+    "name": "libpng15",
+    "summary": "Old version of libpng, needed to run old binaries"
+  },
+  {
+    "name": "libpq",
+    "summary": "PostgreSQL client library"
+  },
+  {
+    "name": "libpq-devel",
+    "summary": "Development files for building PostgreSQL client tools"
+  },
+  {
+    "name": "libproxy-bin",
+    "summary": "Binary to test libproxy"
+  },
+  {
+    "name": "libproxy-gnome",
+    "summary": "Plugin for libproxy and gnome"
+  },
+  {
+    "name": "libproxy-webkitgtk4",
+    "summary": "Plugin for libproxy and webkitgtk3"
+  },
+  {
+    "name": "libpsl-devel",
+    "summary": "Development files for libpsl"
+  },
+  {
+    "name": "libpsm2",
+    "summary": "Intel PSM Libraries"
+  },
+  {
+    "name": "libpst-libs",
+    "summary": "Shared library used by the pst utilities"
+  },
+  {
+    "name": "libqb",
+    "summary": "Library providing high performance logging, tracing, ipc, and poll"
+  },
+  {
+    "name": "libquadmath-devel",
+    "summary": "GCC __float128 support"
+  },
+  {
+    "name": "libqxp",
+    "summary": "Library for import of QuarkXPress documents"
+  },
+  {
+    "name": "librabbitmq",
+    "summary": "Client library for AMQP"
+  },
+  {
+    "name": "librabbitmq-tools",
+    "summary": "Example tools built using the librabbitmq package"
+  },
+  {
+    "name": "librados2",
+    "summary": "RADOS distributed object store client library"
+  },
+  {
+    "name": "LibRaw",
+    "summary": "Library for reading RAW files obtained from digital photo cameras"
+  },
+  {
+    "name": "librbd1",
+    "summary": "RADOS block device client library"
+  },
+  {
+    "name": "librdkafka",
+    "summary": "The Apache Kafka C library"
+  },
+  {
+    "name": "librelp",
+    "summary": "The Reliable Event Logging Protocol library"
+  },
+  {
+    "name": "libreoffice",
+    "summary": "Free Software Productivity Suite"
+  },
+  {
+    "name": "libreoffice-base",
+    "summary": "Database front-end for LibreOffice"
+  },
+  {
+    "name": "libreoffice-calc",
+    "summary": "LibreOffice Spreadsheet Application"
+  },
+  {
+    "name": "libreoffice-core",
+    "summary": "Core modules for LibreOffice"
+  },
+  {
+    "name": "libreoffice-data",
+    "summary": "LibreOffice data files"
+  },
+  {
+    "name": "libreoffice-draw",
+    "summary": "LibreOffice Drawing Application"
+  },
+  {
+    "name": "libreoffice-emailmerge",
+    "summary": "Email mail-merge component for LibreOffice"
+  },
+  {
+    "name": "libreoffice-filters",
+    "summary": "All import / export filters"
+  },
+  {
+    "name": "libreoffice-gdb-debug-support",
+    "summary": "Additional support for debugging with gdb"
+  },
+  {
+    "name": "libreoffice-graphicfilter",
+    "summary": "LibreOffice Extra Graphic filters"
+  },
+  {
+    "name": "libreoffice-gtk3",
+    "summary": "LibreOffice GTK+ 3 integration plug-in"
+  },
+  {
+    "name": "libreoffice-help-ar",
+    "summary": "Arabic help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-bg",
+    "summary": "Bulgarian help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-bn",
+    "summary": "Bengali help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-ca",
+    "summary": "Catalan help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-cs",
+    "summary": "Czech help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-da",
+    "summary": "Danish help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-de",
+    "summary": "German help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-dz",
+    "summary": "Dzongkha help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-el",
+    "summary": "Greek help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-en",
+    "summary": "English help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-eo",
+    "summary": "Esperanto help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-es",
+    "summary": "Spanish help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-et",
+    "summary": "Estonian help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-eu",
+    "summary": "Basque help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-fi",
+    "summary": "Finnish help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-fr",
+    "summary": "French help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-gl",
+    "summary": "Galician help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-gu",
+    "summary": "Gujarati help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-he",
+    "summary": "Hebrew help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-hi",
+    "summary": "Hindi help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-hr",
+    "summary": "Croatian help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-hu",
+    "summary": "Hungarian help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-id",
+    "summary": "Indonesian help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-it",
+    "summary": "Italian help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-ja",
+    "summary": "Japanese help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-ko",
+    "summary": "Korean help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-lt",
+    "summary": "Lithuanian help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-lv",
+    "summary": "Latvian help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-nb",
+    "summary": "Bokmal help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-nl",
+    "summary": "Dutch help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-nn",
+    "summary": "Nynorsk help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-pl",
+    "summary": "Polish help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-pt-BR",
+    "summary": "Brazilian help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-pt-PT",
+    "summary": "Portuguese help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-ro",
+    "summary": "Romanian help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-ru",
+    "summary": "Russian help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-si",
+    "summary": "Sinhalese help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-sk",
+    "summary": "Slovak help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-sl",
+    "summary": "Slovenian help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-sv",
+    "summary": "Swedish help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-ta",
+    "summary": "Tamil help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-tr",
+    "summary": "Turkish help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-uk",
+    "summary": "Ukrainian help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-zh-Hans",
+    "summary": "Simplified help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-help-zh-Hant",
+    "summary": "Traditional help for LibreOffice"
+  },
+  {
+    "name": "libreoffice-impress",
+    "summary": "LibreOffice Presentation Application"
+  },
+  {
+    "name": "libreoffice-langpack-af",
+    "summary": "Afrikaans language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-ar",
+    "summary": "Arabic language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-as",
+    "summary": "Assamese language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-bg",
+    "summary": "Bulgarian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-bn",
+    "summary": "Bengali language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-br",
+    "summary": "Breton language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-ca",
+    "summary": "Catalan language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-cs",
+    "summary": "Czech language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-cy",
+    "summary": "Welsh language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-da",
+    "summary": "Danish language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-de",
+    "summary": "German language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-dz",
+    "summary": "Dzongkha language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-el",
+    "summary": "Greek language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-en",
+    "summary": "English language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-eo",
+    "summary": "Esperanto language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-es",
+    "summary": "Spanish language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-et",
+    "summary": "Estonian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-eu",
+    "summary": "Basque language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-fa",
+    "summary": "Farsi language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-fi",
+    "summary": "Finnish language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-fr",
+    "summary": "French language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-fy",
+    "summary": "Frisian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-ga",
+    "summary": "Irish language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-gl",
+    "summary": "Galician language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-gu",
+    "summary": "Gujarati language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-he",
+    "summary": "Hebrew language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-hi",
+    "summary": "Hindi language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-hr",
+    "summary": "Croatian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-hu",
+    "summary": "Hungarian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-id",
+    "summary": "Indonesian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-it",
+    "summary": "Italian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-ja",
+    "summary": "Japanese language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-kk",
+    "summary": "Kazakh language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-kn",
+    "summary": "Kannada language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-ko",
+    "summary": "Korean language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-lt",
+    "summary": "Lithuanian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-lv",
+    "summary": "Latvian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-mai",
+    "summary": "Maithili language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-ml",
+    "summary": "Malayalam language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-mr",
+    "summary": "Marathi language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-nb",
+    "summary": "Bokmal language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-nl",
+    "summary": "Dutch language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-nn",
+    "summary": "Nynorsk language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-nr",
+    "summary": "Southern language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-nso",
+    "summary": "Northern language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-or",
+    "summary": "Odia language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-pa",
+    "summary": "Punjabi language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-pl",
+    "summary": "Polish language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-pt-BR",
+    "summary": "Brazilian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-pt-PT",
+    "summary": "Portuguese language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-ro",
+    "summary": "Romanian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-ru",
+    "summary": "Russian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-si",
+    "summary": "Sinhalese language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-sk",
+    "summary": "Slovak language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-sl",
+    "summary": "Slovenian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-sr",
+    "summary": "Serbian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-ss",
+    "summary": "Swati language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-st",
+    "summary": "Southern language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-sv",
+    "summary": "Swedish language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-ta",
+    "summary": "Tamil language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-te",
+    "summary": "Telugu language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-th",
+    "summary": "Thai language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-tn",
+    "summary": "Tswana language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-tr",
+    "summary": "Turkish language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-ts",
+    "summary": "Tsonga language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-uk",
+    "summary": "Ukrainian language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-ve",
+    "summary": "Venda language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-xh",
+    "summary": "Xhosa language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-zh-Hans",
+    "summary": "Simplified language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-zh-Hant",
+    "summary": "Traditional language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-langpack-zu",
+    "summary": "Zulu language pack for LibreOffice"
+  },
+  {
+    "name": "libreoffice-math",
+    "summary": "LibreOffice Equation Editor Application"
+  },
+  {
+    "name": "libreoffice-ogltrans",
+    "summary": "3D OpenGL slide transitions for LibreOffice"
+  },
+  {
+    "name": "libreoffice-opensymbol-fonts",
+    "summary": "LibreOffice dingbats font"
+  },
+  {
+    "name": "libreoffice-pdfimport",
+    "summary": "PDF Importer for LibreOffice Draw"
+  },
+  {
+    "name": "libreoffice-pyuno",
+    "summary": "Python support for LibreOffice"
+  },
+  {
+    "name": "libreoffice-ure",
+    "summary": "UNO Runtime Environment"
+  },
+  {
+    "name": "libreoffice-ure-common",
+    "summary": "Common UNO Runtime Environment"
+  },
+  {
+    "name": "libreoffice-voikko",
+    "summary": "Finnish spellchecker and hyphenator extension for LibreOffice"
+  },
+  {
+    "name": "libreoffice-wiki-publisher",
+    "summary": "Create Wiki articles on MediaWiki servers with LibreOffice"
+  },
+  {
+    "name": "libreoffice-writer",
+    "summary": "LibreOffice Word Processor Application"
+  },
+  {
+    "name": "libreoffice-x11",
+    "summary": "LibreOffice generic X11 support plug-in"
+  },
+  {
+    "name": "libreoffice-xsltfilter",
+    "summary": "Optional xsltfilter module for LibreOffice"
+  },
+  {
+    "name": "libreofficekit",
+    "summary": "A library providing access to LibreOffice functionality"
+  },
+  {
+    "name": "libreport",
+    "summary": "Generic library for reporting various problems"
+  },
+  {
+    "name": "libreport-anaconda",
+    "summary": "Default configuration for reporting anaconda bugs"
+  },
+  {
+    "name": "libreport-cli",
+    "summary": "libreport's command line interface"
+  },
+  {
+    "name": "libreport-gtk",
+    "summary": "GTK front-end for libreport"
+  },
+  {
+    "name": "libreport-plugin-bugzilla",
+    "summary": "libreport's bugzilla plugin"
+  },
+  {
+    "name": "libreport-plugin-reportuploader",
+    "summary": "libreport's reportuploader plugin"
+  },
+  {
+    "name": "libreport-rhel-anaconda-bugzilla",
+    "summary": "Default configuration for reporting anaconda bugs to Red Hat Bugzilla"
+  },
+  {
+    "name": "libreport-web",
+    "summary": "Library providing network API for libreport"
+  },
+  {
+    "name": "librepository",
+    "summary": "Hierarchical repository abstraction layer"
+  },
+  {
+    "name": "libreswan",
+    "summary": "Internet Key Exchange (IKEv1 and IKEv2) implementation for IPsec"
+  },
+  {
+    "name": "librevenge",
+    "summary": "A base library for writing document import filters"
+  },
+  {
+    "name": "librevenge-gdb",
+    "summary": "gdb pretty printers for librevenge"
+  },
+  {
+    "name": "librsvg2",
+    "summary": "An SVG library based on cairo"
+  },
+  {
+    "name": "librsvg2-devel",
+    "summary": "Libraries and include files for developing with librsvg"
+  },
+  {
+    "name": "librsvg2-tools",
+    "summary": "Extra tools for librsvg"
+  },
+  {
+    "name": "libsamplerate",
+    "summary": "Sample rate conversion library for audio data"
+  },
+  {
+    "name": "libsane-airscan",
+    "summary": "SANE backend for eSCL or WSD"
+  },
+  {
+    "name": "libsane-hpaio",
+    "summary": "SANE driver for scanners in HP's multi-function devices"
+  },
+  {
+    "name": "libsbc",
+    "summary": "Library for the SBC (Sub Band Codec)"
+  },
+  {
+    "name": "libseccomp-devel",
+    "summary": "Development files used to build applications with libseccomp support"
+  },
+  {
+    "name": "libsecret",
+    "summary": "Library for storing and retrieving passwords and other secrets"
+  },
+  {
+    "name": "libsecret-devel",
+    "summary": "Development files for libsecret"
+  },
+  {
+    "name": "libselinux-devel",
+    "summary": "Header files and libraries used to build SELinux"
+  },
+  {
+    "name": "libselinux-ruby",
+    "summary": "SELinux ruby bindings for libselinux"
+  },
+  {
+    "name": "libsepol-devel",
+    "summary": "Header files and libraries used to build policy manipulation tools"
+  },
+  {
+    "name": "libsepol-utils",
+    "summary": "SELinux libsepol utilities"
+  },
+  {
+    "name": "libserf",
+    "summary": "High-Performance Asynchronous HTTP Client Library"
+  },
+  {
+    "name": "libserializer",
+    "summary": "JFreeReport General Serialization Framework"
+  },
+  {
+    "name": "libshaderc",
+    "summary": "A library for compiling shader strings into SPIR-V"
+  },
+  {
+    "name": "libshout",
+    "summary": "Icecast source streaming library"
+  },
+  {
+    "name": "libsigc++20",
+    "summary": "Typesafe signal framework for C++"
+  },
+  {
+    "name": "libslirp",
+    "summary": "A general purpose TCP-IP emulator"
+  },
+  {
+    "name": "libSM",
+    "summary": "X.Org X11 SM runtime library"
+  },
+  {
+    "name": "libSM-devel",
+    "summary": "X.Org X11 SM development package"
+  },
+  {
+    "name": "libsmi",
+    "summary": "A library to access SMI MIB information"
+  },
+  {
+    "name": "libsndfile",
+    "summary": "Library for reading and writing sound files"
+  },
+  {
+    "name": "libsndfile-utils",
+    "summary": "Command Line Utilities for libsndfile"
+  },
+  {
+    "name": "libsoup",
+    "summary": "Soup, an HTTP library implementation"
+  },
+  {
+    "name": "libsoup-devel",
+    "summary": "Header files for the Soup library"
+  },
+  {
+    "name": "libspectre",
+    "summary": "A library for rendering PostScript(TM) documents"
+  },
+  {
+    "name": "libspiro",
+    "summary": "Library to simplify the drawing of beautiful curves"
+  },
+  {
+    "name": "libsrtp",
+    "summary": "An implementation of the Secure Real-time Transport Protocol (SRTP)"
+  },
+  {
+    "name": "libssh-devel",
+    "summary": "Development files for libssh"
+  },
+  {
+    "name": "libstaroffice",
+    "summary": "A library for import of binary StarOffice documents"
+  },
+  {
+    "name": "libstdc++-devel",
+    "summary": "Header files and libraries for C++ development"
+  },
+  {
+    "name": "libstdc++-docs",
+    "summary": "Documentation for the GNU standard C++ library"
+  },
+  {
+    "name": "libstemmer",
+    "summary": "C stemming algorithm library"
+  },
+  {
+    "name": "libstoragemgmt",
+    "summary": "Storage array management library"
+  },
+  {
+    "name": "libstoragemgmt-arcconf-plugin",
+    "summary": "Files for Microsemi Adaptec and Smart Family support for libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-hpsa-plugin",
+    "summary": "Files for HP SmartArray support for libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-local-plugin",
+    "summary": "Files for local pseudo plugin of libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-megaraid-plugin",
+    "summary": "Files for LSI MegaRAID support for libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-nfs-plugin",
+    "summary": "Files for NFS local filesystem support for libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-smis-plugin",
+    "summary": "Files for SMI-S generic array support for libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-targetd-plugin",
+    "summary": "Files for targetd array support for libstoragemgmt"
+  },
+  {
+    "name": "libstoragemgmt-udev",
+    "summary": "Udev files for libstoragemgmt"
+  },
+  {
+    "name": "libtasn1-devel",
+    "summary": "Files for development of applications which will use libtasn1"
+  },
+  {
+    "name": "libtasn1-tools",
+    "summary": "Some ASN.1 tools"
+  },
+  {
+    "name": "libthai",
+    "summary": "Thai language support routines"
+  },
+  {
+    "name": "libthai-devel",
+    "summary": "Thai language support routines"
+  },
+  {
+    "name": "libtheora",
+    "summary": "Theora Video Compression Codec"
+  },
+  {
+    "name": "libtiff",
+    "summary": "Library of functions for manipulating TIFF format image files"
+  },
+  {
+    "name": "libtiff-devel",
+    "summary": "Development tools for programs which will use the libtiff library"
+  },
+  {
+    "name": "libtimezonemap",
+    "summary": "Time zone map widget for Gtk+"
+  },
+  {
+    "name": "libtool",
+    "summary": "The GNU Portable Library Tool"
+  },
+  {
+    "name": "libtool-ltdl",
+    "summary": "Runtime libraries for GNU Libtool Dynamic Module Loader"
+  },
+  {
+    "name": "libtpms",
+    "summary": "Library providing Trusted Platform Module (TPM) functionality"
+  },
+  {
+    "name": "libtracker-sparql",
+    "summary": "Tracker SPARQL library"
+  },
+  {
+    "name": "libtsan",
+    "summary": "The Thread Sanitizer runtime library"
+  },
+  {
+    "name": "libtsan2",
+    "summary": "The Thread Sanitizer runtime library"
+  },
+  {
+    "name": "libubsan",
+    "summary": "The Undefined Behavior Sanitizer runtime library"
+  },
+  {
+    "name": "libudisks2",
+    "summary": "Dynamic library to access the udisksd daemon"
+  },
+  {
+    "name": "liburing",
+    "summary": "Linux-native io_uring I/O access library"
+  },
+  {
+    "name": "libusb",
+    "summary": "Compatibility shim around libusb-1.0 offering the old 0.1 API"
+  },
+  {
+    "name": "libusbx-devel",
+    "summary": "Development files for libusbx"
+  },
+  {
+    "name": "libuuid-devel",
+    "summary": "Universally unique ID library"
+  },
+  {
+    "name": "libuv",
+    "summary": "Platform layer for node.js"
+  },
+  {
+    "name": "libv4l",
+    "summary": "Collection of video4linux support libraries"
+  },
+  {
+    "name": "libva",
+    "summary": "Video Acceleration (VA) API for Linux"
+  },
+  {
+    "name": "libva-devel",
+    "summary": "Development files for libva"
+  },
+  {
+    "name": "libvdpau",
+    "summary": "Wrapper library for the Video Decode and Presentation API"
+  },
+  {
+    "name": "libvdpau-trace",
+    "summary": "Trace library for libvdpau"
+  },
+  {
+    "name": "libverto-devel",
+    "summary": "Development files for libverto"
+  },
+  {
+    "name": "libvirt",
+    "summary": "Library providing a simple virtualization API"
+  },
+  {
+    "name": "libvirt-client",
+    "summary": "Client side utilities of the libvirt library"
+  },
+  {
+    "name": "libvirt-client-qemu",
+    "summary": "Additional client side utilities for QEMU"
+  },
+  {
+    "name": "libvirt-daemon",
+    "summary": "Server side daemon and supporting files for libvirt library"
+  },
+  {
+    "name": "libvirt-daemon-common",
+    "summary": "Files and utilities used by daemons"
+  },
+  {
+    "name": "libvirt-daemon-config-network",
+    "summary": "Default configuration files for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-config-nwfilter",
+    "summary": "Network filter configuration files for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-interface",
+    "summary": "Interface driver plugin for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-network",
+    "summary": "Network driver plugin for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-nodedev",
+    "summary": "Nodedev driver plugin for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-nwfilter",
+    "summary": "Nwfilter driver plugin for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-qemu",
+    "summary": "QEMU driver plugin for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-secret",
+    "summary": "Secret driver plugin for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage",
+    "summary": "Storage driver plugin including all backends for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-core",
+    "summary": "Storage driver plugin including base backends for the libvirtd daemon"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-disk",
+    "summary": "Storage driver plugin for disk"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-iscsi",
+    "summary": "Storage driver plugin for iscsi"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-logical",
+    "summary": "Storage driver plugin for lvm volumes"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-mpath",
+    "summary": "Storage driver plugin for multipath volumes"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-rbd",
+    "summary": "Storage driver plugin for rbd"
+  },
+  {
+    "name": "libvirt-daemon-driver-storage-scsi",
+    "summary": "Storage driver plugin for local scsi devices"
+  },
+  {
+    "name": "libvirt-daemon-kvm",
+    "summary": "Server side daemon & driver required to run KVM guests"
+  },
+  {
+    "name": "libvirt-daemon-lock",
+    "summary": "Server side daemon for managing locks"
+  },
+  {
+    "name": "libvirt-daemon-log",
+    "summary": "Server side daemon for managing logs"
+  },
+  {
+    "name": "libvirt-daemon-plugin-lockd",
+    "summary": "lockd client plugin for virtlockd"
+  },
+  {
+    "name": "libvirt-daemon-proxy",
+    "summary": "Server side daemon providing libvirtd proxy"
+  },
+  {
+    "name": "libvirt-dbus",
+    "summary": "libvirt D-Bus API binding"
+  },
+  {
+    "name": "libvirt-glib",
+    "summary": "libvirt glib integration for events"
+  },
+  {
+    "name": "libvirt-libs",
+    "summary": "Client side libraries"
+  },
+  {
+    "name": "libvirt-nss",
+    "summary": "Libvirt plugin for Name Service Switch"
+  },
+  {
+    "name": "libvirt-ssh-proxy",
+    "summary": "Libvirt SSH proxy"
+  },
+  {
+    "name": "libvisio",
+    "summary": "A library for import of Microsoft Visio diagrams"
+  },
+  {
+    "name": "libvisual",
+    "summary": "Abstraction library for audio visualisation plugins"
+  },
+  {
+    "name": "libvma",
+    "summary": "A library for boosting TCP and UDP traffic (over RDMA hardware)"
+  },
+  {
+    "name": "libvma-utils",
+    "summary": "Utilities used with libvma"
+  },
+  {
+    "name": "libvoikko",
+    "summary": "Voikko is a library for spellcheckers and hyphenators"
+  },
+  {
+    "name": "libvorbis",
+    "summary": "The Vorbis General Audio Compression Codec"
+  },
+  {
+    "name": "libvpx",
+    "summary": "VP8/VP9 Video Codec SDK"
+  },
+  {
+    "name": "libwacom",
+    "summary": "Tablet Information Client Library"
+  },
+  {
+    "name": "libwacom-data",
+    "summary": "Tablet Information Client Library Data Files"
+  },
+  {
+    "name": "libwayland-client",
+    "summary": "Wayland client library"
+  },
+  {
+    "name": "libwayland-cursor",
+    "summary": "Wayland cursor library"
+  },
+  {
+    "name": "libwayland-egl",
+    "summary": "Wayland egl library"
+  },
+  {
+    "name": "libwayland-server",
+    "summary": "Wayland server library"
+  },
+  {
+    "name": "libwebp",
+    "summary": "Library and tools for the WebP graphics format"
+  },
+  {
+    "name": "libwebp-devel",
+    "summary": "Development files for libwebp, a library for the WebP format"
+  },
+  {
+    "name": "libwinpr",
+    "summary": "Windows Portable Runtime"
+  },
+  {
+    "name": "libwmf",
+    "summary": "Windows MetaFile Library"
+  },
+  {
+    "name": "libwmf-lite",
+    "summary": "Windows Metafile parser library"
+  },
+  {
+    "name": "libwnck3",
+    "summary": "Window Navigator Construction Kit"
+  },
+  {
+    "name": "libwpd",
+    "summary": "A library for import of WordPerfect documents"
+  },
+  {
+    "name": "libwpe",
+    "summary": "General-purpose library for the WPE-flavored port of WebKit"
+  },
+  {
+    "name": "libwpg",
+    "summary": "A library for import of WordPerfect Graphics images"
+  },
+  {
+    "name": "libwps",
+    "summary": "A library for import of Microsoft Works documents"
+  },
+  {
+    "name": "libwsman1",
+    "summary": "Open source Implementation of WS-Management"
+  },
+  {
+    "name": "libX11",
+    "summary": "Core X11 protocol client library"
+  },
+  {
+    "name": "libX11-common",
+    "summary": "Common data for libX11"
+  },
+  {
+    "name": "libX11-devel",
+    "summary": "Development files for libX11"
+  },
+  {
+    "name": "libX11-xcb",
+    "summary": "XCB interop for libX11"
+  },
+  {
+    "name": "libXau",
+    "summary": "Sample Authorization Protocol for X"
+  },
+  {
+    "name": "libXau-devel",
+    "summary": "Development files for libXau"
+  },
+  {
+    "name": "libXaw",
+    "summary": "X Athena Widget Set"
+  },
+  {
+    "name": "libXaw-devel",
+    "summary": "Development files for libXaw"
+  },
+  {
+    "name": "libxcb",
+    "summary": "A C binding to the X11 protocol"
+  },
+  {
+    "name": "libxcb-devel",
+    "summary": "Development files for libxcb"
+  },
+  {
+    "name": "libXcomposite",
+    "summary": "X Composite Extension library"
+  },
+  {
+    "name": "libXcomposite-devel",
+    "summary": "Development files for libXcomposite"
+  },
+  {
+    "name": "libxcrypt-compat",
+    "summary": "Compatibility library providing legacy API functions"
+  },
+  {
+    "name": "libxcrypt-devel",
+    "summary": "Development files for libxcrypt"
+  },
+  {
+    "name": "libXcursor",
+    "summary": "Cursor management library"
+  },
+  {
+    "name": "libXcursor-devel",
+    "summary": "Development files for libXcursor"
+  },
+  {
+    "name": "libxcvt",
+    "summary": "VESA CVT standard timing modelines generator"
+  },
+  {
+    "name": "libXdamage",
+    "summary": "X Damage extension library"
+  },
+  {
+    "name": "libXdamage-devel",
+    "summary": "Development files for libXdamage"
+  },
+  {
+    "name": "libXdmcp",
+    "summary": "X Display Manager Control Protocol library"
+  },
+  {
+    "name": "libxdp",
+    "summary": "XDP helper library"
+  },
+  {
+    "name": "libXext",
+    "summary": "X.Org X11 libXext runtime library"
+  },
+  {
+    "name": "libXext-devel",
+    "summary": "X.Org X11 libXext development package"
+  },
+  {
+    "name": "libXfixes",
+    "summary": "X Fixes library"
+  },
+  {
+    "name": "libXfixes-devel",
+    "summary": "Development files for libXfixes"
+  },
+  {
+    "name": "libXfont2",
+    "summary": "X.Org X11 libXfont2 runtime library"
+  },
+  {
+    "name": "libXft",
+    "summary": "X.Org X11 libXft runtime library"
+  },
+  {
+    "name": "libXft-devel",
+    "summary": "X.Org X11 libXft development package"
+  },
+  {
+    "name": "libXi",
+    "summary": "X.Org X11 libXi runtime library"
+  },
+  {
+    "name": "libXi-devel",
+    "summary": "X.Org X11 libXi development package"
+  },
+  {
+    "name": "libXinerama",
+    "summary": "X.Org X11 libXinerama runtime library"
+  },
+  {
+    "name": "libXinerama-devel",
+    "summary": "X.Org X11 libXinerama development package"
+  },
+  {
+    "name": "libxkbcommon",
+    "summary": "X.Org X11 XKB parsing library"
+  },
+  {
+    "name": "libxkbcommon-devel",
+    "summary": "X.Org X11 XKB parsing development package"
+  },
+  {
+    "name": "libxkbcommon-x11",
+    "summary": "X.Org X11 XKB keymap creation library"
+  },
+  {
+    "name": "libxkbfile",
+    "summary": "X.Org X11 libxkbfile runtime library"
+  },
+  {
+    "name": "libxklavier",
+    "summary": "High-level API for X Keyboard Extension"
+  },
+  {
+    "name": "libxml2-devel",
+    "summary": "Libraries, includes, etc. to develop XML and HTML applications"
+  },
+  {
+    "name": "libXmu",
+    "summary": "X.Org X11 libXmu/libXmuu runtime libraries"
+  },
+  {
+    "name": "libXmu-devel",
+    "summary": "X.Org X11 libXmu development package"
+  },
+  {
+    "name": "libXp",
+    "summary": "X.Org X11 libXp runtime library"
+  },
+  {
+    "name": "libXp-devel",
+    "summary": "X.Org X11 libXp development package"
+  },
+  {
+    "name": "libXpm",
+    "summary": "X.Org X11 libXpm runtime library"
+  },
+  {
+    "name": "libXpm-devel",
+    "summary": "X.Org X11 libXpm development package"
+  },
+  {
+    "name": "libXrandr",
+    "summary": "X.Org X11 libXrandr runtime library"
+  },
+  {
+    "name": "libXrandr-devel",
+    "summary": "X.Org X11 libXrandr development package"
+  },
+  {
+    "name": "libXrender",
+    "summary": "X.Org X11 libXrender runtime library"
+  },
+  {
+    "name": "libXrender-devel",
+    "summary": "X.Org X11 libXrender development package"
+  },
+  {
+    "name": "libXres",
+    "summary": "X-Resource extension client library"
+  },
+  {
+    "name": "libXScrnSaver",
+    "summary": "X.Org X11 libXss runtime library"
+  },
+  {
+    "name": "libXScrnSaver-devel",
+    "summary": "X.Org X11 libXScrnSaver development package"
+  },
+  {
+    "name": "libxshmfence",
+    "summary": "X11 shared memory fences"
+  },
+  {
+    "name": "libxshmfence-devel",
+    "summary": "Development files for libxshmfence"
+  },
+  {
+    "name": "libxslt",
+    "summary": "Library providing the Gnome XSLT engine"
+  },
+  {
+    "name": "libxslt-devel",
+    "summary": "Development libraries and header files for libxslt"
+  },
+  {
+    "name": "libXt",
+    "summary": "X.Org X11 libXt runtime library"
+  },
+  {
+    "name": "libXt-devel",
+    "summary": "X.Org X11 libXt development package"
+  },
+  {
+    "name": "libXtst",
+    "summary": "X.Org X11 libXtst runtime library"
+  },
+  {
+    "name": "libXtst-devel",
+    "summary": "X.Org X11 libXtst development package"
+  },
+  {
+    "name": "libXv",
+    "summary": "X.Org X11 libXv runtime library"
+  },
+  {
+    "name": "libXv-devel",
+    "summary": "X.Org X11 libXv development package"
+  },
+  {
+    "name": "libXxf86dga",
+    "summary": "X.Org X11 libXxf86dga runtime library"
+  },
+  {
+    "name": "libXxf86dga-devel",
+    "summary": "X.Org X11 libXxf86dga development package"
+  },
+  {
+    "name": "libXxf86vm",
+    "summary": "X.Org X11 libXxf86vm runtime library"
+  },
+  {
+    "name": "libyang",
+    "summary": "YANG data modeling language library"
+  },
+  {
+    "name": "libzhuyin",
+    "summary": "Library to deal with zhuyin"
+  },
+  {
+    "name": "libzip",
+    "summary": "C library for reading, creating, and modifying zip archives"
+  },
+  {
+    "name": "libzip-tools",
+    "summary": "Command line tools from libzip"
+  },
+  {
+    "name": "libzmf",
+    "summary": "A library for import of Zoner document formats"
+  },
+  {
+    "name": "libzstd-devel",
+    "summary": "Header files for Zstd library"
+  },
+  {
+    "name": "linuxconsoletools",
+    "summary": "Tools for connecting joysticks & legacy devices to the kernel's input subsystem"
+  },
+  {
+    "name": "linuxptp",
+    "summary": "PTP implementation for Linux"
+  },
+  {
+    "name": "lklug-fonts",
+    "summary": "Fonts for Sinhala language"
+  },
+  {
+    "name": "lksctp-tools-devel",
+    "summary": "Development files for lksctp-tools"
+  },
+  {
+    "name": "lksctp-tools-doc",
+    "summary": "Documents pertaining to SCTP"
+  },
+  {
+    "name": "lld",
+    "summary": "The LLVM Linker"
+  },
+  {
+    "name": "lld-devel",
+    "summary": "Libraries and header files for LLD"
+  },
+  {
+    "name": "lld-libs",
+    "summary": "LLD shared libraries"
+  },
+  {
+    "name": "lld-test",
+    "summary": "LLD regression tests"
+  },
+  {
+    "name": "lldb",
+    "summary": "Next generation high-performance debugger"
+  },
+  {
+    "name": "lldb-devel",
+    "summary": "Development header files for LLDB"
+  },
+  {
+    "name": "lldpd",
+    "summary": "ISC-licensed implementation of LLDP"
+  },
+  {
+    "name": "lldpd-devel",
+    "summary": "ISC-licensed implementation of LLDP"
+  },
+  {
+    "name": "llvm",
+    "summary": "The Low Level Virtual Machine"
+  },
+  {
+    "name": "llvm-devel",
+    "summary": "Libraries and header files for LLVM"
+  },
+  {
+    "name": "llvm-doc",
+    "summary": "Documentation for LLVM"
+  },
+  {
+    "name": "llvm-googletest",
+    "summary": "LLVM's modified googletest sources"
+  },
+  {
+    "name": "llvm-libs",
+    "summary": "LLVM shared libraries"
+  },
+  {
+    "name": "llvm-static",
+    "summary": "LLVM static libraries"
+  },
+  {
+    "name": "llvm-test",
+    "summary": "LLVM regression tests"
+  },
+  {
+    "name": "llvm-toolset",
+    "summary": "Package that installs llvm-toolset"
+  },
+  {
+    "name": "lm_sensors",
+    "summary": "Hardware monitoring tools"
+  },
+  {
+    "name": "lm_sensors-devel",
+    "summary": "Development files for programs which will use lm_sensors"
+  },
+  {
+    "name": "lm_sensors-libs",
+    "summary": "Lm_sensors core libraries"
+  },
+  {
+    "name": "lm_sensors-sensord",
+    "summary": "Daemon that periodically logs sensor readings"
+  },
+  {
+    "name": "log4j",
+    "summary": "Java logging package"
+  },
+  {
+    "name": "log4j-jcl",
+    "summary": "Apache Log4j Commons Logging Bridge"
+  },
+  {
+    "name": "log4j-slf4j",
+    "summary": "Binding between LOG4J 2 API and SLF4J"
+  },
+  {
+    "name": "logwatch",
+    "summary": "A log file analysis program"
+  },
+  {
+    "name": "lohit-assamese-fonts",
+    "summary": "Free Assamese font"
+  },
+  {
+    "name": "lohit-bengali-fonts",
+    "summary": "Free Bengali script font"
+  },
+  {
+    "name": "lohit-devanagari-fonts",
+    "summary": "Free Devanagari Script Font"
+  },
+  {
+    "name": "lohit-gujarati-fonts",
+    "summary": "Free Gujarati font"
+  },
+  {
+    "name": "lohit-gurmukhi-fonts",
+    "summary": "Free Gurmukhi truetype font for Punjabi language"
+  },
+  {
+    "name": "lohit-kannada-fonts",
+    "summary": "Free Kannada font"
+  },
+  {
+    "name": "lohit-marathi-fonts",
+    "summary": "Free truetype font for Marathi language"
+  },
+  {
+    "name": "lohit-odia-fonts",
+    "summary": "Free truetype font for Odia language"
+  },
+  {
+    "name": "lohit-tamil-fonts",
+    "summary": "Free truetype font for Tamil language"
+  },
+  {
+    "name": "lohit-telugu-fonts",
+    "summary": "Free Telugu font"
+  },
+  {
+    "name": "lorax",
+    "summary": "Tool for creating the anaconda install images"
+  },
+  {
+    "name": "lorax-docs",
+    "summary": "Lorax html documentation"
+  },
+  {
+    "name": "lorax-lmc-novirt",
+    "summary": "livemedia-creator no-virt dependencies"
+  },
+  {
+    "name": "lorax-lmc-virt",
+    "summary": "livemedia-creator libvirt dependencies"
+  },
+  {
+    "name": "lorax-templates-generic",
+    "summary": "Generic build templates for lorax and livemedia-creator"
+  },
+  {
+    "name": "lorax-templates-rhel",
+    "summary": "RHEL8 build templates for lorax and livemedia-creator"
+  },
+  {
+    "name": "low-memory-monitor",
+    "summary": "Monitors low-memory conditions"
+  },
+  {
+    "name": "lpsolve",
+    "summary": "A Mixed Integer Linear Programming (MILP) solver"
+  },
+  {
+    "name": "lshw-gui",
+    "summary": "Graphical hardware lister"
+  },
+  {
+    "name": "ltrace",
+    "summary": "Tracks runtime library calls from dynamically linked executables"
+  },
+  {
+    "name": "lttng-ust",
+    "summary": "LTTng Userspace Tracer library"
+  },
+  {
+    "name": "lua",
+    "summary": "Powerful light-weight programming language"
+  },
+  {
+    "name": "lua-posix",
+    "summary": "A POSIX library for Lua"
+  },
+  {
+    "name": "lua-rpm-macros",
+    "summary": "The common Lua RPM macros"
+  },
+  {
+    "name": "lua-srpm-macros",
+    "summary": "RPM macros for building Lua source packages"
+  },
+  {
+    "name": "luksmeta",
+    "summary": "Utility for storing small metadata in the LUKSv1 header"
+  },
+  {
+    "name": "lvm2-dbusd",
+    "summary": "LVM2 D-Bus daemon"
+  },
+  {
+    "name": "lvm2-lockd",
+    "summary": "LVM locking daemon"
+  },
+  {
+    "name": "lynx",
+    "summary": "A text-based Web browser"
+  },
+  {
+    "name": "lz4-devel",
+    "summary": "Development files for lz4"
+  },
+  {
+    "name": "lzo-devel",
+    "summary": "Development files for the lzo library"
+  },
+  {
+    "name": "lzo-minilzo",
+    "summary": "Mini version of lzo for apps which don't need the full version"
+  },
+  {
+    "name": "m17n-db",
+    "summary": "Multilingualization datafiles for m17n-lib"
+  },
+  {
+    "name": "m17n-lib",
+    "summary": "Multilingual text library"
+  },
+  {
+    "name": "m4",
+    "summary": "GNU macro processor"
+  },
+  {
+    "name": "madan-fonts",
+    "summary": "Font for Nepali language"
+  },
+  {
+    "name": "make-latest",
+    "summary": "Meta package to include latest version of make"
+  },
+  {
+    "name": "make441",
+    "summary": "A GNU tool which simplifies the build process for users"
+  },
+  {
+    "name": "mallard-rng",
+    "summary": "RELAX NG schemas for all Mallard versions"
+  },
+  {
+    "name": "man-db-cron",
+    "summary": "Periodic update of man-db cache"
+  },
+  {
+    "name": "man-pages-overrides",
+    "summary": "Complementary and updated manual pages"
+  },
+  {
+    "name": "mariadb",
+    "summary": "A very fast and robust SQL database server"
+  },
+  {
+    "name": "mariadb-backup",
+    "summary": "The mariabackup tool for physical online backups"
+  },
+  {
+    "name": "mariadb-common",
+    "summary": "The shared files required by server and client"
+  },
+  {
+    "name": "mariadb-connector-c",
+    "summary": "The MariaDB Native Client library (C driver)"
+  },
+  {
+    "name": "mariadb-connector-c-config",
+    "summary": "Configuration files for packages that use /etc/my.cnf as a configuration file"
+  },
+  {
+    "name": "mariadb-connector-c-devel",
+    "summary": "Development files for mariadb-connector-c"
+  },
+  {
+    "name": "mariadb-connector-odbc",
+    "summary": "The MariaDB Native Client library (ODBC driver)"
+  },
+  {
+    "name": "mariadb-embedded",
+    "summary": "MariaDB as an embeddable library"
+  },
+  {
+    "name": "mariadb-errmsg",
+    "summary": "The error messages files required by server and embedded"
+  },
+  {
+    "name": "mariadb-gssapi-server",
+    "summary": "GSSAPI authentication plugin for server"
+  },
+  {
+    "name": "mariadb-java-client",
+    "summary": "Connects applications developed in Java to MariaDB and MySQL databases"
+  },
+  {
+    "name": "mariadb-oqgraph-engine",
+    "summary": "The Open Query GRAPH engine for MariaDB"
+  },
+  {
+    "name": "mariadb-pam",
+    "summary": "PAM authentication plugin for the MariaDB server"
+  },
+  {
+    "name": "mariadb-server",
+    "summary": "The MariaDB server and related files"
+  },
+  {
+    "name": "mariadb-server-galera",
+    "summary": "The configuration files and scripts for galera replication"
+  },
+  {
+    "name": "mariadb-server-utils",
+    "summary": "Non-essential server utilities for MariaDB/MySQL applications"
+  },
+  {
+    "name": "matchbox-window-manager",
+    "summary": "Window manager for the Matchbox Desktop"
+  },
+  {
+    "name": "maven",
+    "summary": "Java project management and project comprehension tool"
+  },
+  {
+    "name": "maven-lib",
+    "summary": "Core part of Maven"
+  },
+  {
+    "name": "maven-openjdk11",
+    "summary": "OpenJDK 11 binding for Maven"
+  },
+  {
+    "name": "maven-openjdk17",
+    "summary": "OpenJDK 17 binding for Maven"
+  },
+  {
+    "name": "maven-openjdk21",
+    "summary": "OpenJDK 21 binding for Maven"
+  },
+  {
+    "name": "maven-openjdk8",
+    "summary": "OpenJDK 8 binding for Maven"
+  },
+  {
+    "name": "maven-resolver",
+    "summary": "Apache Maven Artifact Resolver library"
+  },
+  {
+    "name": "maven-shared-utils",
+    "summary": "Maven shared utility classes"
+  },
+  {
+    "name": "maven-wagon",
+    "summary": "Tools to manage artifacts and deployment"
+  },
+  {
+    "name": "mc",
+    "summary": "User-friendly text console file manager and visual shell"
+  },
+  {
+    "name": "mdevctl",
+    "summary": "Mediated device management and persistence utility"
+  },
+  {
+    "name": "mecab",
+    "summary": "Yet Another Part-of-Speech and Morphological Analyzer"
+  },
+  {
+    "name": "mecab-ipadic",
+    "summary": "IPA dictionary for MeCab"
+  },
+  {
+    "name": "mecab-ipadic-EUCJP",
+    "summary": "IPA dictionary for Mecab with encoded by EUC-JP"
+  },
+  {
+    "name": "memcached",
+    "summary": "High Performance, Distributed Memory Object Cache"
+  },
+  {
+    "name": "memcached-selinux",
+    "summary": "Selinux policy module"
+  },
+  {
+    "name": "memkind",
+    "summary": "User Extensible Heap Manager"
+  },
+  {
+    "name": "memstrack",
+    "summary": "A memory allocation tracer, like a hot spot analyzer for memory allocation"
+  },
+  {
+    "name": "memtest86+",
+    "summary": "Stand-alone memory tester for x86 and x86-64 computers"
+  },
+  {
+    "name": "mesa-demos",
+    "summary": "Mesa demos"
+  },
+  {
+    "name": "mesa-dri-drivers",
+    "summary": "Mesa-based DRI drivers"
+  },
+  {
+    "name": "mesa-filesystem",
+    "summary": "Mesa driver filesystem"
+  },
+  {
+    "name": "mesa-libEGL",
+    "summary": "Mesa libEGL runtime libraries"
+  },
+  {
+    "name": "mesa-libEGL-devel",
+    "summary": "Mesa libEGL development package"
+  },
+  {
+    "name": "mesa-libgbm",
+    "summary": "Mesa gbm runtime library"
+  },
+  {
+    "name": "mesa-libgbm-devel",
+    "summary": "Mesa libgbm development package"
+  },
+  {
+    "name": "mesa-libGL",
+    "summary": "Mesa libGL runtime libraries"
+  },
+  {
+    "name": "mesa-libGL-devel",
+    "summary": "Mesa libGL development package"
+  },
+  {
+    "name": "mesa-libglapi",
+    "summary": "Mesa shared glapi"
+  },
+  {
+    "name": "mesa-libGLU",
+    "summary": "Mesa libGLU library"
+  },
+  {
+    "name": "mesa-libGLU-devel",
+    "summary": "Development files for mesa-libGLU"
+  },
+  {
+    "name": "mesa-libGLw",
+    "summary": "Xt / Motif OpenGL widgets"
+  },
+  {
+    "name": "mesa-libGLw-devel",
+    "summary": "Mesa libGLw development package"
+  },
+  {
+    "name": "mesa-libxatracker",
+    "summary": "Mesa XA state tracker"
+  },
+  {
+    "name": "mesa-vulkan-drivers",
+    "summary": "Mesa Vulkan drivers"
+  },
+  {
+    "name": "micropipenv",
+    "summary": "A simple wrapper around pip to support Pipenv and Poetry files"
+  },
+  {
+    "name": "mingw-binutils-generic",
+    "summary": "Utilities which are needed for both the Win32 and Win64 toolchains"
+  },
+  {
+    "name": "mingw-filesystem-base",
+    "summary": "Generic files which are needed for both mingw32-filesystem and mingw64-filesystem"
+  },
+  {
+    "name": "mingw-qemu-ga-win",
+    "summary": "Qemus Guest agent for Windows"
+  },
+  {
+    "name": "mingw32-crt",
+    "summary": "MinGW Windows cross-compiler runtime for the win32 target"
+  },
+  {
+    "name": "mingw32-filesystem",
+    "summary": "MinGW cross compiler base filesystem and environment for the win32 target"
+  },
+  {
+    "name": "mingw32-srvany",
+    "summary": "Utility for creating services for Windows"
+  },
+  {
+    "name": "mkfontscale",
+    "summary": "Tool to generate legacy X11 font system index files"
+  },
+  {
+    "name": "mkpasswd",
+    "summary": "Encrypt a password with crypt(3) function using a salt"
+  },
+  {
+    "name": "mobile-broadband-provider-info",
+    "summary": "Mobile broadband provider database"
+  },
+  {
+    "name": "mod_auth_gssapi",
+    "summary": "A GSSAPI Authentication module for Apache"
+  },
+  {
+    "name": "mod_auth_mellon",
+    "summary": "A SAML 2.0 authentication module for the Apache Httpd Server"
+  },
+  {
+    "name": "mod_auth_openidc",
+    "summary": "OpenID Connect auth module for Apache HTTP Server"
+  },
+  {
+    "name": "mod_authnz_pam",
+    "summary": "PAM authorization checker and PAM Basic Authentication provider"
+  },
+  {
+    "name": "mod_dav_svn",
+    "summary": "Apache httpd module for Subversion server"
+  },
+  {
+    "name": "mod_fcgid",
+    "summary": "FastCGI interface module for Apache 2"
+  },
+  {
+    "name": "mod_http2",
+    "summary": "module implementing HTTP/2 for Apache 2"
+  },
+  {
+    "name": "mod_intercept_form_submit",
+    "summary": "Apache module to intercept login form submission and run PAM authentication"
+  },
+  {
+    "name": "mod_jk",
+    "summary": "Tomcat mod_jk connector for Apache"
+  },
+  {
+    "name": "mod_ldap",
+    "summary": "LDAP authentication modules for the Apache HTTP Server"
+  },
+  {
+    "name": "mod_lookup_identity",
+    "summary": "Apache module to retrieve additional information about the authenticated user"
+  },
+  {
+    "name": "mod_lua",
+    "summary": "Lua scripting support for the Apache HTTP Server"
+  },
+  {
+    "name": "mod_md",
+    "summary": "Certificate provisioning using ACME for the Apache HTTP Server"
+  },
+  {
+    "name": "mod_proxy_cluster",
+    "summary": "JBoss mod_proxy_cluster for Apache httpd"
+  },
+  {
+    "name": "mod_proxy_html",
+    "summary": "HTML and XML content filters for the Apache HTTP Server"
+  },
+  {
+    "name": "mod_security",
+    "summary": "Security module for the Apache HTTP Server"
+  },
+  {
+    "name": "mod_security-mlogc",
+    "summary": "ModSecurity Audit Log Collector"
+  },
+  {
+    "name": "mod_security_crs",
+    "summary": "ModSecurity Rules"
+  },
+  {
+    "name": "mod_session",
+    "summary": "Session interface for the Apache HTTP Server"
+  },
+  {
+    "name": "mod_ssl",
+    "summary": "SSL/TLS module for the Apache HTTP Server"
+  },
+  {
+    "name": "modulemd-tools",
+    "summary": "Collection of tools for parsing and generating modulemd YAML files"
+  },
+  {
+    "name": "motif",
+    "summary": "Run-time libraries and programs"
+  },
+  {
+    "name": "motif-devel",
+    "summary": "Development libraries and header files"
+  },
+  {
+    "name": "mozilla-filesystem",
+    "summary": "Mozilla filesytem layout"
+  },
+  {
+    "name": "mpdecimal",
+    "summary": "Library for general decimal arithmetic"
+  },
+  {
+    "name": "mpfr-devel",
+    "summary": "Development files for the MPFR library"
+  },
+  {
+    "name": "mpg123",
+    "summary": "Real time MPEG 1.0/2.0/2.5 audio player/decoder for layers 1, 2 and 3"
+  },
+  {
+    "name": "mpg123-libs",
+    "summary": "Real time MPEG 1.0/2.0/2.5 audio player/decoder for layers 1, 2 and 3"
+  },
+  {
+    "name": "mpg123-plugins-pulseaudio",
+    "summary": "Pulseaudio output plug-in for mpg123"
+  },
+  {
+    "name": "mpich",
+    "summary": "A high-performance implementation of MPI"
+  },
+  {
+    "name": "mpich-autoload",
+    "summary": "Load mpich automatically into profile"
+  },
+  {
+    "name": "mpich-devel",
+    "summary": "Development files for mpich"
+  },
+  {
+    "name": "mpich-doc",
+    "summary": "Documentations and examples for mpich"
+  },
+  {
+    "name": "mpitests-mpich",
+    "summary": "MPI tests package compiled against mpich"
+  },
+  {
+    "name": "mpitests-mvapich2",
+    "summary": "MPI tests package compiled against mvapich2"
+  },
+  {
+    "name": "mpitests-mvapich2-psm2",
+    "summary": "MPI tests package compiled against mvapich2 using OmniPath"
+  },
+  {
+    "name": "mpitests-openmpi",
+    "summary": "MPI tests package compiled against openmpi"
+  },
+  {
+    "name": "mptcpd",
+    "summary": "Multipath TCP daemon"
+  },
+  {
+    "name": "mrtg",
+    "summary": "Multi Router Traffic Grapher"
+  },
+  {
+    "name": "mstflint",
+    "summary": "Mellanox firmware burning tool"
+  },
+  {
+    "name": "mt-st",
+    "summary": "Tool for controlling tape drives"
+  },
+  {
+    "name": "mtdev",
+    "summary": "Multitouch Protocol Translation Library"
+  },
+  {
+    "name": "mtr-gtk",
+    "summary": "GTK interface for MTR"
+  },
+  {
+    "name": "mtx",
+    "summary": "SCSI media changer control program"
+  },
+  {
+    "name": "munge",
+    "summary": "Enables uid & gid authentication across a host cluster"
+  },
+  {
+    "name": "munge-libs",
+    "summary": "Runtime libs for uid * gid authentication across a host cluster"
+  },
+  {
+    "name": "mutt",
+    "summary": "A text mode mail user agent"
+  },
+  {
+    "name": "mutter",
+    "summary": "Window and compositing manager based on Clutter"
+  },
+  {
+    "name": "mvapich2",
+    "summary": "OSU MVAPICH2 MPI package"
+  },
+  {
+    "name": "mvapich2-devel",
+    "summary": "Development files for mvapich2"
+  },
+  {
+    "name": "mvapich2-doc",
+    "summary": "Documentation files for mvapich2"
+  },
+  {
+    "name": "mvapich2-psm2",
+    "summary": "OSU MVAPICH2 MPI package 2.3 for Omni-Path adapters"
+  },
+  {
+    "name": "mypaint-brushes",
+    "summary": "Brushes to be used with the MyPaint library"
+  },
+  {
+    "name": "mysql",
+    "summary": "MySQL client programs and shared libraries"
+  },
+  {
+    "name": "mysql-common",
+    "summary": "The shared files required for MySQL server and client"
+  },
+  {
+    "name": "mysql-errmsg",
+    "summary": "The error messages files required by MySQL server"
+  },
+  {
+    "name": "mysql-selinux",
+    "summary": "SELinux policy modules for MySQL and MariaDB packages"
+  },
+  {
+    "name": "mysql-server",
+    "summary": "The MySQL server and related files"
+  },
+  {
+    "name": "mythes",
+    "summary": "A thesaurus library"
+  },
+  {
+    "name": "mythes-bg",
+    "summary": "Bulgarian thesaurus"
+  },
+  {
+    "name": "mythes-ca",
+    "summary": "Catalan thesaurus"
+  },
+  {
+    "name": "mythes-cs",
+    "summary": "Czech thesaurus"
+  },
+  {
+    "name": "mythes-da",
+    "summary": "Danish thesaurus"
+  },
+  {
+    "name": "mythes-de",
+    "summary": "German thesaurus"
+  },
+  {
+    "name": "mythes-el",
+    "summary": "Greek thesaurus"
+  },
+  {
+    "name": "mythes-en",
+    "summary": "English thesaurus"
+  },
+  {
+    "name": "mythes-eo",
+    "summary": "Esperanto thesaurus"
+  },
+  {
+    "name": "mythes-es",
+    "summary": "Spanish thesaurus"
+  },
+  {
+    "name": "mythes-fr",
+    "summary": "French thesaurus"
+  },
+  {
+    "name": "mythes-ga",
+    "summary": "Irish thesaurus"
+  },
+  {
+    "name": "mythes-hu",
+    "summary": "Hungarian thesaurus"
+  },
+  {
+    "name": "mythes-it",
+    "summary": "Italian thesaurus"
+  },
+  {
+    "name": "mythes-lv",
+    "summary": "Latvian thesaurus"
+  },
+  {
+    "name": "mythes-nb",
+    "summary": "Bokmaal thesaurus"
+  },
+  {
+    "name": "mythes-nl",
+    "summary": "Dutch thesaurus"
+  },
+  {
+    "name": "mythes-nn",
+    "summary": "Nynorsk thesaurus"
+  },
+  {
+    "name": "mythes-pl",
+    "summary": "Polish thesaurus"
+  },
+  {
+    "name": "mythes-pt",
+    "summary": "Portuguese thesaurus"
+  },
+  {
+    "name": "mythes-ro",
+    "summary": "Romanian thesaurus"
+  },
+  {
+    "name": "mythes-ru",
+    "summary": "Russian thesaurus"
+  },
+  {
+    "name": "mythes-sk",
+    "summary": "Slovak thesaurus"
+  },
+  {
+    "name": "mythes-sl",
+    "summary": "Slovenian thesaurus"
+  },
+  {
+    "name": "mythes-sv",
+    "summary": "Swedish thesaurus"
+  },
+  {
+    "name": "mythes-uk",
+    "summary": "Ukrainian thesaurus"
+  },
+  {
+    "name": "nautilus",
+    "summary": "File manager for GNOME"
+  },
+  {
+    "name": "nautilus-extensions",
+    "summary": "Nautilus extensions library"
+  },
+  {
+    "name": "navilu-fonts",
+    "summary": "Free Kannada opentype sans-serif font"
+  },
+  {
+    "name": "nbdfuse",
+    "summary": "FUSE support for libnbd"
+  },
+  {
+    "name": "nbdkit",
+    "summary": "NBD server"
+  },
+  {
+    "name": "nbdkit-bash-completion",
+    "summary": "Bash tab-completion for nbdkit"
+  },
+  {
+    "name": "nbdkit-basic-filters",
+    "summary": "Basic filters for nbdkit"
+  },
+  {
+    "name": "nbdkit-basic-plugins",
+    "summary": "Basic plugins for nbdkit"
+  },
+  {
+    "name": "nbdkit-curl-plugin",
+    "summary": "HTTP/FTP (cURL) plugin for nbdkit"
+  },
+  {
+    "name": "nbdkit-gzip-filter",
+    "summary": "GZip filter for nbdkit"
+  },
+  {
+    "name": "nbdkit-linuxdisk-plugin",
+    "summary": "Virtual Linux disk plugin for nbdkit"
+  },
+  {
+    "name": "nbdkit-nbd-plugin",
+    "summary": "NBD proxy / forward plugin for nbdkit"
+  },
+  {
+    "name": "nbdkit-python-plugin",
+    "summary": "Python 3 plugin for nbdkit"
+  },
+  {
+    "name": "nbdkit-selinux",
+    "summary": "nbdkit SELinux policy"
+  },
+  {
+    "name": "nbdkit-server",
+    "summary": "The nbdkit server"
+  },
+  {
+    "name": "nbdkit-ssh-plugin",
+    "summary": "SSH plugin for nbdkit"
+  },
+  {
+    "name": "nbdkit-tar-filter",
+    "summary": "Tar archive filter for nbdkit"
+  },
+  {
+    "name": "nbdkit-tmpdisk-plugin",
+    "summary": "Remote temporary filesystem disk plugin for nbdkit"
+  },
+  {
+    "name": "nbdkit-vddk-plugin",
+    "summary": "VMware VDDK plugin for nbdkit"
+  },
+  {
+    "name": "nbdkit-xz-filter",
+    "summary": "XZ filter for nbdkit"
+  },
+  {
+    "name": "ncurses-c++-libs",
+    "summary": "Ncurses C++ bindings"
+  },
+  {
+    "name": "ncurses-devel",
+    "summary": "Development files for the ncurses library"
+  },
+  {
+    "name": "ncurses-term",
+    "summary": "Terminal descriptions"
+  },
+  {
+    "name": "ndctl-devel",
+    "summary": "Development files for libndctl"
+  },
+  {
+    "name": "neon",
+    "summary": "An HTTP and WebDAV client library"
+  },
+  {
+    "name": "net-snmp",
+    "summary": "A collection of SNMP protocol tools and libraries"
+  },
+  {
+    "name": "net-snmp-agent-libs",
+    "summary": "The NET-SNMP runtime agent libraries"
+  },
+  {
+    "name": "net-snmp-devel",
+    "summary": "The development environment for the NET-SNMP project"
+  },
+  {
+    "name": "net-snmp-libs",
+    "summary": "The NET-SNMP runtime client libraries"
+  },
+  {
+    "name": "net-snmp-perl",
+    "summary": "The perl NET-SNMP module and the mib2c tool"
+  },
+  {
+    "name": "net-snmp-utils",
+    "summary": "Network management utilities using SNMP, from the NET-SNMP project"
+  },
+  {
+    "name": "netavark",
+    "summary": "OCI network stack"
+  },
+  {
+    "name": "netpbm",
+    "summary": "A library for handling different graphics file formats"
+  },
+  {
+    "name": "netpbm-progs",
+    "summary": "Tools for manipulating graphics files in netpbm supported formats"
+  },
+  {
+    "name": "netstandard-targeting-pack-2.1",
+    "summary": "Targeting Pack for NETStandard.Library 2.1"
+  },
+  {
+    "name": "nettle-devel",
+    "summary": "Development headers for a low-level cryptographic library"
+  },
+  {
+    "name": "network-manager-applet",
+    "summary": "A network control and status applet for NetworkManager"
+  },
+  {
+    "name": "NetworkManager-cloud-setup",
+    "summary": "Automatically configure NetworkManager in cloud"
+  },
+  {
+    "name": "NetworkManager-config-connectivity-redhat",
+    "summary": "NetworkManager config file for connectivity checking via Red Hat servers"
+  },
+  {
+    "name": "NetworkManager-dispatcher-routing-rules",
+    "summary": "NetworkManager dispatcher file for advanced routing rules"
+  },
+  {
+    "name": "NetworkManager-libreswan",
+    "summary": "NetworkManager VPN plug-in for IPsec VPN"
+  },
+  {
+    "name": "NetworkManager-libreswan-gnome",
+    "summary": "NetworkManager VPN plugin for libreswan - GNOME files"
+  },
+  {
+    "name": "NetworkManager-ovs",
+    "summary": "Open vSwitch device plugin for NetworkManager"
+  },
+  {
+    "name": "NetworkManager-ppp",
+    "summary": "PPP plugin for NetworkManager"
+  },
+  {
+    "name": "newt-devel",
+    "summary": "Newt windowing toolkit development files"
+  },
+  {
+    "name": "nfs-utils-coreos",
+    "summary": "Minimal NFS utilities for supporting clients"
+  },
+  {
+    "name": "nfsv4-client-utils",
+    "summary": "NFSv4 utilities for supporting client"
+  },
+  {
+    "name": "nginx",
+    "summary": "A high performance web server and reverse proxy server"
+  },
+  {
+    "name": "nginx-all-modules",
+    "summary": "A meta package that installs all available Nginx modules"
+  },
+  {
+    "name": "nginx-core",
+    "summary": "nginx minimal core"
+  },
+  {
+    "name": "nginx-filesystem",
+    "summary": "The basic directory layout for the Nginx server"
+  },
+  {
+    "name": "nginx-mod-http-image-filter",
+    "summary": "Nginx HTTP image filter module"
+  },
+  {
+    "name": "nginx-mod-http-perl",
+    "summary": "Nginx HTTP perl module"
+  },
+  {
+    "name": "nginx-mod-http-xslt-filter",
+    "summary": "Nginx XSLT module"
+  },
+  {
+    "name": "nginx-mod-mail",
+    "summary": "Nginx mail modules"
+  },
+  {
+    "name": "nginx-mod-stream",
+    "summary": "Nginx stream modules"
+  },
+  {
+    "name": "nispor",
+    "summary": "API for network status querying"
+  },
+  {
+    "name": "nm-connection-editor",
+    "summary": "A network connection configuration editor for NetworkManager"
+  },
+  {
+    "name": "nmap",
+    "summary": "Network exploration tool and security scanner"
+  },
+  {
+    "name": "nmap-ncat",
+    "summary": "Nmap's Netcat replacement"
+  },
+  {
+    "name": "nmstate",
+    "summary": "Declarative network manager API"
+  },
+  {
+    "name": "nmstate-libs",
+    "summary": "C binding of nmstate"
+  },
+  {
+    "name": "nmstate-plugin-ovsdb",
+    "summary": "nmstate plugin for OVS database manipulation"
+  },
+  {
+    "name": "nodejs",
+    "summary": "JavaScript runtime"
+  },
+  {
+    "name": "nodejs-docs",
+    "summary": "Node.js API documentation"
+  },
+  {
+    "name": "nodejs-full-i18n",
+    "summary": "Non-English locale data for Node.js"
+  },
+  {
+    "name": "nodejs-libs",
+    "summary": "Node.js and v8 libraries"
+  },
+  {
+    "name": "nodejs-nodemon",
+    "summary": "Simple monitor script for use during development of a node.js app"
+  },
+  {
+    "name": "npm",
+    "summary": "Node.js Package Manager"
+  },
+  {
+    "name": "nspr",
+    "summary": "Netscape Portable Runtime"
+  },
+  {
+    "name": "nspr-devel",
+    "summary": "Development libraries for the Netscape Portable Runtime"
+  },
+  {
+    "name": "nss",
+    "summary": "Network Security Services"
+  },
+  {
+    "name": "nss-altfiles",
+    "summary": "NSS module to look up users in /usr/lib/passwd too"
+  },
+  {
+    "name": "nss-devel",
+    "summary": "Development libraries for Network Security Services"
+  },
+  {
+    "name": "nss-softokn",
+    "summary": "Network Security Services Softoken Module"
+  },
+  {
+    "name": "nss-softokn-devel",
+    "summary": "Development libraries for Network Security Services"
+  },
+  {
+    "name": "nss-softokn-freebl",
+    "summary": "Freebl library for the Network Security Services"
+  },
+  {
+    "name": "nss-softokn-freebl-devel",
+    "summary": "Header and Library files for doing development with the Freebl library for NSS"
+  },
+  {
+    "name": "nss-sysinit",
+    "summary": "System NSS Initialization"
+  },
+  {
+    "name": "nss-tools",
+    "summary": "Tools for the Network Security Services"
+  },
+  {
+    "name": "nss-util",
+    "summary": "Network Security Services Utilities Library"
+  },
+  {
+    "name": "nss-util-devel",
+    "summary": "Development libraries for Network Security Services Utilities"
+  },
+  {
+    "name": "nss_wrapper",
+    "summary": "A wrapper for the user, group and hosts NSS API"
+  },
+  {
+    "name": "nss_wrapper-libs",
+    "summary": "nss_library shared library only"
+  },
+  {
+    "name": "ntpstat",
+    "summary": "Utility to print NTP synchronization status"
+  },
+  {
+    "name": "ntsysv",
+    "summary": "A tool to set the stop/start of system services in a runlevel"
+  },
+  {
+    "name": "numactl-devel",
+    "summary": "Development package for building Applications that use numa"
+  },
+  {
+    "name": "nvme-stas",
+    "summary": "NVMe STorage Appliance Services"
+  },
+  {
+    "name": "objectweb-asm",
+    "summary": "Java bytecode manipulation and analysis framework"
+  },
+  {
+    "name": "ocaml-srpm-macros",
+    "summary": "OCaml architecture macros"
+  },
+  {
+    "name": "oci-seccomp-bpf-hook",
+    "summary": "OCI Hook to generate seccomp json files based on EBF syscalls used by container"
+  },
+  {
+    "name": "ocl-icd",
+    "summary": "OpenCL Library (Installable Client Library) Bindings"
+  },
+  {
+    "name": "oddjob",
+    "summary": "A D-Bus service which runs odd jobs on behalf of client applications"
+  },
+  {
+    "name": "oddjob-mkhomedir",
+    "summary": "An oddjob helper which creates and populates home directories"
+  },
+  {
+    "name": "omping",
+    "summary": "Utility to test IP multicast functionality"
+  },
+  {
+    "name": "ongres-scram",
+    "summary": "Salted Challenge Response Authentication Mechanism (SCRAM) - Java Implementation"
+  },
+  {
+    "name": "ongres-scram-client",
+    "summary": "Client for ongres-scram"
+  },
+  {
+    "name": "oniguruma",
+    "summary": "Regular expressions library"
+  },
+  {
+    "name": "opa-address-resolution",
+    "summary": "OPA Address Resolution manager"
+  },
+  {
+    "name": "opa-basic-tools",
+    "summary": "OPA management level tools and scripts"
+  },
+  {
+    "name": "opa-fastfabric",
+    "summary": "Management level tools and scripts"
+  },
+  {
+    "name": "opa-fm",
+    "summary": "Intel Omni-Path Fabric Management Software"
+  },
+  {
+    "name": "opa-libopamgt",
+    "summary": "Omni-Path management API library"
+  },
+  {
+    "name": "open-sans-fonts",
+    "summary": "Open Sans is a humanist sans-serif typeface designed by Steve Matteson"
+  },
+  {
+    "name": "open-vm-tools",
+    "summary": "Open Virtual Machine Tools for virtual machines hosted on VMware"
+  },
+  {
+    "name": "open-vm-tools-desktop",
+    "summary": "User experience components for Open Virtual Machine Tools"
+  },
+  {
+    "name": "open-vm-tools-salt-minion",
+    "summary": "Script file to install/uninstall salt-minion"
+  },
+  {
+    "name": "open-vm-tools-sdmp",
+    "summary": "Service Discovery components for Open Virtual Machine Tools"
+  },
+  {
+    "name": "open-vm-tools-test",
+    "summary": "Test utilities for Open Virtual Machine Tools"
+  },
+  {
+    "name": "openal-soft",
+    "summary": "Open Audio Library"
+  },
+  {
+    "name": "openblas",
+    "summary": "An optimized BLAS library based on GotoBLAS2"
+  },
+  {
+    "name": "openblas-openmp",
+    "summary": "An optimized BLAS library based on GotoBLAS2, OpenMP version"
+  },
+  {
+    "name": "openblas-openmp64",
+    "summary": "An optimized BLAS library based on GotoBLAS2, OpenMP version"
+  },
+  {
+    "name": "openblas-serial",
+    "summary": "An optimized BLAS library based on GotoBLAS2, serial version"
+  },
+  {
+    "name": "openblas-srpm-macros",
+    "summary": "OpenBLAS architecture macros"
+  },
+  {
+    "name": "openchange",
+    "summary": "Provides access to Microsoft Exchange servers using native protocols"
+  },
+  {
+    "name": "opencl-filesystem",
+    "summary": "OpenCL filesystem layout"
+  },
+  {
+    "name": "opencl-headers",
+    "summary": "OpenCL (Open Computing Language) header files"
+  },
+  {
+    "name": "opendnssec",
+    "summary": "DNSSEC key and zone management software"
+  },
+  {
+    "name": "openexr",
+    "summary": "Provides the specification and reference implementation of the EXR file format"
+  },
+  {
+    "name": "openexr-libs",
+    "summary": "OpenEXR Libraries"
+  },
+  {
+    "name": "OpenIPMI",
+    "summary": "IPMI (Intelligent Platform Management Interface) library and tools"
+  },
+  {
+    "name": "OpenIPMI-lanserv",
+    "summary": "Emulates an IPMI network listener"
+  },
+  {
+    "name": "OpenIPMI-libs",
+    "summary": "The OpenIPMI runtime libraries"
+  },
+  {
+    "name": "openjpeg2",
+    "summary": "C-Library for JPEG 2000"
+  },
+  {
+    "name": "openldap-devel",
+    "summary": "LDAP development libraries and header files"
+  },
+  {
+    "name": "openmpi",
+    "summary": "Open Message Passing Interface"
+  },
+  {
+    "name": "openmpi-devel",
+    "summary": "Development files for openmpi"
+  },
+  {
+    "name": "openmpi-java",
+    "summary": "Java library"
+  },
+  {
+    "name": "openscap",
+    "summary": "Set of open source libraries enabling integration of the SCAP line of standards"
+  },
+  {
+    "name": "openscap-devel",
+    "summary": "Development files for openscap"
+  },
+  {
+    "name": "openscap-engine-sce",
+    "summary": "Script Check Engine plug-in for OpenSCAP"
+  },
+  {
+    "name": "openscap-python3",
+    "summary": "Python 3 bindings for openscap"
+  },
+  {
+    "name": "openscap-scanner",
+    "summary": "OpenSCAP Scanner Tool (oscap)"
+  },
+  {
+    "name": "openscap-utils",
+    "summary": "OpenSCAP Utilities"
+  },
+  {
+    "name": "openslp",
+    "summary": "Open implementation of Service Location Protocol V2"
+  },
+  {
+    "name": "openslp-server",
+    "summary": "OpenSLP server daemon"
+  },
+  {
+    "name": "openssh-askpass",
+    "summary": "A passphrase dialog for OpenSSH and X"
+  },
+  {
+    "name": "openssl-devel",
+    "summary": "Files for development of applications which will use OpenSSL"
+  },
+  {
+    "name": "openssl-perl",
+    "summary": "Perl scripts provided with OpenSSL"
+  },
+  {
+    "name": "opentelemetry-collector",
+    "summary": "Red Hat build of OpenTelemetry"
+  },
+  {
+    "name": "opentest4j",
+    "summary": "Open Test Alliance for the JVM"
+  },
+  {
+    "name": "openwsman-python3",
+    "summary": "Python bindings for openwsman client API"
+  },
+  {
+    "name": "openwsman-server",
+    "summary": "Openwsman Server and service libraries"
+  },
+  {
+    "name": "opus",
+    "summary": "An audio codec for use in low-delay speech and audio communication"
+  },
+  {
+    "name": "orc",
+    "summary": "The Oil Run-time Compiler"
+  },
+  {
+    "name": "orc-compiler",
+    "summary": "Orc compiler"
+  },
+  {
+    "name": "orc-devel",
+    "summary": "Development files and libraries for Orc"
+  },
+  {
+    "name": "orca",
+    "summary": "Assistive technology for people with visual impairments"
+  },
+  {
+    "name": "osbuild",
+    "summary": "A build system for OS images"
+  },
+  {
+    "name": "osbuild-composer",
+    "summary": "An image building service based on osbuild"
+  },
+  {
+    "name": "osbuild-composer-core",
+    "summary": "The core osbuild-composer binary"
+  },
+  {
+    "name": "osbuild-composer-dnf-json",
+    "summary": "The dnf-json binary used by osbuild-composer and the workers"
+  },
+  {
+    "name": "osbuild-composer-worker",
+    "summary": "The worker for osbuild-composer"
+  },
+  {
+    "name": "osbuild-depsolve-dnf",
+    "summary": "Dependency solving support for DNF"
+  },
+  {
+    "name": "osbuild-luks2",
+    "summary": "LUKS2 support"
+  },
+  {
+    "name": "osbuild-lvm2",
+    "summary": "LVM2 support"
+  },
+  {
+    "name": "osbuild-ostree",
+    "summary": "OSTree support"
+  },
+  {
+    "name": "osbuild-selinux",
+    "summary": "SELinux policies"
+  },
+  {
+    "name": "oscap-anaconda-addon",
+    "summary": "Anaconda addon integrating OpenSCAP to the installation process"
+  },
+  {
+    "name": "osinfo-db",
+    "summary": "osinfo database files"
+  },
+  {
+    "name": "osinfo-db-tools",
+    "summary": "Tools for managing the osinfo database"
+  },
+  {
+    "name": "ostree",
+    "summary": "Tool for managing bootable, immutable filesystem trees"
+  },
+  {
+    "name": "ostree-grub2",
+    "summary": "GRUB2 integration for OSTree"
+  },
+  {
+    "name": "ostree-libs",
+    "summary": "Development headers for ostree"
+  },
+  {
+    "name": "overpass-fonts",
+    "summary": "Typeface based on the U.S. interstate highway road signage type system"
+  },
+  {
+    "name": "owasp-java-encoder",
+    "summary": "Collection of high-performance low-overhead contextual encoders"
+  },
+  {
+    "name": "p11-kit-devel",
+    "summary": "Development files for p11-kit"
+  },
+  {
+    "name": "p11-kit-server",
+    "summary": "Server and client commands for p11-kit"
+  },
+  {
+    "name": "pacemaker-cluster-libs",
+    "summary": "Cluster Libraries used by Pacemaker"
+  },
+  {
+    "name": "pacemaker-libs",
+    "summary": "Core Pacemaker libraries"
+  },
+  {
+    "name": "pacemaker-schemas",
+    "summary": "Schemas and upgrade stylesheets for Pacemaker"
+  },
+  {
+    "name": "PackageKit",
+    "summary": "Package management service"
+  },
+  {
+    "name": "PackageKit-command-not-found",
+    "summary": "Ask the user to install command line programs automatically"
+  },
+  {
+    "name": "PackageKit-glib",
+    "summary": "GLib libraries for accessing PackageKit"
+  },
+  {
+    "name": "PackageKit-gstreamer-plugin",
+    "summary": "Install GStreamer codecs using PackageKit"
+  },
+  {
+    "name": "PackageKit-gtk3-module",
+    "summary": "Install fonts automatically using PackageKit"
+  },
+  {
+    "name": "paktype-naqsh-fonts",
+    "summary": "Fonts for Arabic from PakType"
+  },
+  {
+    "name": "paktype-naskh-basic-fonts",
+    "summary": "Fonts for Arabic, Farsi, Urdu and Sindhi from PakType"
+  },
+  {
+    "name": "paktype-tehreer-fonts",
+    "summary": "Fonts for Arabic from PakType"
+  },
+  {
+    "name": "pam-devel",
+    "summary": "Files needed for developing PAM-aware applications and modules for PAM"
+  },
+  {
+    "name": "pam-docs",
+    "summary": "Extra documentation for PAM."
+  },
+  {
+    "name": "pam_cifscreds",
+    "summary": "PAM module to manage NTLM credentials in kernel keyring"
+  },
+  {
+    "name": "pam_ssh_agent_auth",
+    "summary": "PAM module for authentication with ssh-agent"
+  },
+  {
+    "name": "pango",
+    "summary": "System for layout and rendering of internationalized text"
+  },
+  {
+    "name": "pango-devel",
+    "summary": "Development files for pango"
+  },
+  {
+    "name": "pangomm",
+    "summary": "C++ interface for Pango"
+  },
+  {
+    "name": "papi",
+    "summary": "Performance Application Programming Interface"
+  },
+  {
+    "name": "papi-devel",
+    "summary": "Header files for the compiling programs with PAPI"
+  },
+  {
+    "name": "papi-libs",
+    "summary": "Libraries for PAPI clients"
+  },
+  {
+    "name": "paps",
+    "summary": "Plain Text to PostScript converter"
+  },
+  {
+    "name": "passt",
+    "summary": "User-mode networking daemons for virtual machines and namespaces"
+  },
+  {
+    "name": "passt-selinux",
+    "summary": "SELinux support for passt and pasta"
+  },
+  {
+    "name": "patch",
+    "summary": "Utility for modifying/upgrading files"
+  },
+  {
+    "name": "patchutils",
+    "summary": "A collection of programs for manipulating patch files"
+  },
+  {
+    "name": "pavucontrol",
+    "summary": "Volume control for PulseAudio"
+  },
+  {
+    "name": "pbzip2",
+    "summary": "Parallel implementation of bzip2"
+  },
+  {
+    "name": "pcaudiolib",
+    "summary": "Portable C Audio Library"
+  },
+  {
+    "name": "pciutils",
+    "summary": "PCI bus related utilities"
+  },
+  {
+    "name": "pciutils-devel",
+    "summary": "Linux PCI development library"
+  },
+  {
+    "name": "pcm",
+    "summary": "Processor Counter Monitor"
+  },
+  {
+    "name": "pcp",
+    "summary": "System-level performance monitoring and performance management"
+  },
+  {
+    "name": "pcp-conf",
+    "summary": "Performance Co-Pilot run-time configuration"
+  },
+  {
+    "name": "pcp-devel",
+    "summary": "Performance Co-Pilot (PCP) development tools and documentation"
+  },
+  {
+    "name": "pcp-doc",
+    "summary": "Documentation and tutorial for the Performance Co-Pilot"
+  },
+  {
+    "name": "pcp-export-pcp2elasticsearch",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics to ElasticSearch"
+  },
+  {
+    "name": "pcp-export-pcp2graphite",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics to Graphite"
+  },
+  {
+    "name": "pcp-export-pcp2influxdb",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics to InfluxDB"
+  },
+  {
+    "name": "pcp-export-pcp2json",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics in JSON format"
+  },
+  {
+    "name": "pcp-export-pcp2openmetrics",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics in OpenMetrics format"
+  },
+  {
+    "name": "pcp-export-pcp2spark",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics to Apache Spark"
+  },
+  {
+    "name": "pcp-export-pcp2xml",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics in XML format"
+  },
+  {
+    "name": "pcp-export-pcp2zabbix",
+    "summary": "Performance Co-Pilot tools for exporting PCP metrics to Zabbix"
+  },
+  {
+    "name": "pcp-export-zabbix-agent",
+    "summary": "Module for exporting PCP metrics to Zabbix agent"
+  },
+  {
+    "name": "pcp-geolocate",
+    "summary": "Performance Co-Pilot geographical location metric labels"
+  },
+  {
+    "name": "pcp-gui",
+    "summary": "Visualization tools for the Performance Co-Pilot toolkit"
+  },
+  {
+    "name": "pcp-import-collectl2pcp",
+    "summary": "Performance Co-Pilot tools for importing collectl log files into PCP archive logs"
+  },
+  {
+    "name": "pcp-import-ganglia2pcp",
+    "summary": "Performance Co-Pilot tools for importing ganglia data into PCP archive logs"
+  },
+  {
+    "name": "pcp-import-iostat2pcp",
+    "summary": "Performance Co-Pilot tools for importing iostat data into PCP archive logs"
+  },
+  {
+    "name": "pcp-import-mrtg2pcp",
+    "summary": "Performance Co-Pilot tools for importing MTRG data into PCP archive logs"
+  },
+  {
+    "name": "pcp-import-sar2pcp",
+    "summary": "Performance Co-Pilot tools for importing sar data into PCP archive logs"
+  },
+  {
+    "name": "pcp-libs",
+    "summary": "Performance Co-Pilot run-time libraries"
+  },
+  {
+    "name": "pcp-libs-devel",
+    "summary": "Performance Co-Pilot (PCP) development headers"
+  },
+  {
+    "name": "pcp-pmda-activemq",
+    "summary": "Performance Co-Pilot (PCP) metrics for ActiveMQ"
+  },
+  {
+    "name": "pcp-pmda-apache",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Apache webserver"
+  },
+  {
+    "name": "pcp-pmda-bash",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Bash shell"
+  },
+  {
+    "name": "pcp-pmda-bcc",
+    "summary": "Performance Co-Pilot (PCP) metrics from eBPF/BCC modules"
+  },
+  {
+    "name": "pcp-pmda-bind2",
+    "summary": "Performance Co-Pilot (PCP) metrics for BIND servers"
+  },
+  {
+    "name": "pcp-pmda-bonding",
+    "summary": "Performance Co-Pilot (PCP) metrics for Bonded network interfaces"
+  },
+  {
+    "name": "pcp-pmda-bpf",
+    "summary": "Performance Co-Pilot (PCP) metrics from eBPF ELF modules"
+  },
+  {
+    "name": "pcp-pmda-bpftrace",
+    "summary": "Performance Co-Pilot (PCP) metrics from bpftrace scripts"
+  },
+  {
+    "name": "pcp-pmda-cifs",
+    "summary": "Performance Co-Pilot (PCP) metrics for the CIFS protocol"
+  },
+  {
+    "name": "pcp-pmda-cisco",
+    "summary": "Performance Co-Pilot (PCP) metrics for Cisco routers"
+  },
+  {
+    "name": "pcp-pmda-dbping",
+    "summary": "Performance Co-Pilot (PCP) metrics for Database response times and Availablility"
+  },
+  {
+    "name": "pcp-pmda-denki",
+    "summary": "Performance Co-Pilot (PCP) metrics dealing with electrical power"
+  },
+  {
+    "name": "pcp-pmda-dm",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Device Mapper Cache and Thin Client"
+  },
+  {
+    "name": "pcp-pmda-docker",
+    "summary": "Performance Co-Pilot (PCP) metrics from the Docker daemon"
+  },
+  {
+    "name": "pcp-pmda-ds389",
+    "summary": "Performance Co-Pilot (PCP) metrics for 389 Directory Servers"
+  },
+  {
+    "name": "pcp-pmda-ds389log",
+    "summary": "Performance Co-Pilot (PCP) metrics for 389 Directory Server Loggers"
+  },
+  {
+    "name": "pcp-pmda-elasticsearch",
+    "summary": "Performance Co-Pilot (PCP) metrics for Elasticsearch"
+  },
+  {
+    "name": "pcp-pmda-farm",
+    "summary": "Performance Co-Pilot (PCP) metrics for Seagate FARM Log metrics"
+  },
+  {
+    "name": "pcp-pmda-gfs2",
+    "summary": "Performance Co-Pilot (PCP) metrics for the GFS2 filesystem"
+  },
+  {
+    "name": "pcp-pmda-gluster",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Gluster filesystem"
+  },
+  {
+    "name": "pcp-pmda-gpfs",
+    "summary": "Performance Co-Pilot (PCP) metrics for GPFS Filesystem"
+  },
+  {
+    "name": "pcp-pmda-gpsd",
+    "summary": "Performance Co-Pilot (PCP) metrics for a GPS Daemon"
+  },
+  {
+    "name": "pcp-pmda-hacluster",
+    "summary": "Performance Co-Pilot (PCP) metrics for High Availability Clusters"
+  },
+  {
+    "name": "pcp-pmda-haproxy",
+    "summary": "Performance Co-Pilot (PCP) metrics for HAProxy"
+  },
+  {
+    "name": "pcp-pmda-infiniband",
+    "summary": "Performance Co-Pilot (PCP) metrics for Infiniband HCAs and switches"
+  },
+  {
+    "name": "pcp-pmda-json",
+    "summary": "Performance Co-Pilot (PCP) metrics for JSON data"
+  },
+  {
+    "name": "pcp-pmda-libvirt",
+    "summary": "Performance Co-Pilot (PCP) metrics from virtual machines"
+  },
+  {
+    "name": "pcp-pmda-lio",
+    "summary": "Performance Co-Pilot (PCP) metrics for the LIO subsystem"
+  },
+  {
+    "name": "pcp-pmda-lmsensors",
+    "summary": "Performance Co-Pilot (PCP) metrics for hardware sensors"
+  },
+  {
+    "name": "pcp-pmda-logger",
+    "summary": "Performance Co-Pilot (PCP) metrics from arbitrary log files"
+  },
+  {
+    "name": "pcp-pmda-lustre",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Lustre Filesytem"
+  },
+  {
+    "name": "pcp-pmda-lustrecomm",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Lustre Filesytem Comms"
+  },
+  {
+    "name": "pcp-pmda-mailq",
+    "summary": "Performance Co-Pilot (PCP) metrics for the sendmail queue"
+  },
+  {
+    "name": "pcp-pmda-memcache",
+    "summary": "Performance Co-Pilot (PCP) metrics for Memcached"
+  },
+  {
+    "name": "pcp-pmda-mic",
+    "summary": "Performance Co-Pilot (PCP) metrics for Intel MIC cards"
+  },
+  {
+    "name": "pcp-pmda-mongodb",
+    "summary": "Performance Co-Pilot (PCP) metrics for MongoDB"
+  },
+  {
+    "name": "pcp-pmda-mounts",
+    "summary": "Performance Co-Pilot (PCP) metrics for filesystem mounts"
+  },
+  {
+    "name": "pcp-pmda-mssql",
+    "summary": "Performance Co-Pilot (PCP) metrics for Microsoft SQL Server"
+  },
+  {
+    "name": "pcp-pmda-mysql",
+    "summary": "Performance Co-Pilot (PCP) metrics for MySQL"
+  },
+  {
+    "name": "pcp-pmda-named",
+    "summary": "Performance Co-Pilot (PCP) metrics for Named"
+  },
+  {
+    "name": "pcp-pmda-netcheck",
+    "summary": "Performance Co-Pilot (PCP) metrics for simple network checks"
+  },
+  {
+    "name": "pcp-pmda-netfilter",
+    "summary": "Performance Co-Pilot (PCP) metrics for Netfilter framework"
+  },
+  {
+    "name": "pcp-pmda-news",
+    "summary": "Performance Co-Pilot (PCP) metrics for Usenet News"
+  },
+  {
+    "name": "pcp-pmda-nfsclient",
+    "summary": "Performance Co-Pilot (PCP) metrics for NFS Clients"
+  },
+  {
+    "name": "pcp-pmda-nginx",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Nginx Webserver"
+  },
+  {
+    "name": "pcp-pmda-nvidia-gpu",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Nvidia GPU"
+  },
+  {
+    "name": "pcp-pmda-openmetrics",
+    "summary": "Performance Co-Pilot (PCP) metrics from OpenMetrics endpoints"
+  },
+  {
+    "name": "pcp-pmda-openvswitch",
+    "summary": "Performance Co-Pilot (PCP) metrics for Open vSwitch"
+  },
+  {
+    "name": "pcp-pmda-oracle",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Oracle database"
+  },
+  {
+    "name": "pcp-pmda-pdns",
+    "summary": "Performance Co-Pilot (PCP) metrics for PowerDNS"
+  },
+  {
+    "name": "pcp-pmda-perfevent",
+    "summary": "Performance Co-Pilot (PCP) metrics for hardware counters"
+  },
+  {
+    "name": "pcp-pmda-podman",
+    "summary": "Performance Co-Pilot (PCP) metrics for podman containers"
+  },
+  {
+    "name": "pcp-pmda-postfix",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Postfix (MTA)"
+  },
+  {
+    "name": "pcp-pmda-postgresql",
+    "summary": "Performance Co-Pilot (PCP) metrics for PostgreSQL"
+  },
+  {
+    "name": "pcp-pmda-rabbitmq",
+    "summary": "Performance Co-Pilot (PCP) metrics for RabbitMQ queues"
+  },
+  {
+    "name": "pcp-pmda-redis",
+    "summary": "Performance Co-Pilot (PCP) metrics for Redis"
+  },
+  {
+    "name": "pcp-pmda-resctrl",
+    "summary": "Performance Co-Pilot (PCP) metrics from Linux resource control"
+  },
+  {
+    "name": "pcp-pmda-roomtemp",
+    "summary": "Performance Co-Pilot (PCP) metrics for the room temperature"
+  },
+  {
+    "name": "pcp-pmda-rsyslog",
+    "summary": "Performance Co-Pilot (PCP) metrics for Rsyslog"
+  },
+  {
+    "name": "pcp-pmda-samba",
+    "summary": "Performance Co-Pilot (PCP) metrics for Samba"
+  },
+  {
+    "name": "pcp-pmda-sendmail",
+    "summary": "Performance Co-Pilot (PCP) metrics for Sendmail"
+  },
+  {
+    "name": "pcp-pmda-shping",
+    "summary": "Performance Co-Pilot (PCP) metrics for shell command responses"
+  },
+  {
+    "name": "pcp-pmda-slurm",
+    "summary": "Performance Co-Pilot (PCP) metrics for the SLURM Workload Manager"
+  },
+  {
+    "name": "pcp-pmda-smart",
+    "summary": "Performance Co-Pilot (PCP) metrics for S.M.A.R.T values"
+  },
+  {
+    "name": "pcp-pmda-snmp",
+    "summary": "Performance Co-Pilot (PCP) metrics for Simple Network Management Protocol"
+  },
+  {
+    "name": "pcp-pmda-sockets",
+    "summary": "Performance Co-Pilot (PCP) per-socket metrics"
+  },
+  {
+    "name": "pcp-pmda-statsd",
+    "summary": "Performance Co-Pilot (PCP) metrics from statsd"
+  },
+  {
+    "name": "pcp-pmda-summary",
+    "summary": "Performance Co-Pilot (PCP) summary metrics from pmie"
+  },
+  {
+    "name": "pcp-pmda-systemd",
+    "summary": "Performance Co-Pilot (PCP) metrics from the Systemd journal"
+  },
+  {
+    "name": "pcp-pmda-trace",
+    "summary": "Performance Co-Pilot (PCP) metrics for application tracing"
+  },
+  {
+    "name": "pcp-pmda-unbound",
+    "summary": "Performance Co-Pilot (PCP) metrics for the Unbound DNS Resolver"
+  },
+  {
+    "name": "pcp-pmda-uwsgi",
+    "summary": "Performance Co-Pilot (PCP) metrics from uWSGI servers"
+  },
+  {
+    "name": "pcp-pmda-weblog",
+    "summary": "Performance Co-Pilot (PCP) metrics from web server logs"
+  },
+  {
+    "name": "pcp-pmda-zimbra",
+    "summary": "Performance Co-Pilot (PCP) metrics for Zimbra"
+  },
+  {
+    "name": "pcp-pmda-zswap",
+    "summary": "Performance Co-Pilot (PCP) metrics for compressed swap"
+  },
+  {
+    "name": "pcp-selinux",
+    "summary": "Selinux policy package"
+  },
+  {
+    "name": "pcp-system-tools",
+    "summary": "Performance Co-Pilot (PCP) System and Monitoring Tools"
+  },
+  {
+    "name": "pcp-testsuite",
+    "summary": "Performance Co-Pilot (PCP) test suite"
+  },
+  {
+    "name": "pcp-zeroconf",
+    "summary": "Performance Co-Pilot (PCP) Zeroconf Package"
+  },
+  {
+    "name": "pcre-cpp",
+    "summary": "C++ bindings for PCRE"
+  },
+  {
+    "name": "pcre-devel",
+    "summary": "Development files for pcre"
+  },
+  {
+    "name": "pcre-utf16",
+    "summary": "UTF-16 variant of PCRE"
+  },
+  {
+    "name": "pcre-utf32",
+    "summary": "UTF-32 variant of PCRE"
+  },
+  {
+    "name": "pcre2-devel",
+    "summary": "Development files for pcre2"
+  },
+  {
+    "name": "pcre2-utf16",
+    "summary": "UTF-16 variant of PCRE2"
+  },
+  {
+    "name": "pcre2-utf32",
+    "summary": "UTF-32 variant of PCRE2"
+  },
+  {
+    "name": "pentaho-libxml",
+    "summary": "Namespace aware SAX-Parser utility library"
+  },
+  {
+    "name": "pentaho-reporting-flow-engine",
+    "summary": "Pentaho Flow Reporting Engine"
+  },
+  {
+    "name": "perf",
+    "summary": "Performance monitoring for the Linux kernel"
+  },
+  {
+    "name": "perl",
+    "summary": "Practical Extraction and Report Language"
+  },
+  {
+    "name": "perl-Algorithm-Diff",
+    "summary": "Compute 'intelligent' differences between two files/lists"
+  },
+  {
+    "name": "perl-App-cpanminus",
+    "summary": "Get, unpack, build and install CPAN modules"
+  },
+  {
+    "name": "perl-Archive-Tar",
+    "summary": "A module for Perl manipulation of .tar files"
+  },
+  {
+    "name": "perl-Archive-Zip",
+    "summary": "Perl library for accessing Zip archives"
+  },
+  {
+    "name": "perl-Attribute-Handlers",
+    "summary": "Simpler definition of attribute handlers"
+  },
+  {
+    "name": "perl-Authen-SASL",
+    "summary": "SASL Authentication framework for Perl"
+  },
+  {
+    "name": "perl-autodie",
+    "summary": "Replace functions with ones that succeed or die"
+  },
+  {
+    "name": "perl-AutoLoader",
+    "summary": "Load subroutines only on demand"
+  },
+  {
+    "name": "perl-AutoSplit",
+    "summary": "Split a package for automatic loading"
+  },
+  {
+    "name": "perl-autouse",
+    "summary": "Postpone load of modules until a function is used"
+  },
+  {
+    "name": "perl-B",
+    "summary": "Perl compiler backend"
+  },
+  {
+    "name": "perl-base",
+    "summary": "Establish an ISA relationship with base classes at compile time"
+  },
+  {
+    "name": "perl-Benchmark",
+    "summary": "Benchmark running times of Perl code"
+  },
+  {
+    "name": "perl-bignum",
+    "summary": "Transparent big number support for Perl"
+  },
+  {
+    "name": "perl-Bit-Vector",
+    "summary": "Efficient bit vector, set of integers and \"big int\" math library"
+  },
+  {
+    "name": "perl-blib",
+    "summary": "Use uninstalled version of a package"
+  },
+  {
+    "name": "perl-BSD-Resource",
+    "summary": "BSD process resource limit and priority functions"
+  },
+  {
+    "name": "perl-Carp",
+    "summary": "Alternative warn and die for modules"
+  },
+  {
+    "name": "perl-Carp-Clan",
+    "summary": "Perl module to print improved warning messages"
+  },
+  {
+    "name": "perl-CGI",
+    "summary": "Handle Common Gateway Interface requests and responses"
+  },
+  {
+    "name": "perl-Class-Inspector",
+    "summary": "Get information about a class and its structure"
+  },
+  {
+    "name": "perl-Class-Struct",
+    "summary": "Declare struct-like data types as Perl classes"
+  },
+  {
+    "name": "perl-Clone",
+    "summary": "Recursively copy perl data types"
+  },
+  {
+    "name": "perl-Compress-Bzip2",
+    "summary": "Interface to Bzip2 compression library"
+  },
+  {
+    "name": "perl-Compress-Raw-Bzip2",
+    "summary": "Low-level interface to bzip2 compression library"
+  },
+  {
+    "name": "perl-Compress-Raw-Lzma",
+    "summary": "Low-level interface to lzma compression library"
+  },
+  {
+    "name": "perl-Compress-Raw-Zlib",
+    "summary": "Low-level interface to the zlib compression library"
+  },
+  {
+    "name": "perl-Config-Extensions",
+    "summary": "Hash lookup of which Perl core extensions were built"
+  },
+  {
+    "name": "perl-Config-Perl-V",
+    "summary": "Structured data retrieval of perl -V output"
+  },
+  {
+    "name": "perl-constant",
+    "summary": "Perl pragma to declare constants"
+  },
+  {
+    "name": "perl-Convert-ASN1",
+    "summary": "ASN.1 encode/decode library"
+  },
+  {
+    "name": "perl-CPAN",
+    "summary": "Query, download and build perl modules from CPAN sites"
+  },
+  {
+    "name": "perl-CPAN-DistnameInfo",
+    "summary": "Extract distribution name and version from a distribution filename"
+  },
+  {
+    "name": "perl-CPAN-Meta",
+    "summary": "Distribution metadata for a CPAN dist"
+  },
+  {
+    "name": "perl-CPAN-Meta-Check",
+    "summary": "Verify requirements in a CPAN::Meta object"
+  },
+  {
+    "name": "perl-CPAN-Meta-Requirements",
+    "summary": "Set of version requirements for a CPAN dist"
+  },
+  {
+    "name": "perl-CPAN-Meta-YAML",
+    "summary": "Read and write a subset of YAML for CPAN Meta files"
+  },
+  {
+    "name": "perl-Crypt-OpenSSL-Bignum",
+    "summary": "Perl interface to OpenSSL for Bignum"
+  },
+  {
+    "name": "perl-Crypt-OpenSSL-Random",
+    "summary": "OpenSSL/LibreSSL pseudo-random number generator access"
+  },
+  {
+    "name": "perl-Crypt-OpenSSL-RSA",
+    "summary": "Perl interface to OpenSSL for RSA"
+  },
+  {
+    "name": "perl-Cyrus",
+    "summary": "Perl libraries for interfacing with Cyrus IMAPd"
+  },
+  {
+    "name": "perl-Data-Dump",
+    "summary": "Pretty printing of data structures"
+  },
+  {
+    "name": "perl-Data-Dumper",
+    "summary": "Stringify perl data structures, suitable for printing and eval"
+  },
+  {
+    "name": "perl-Data-OptList",
+    "summary": "Parse and validate simple name/value option pairs"
+  },
+  {
+    "name": "perl-Data-Section",
+    "summary": "Read multiple hunks of data out of your DATA section"
+  },
+  {
+    "name": "perl-Date-Calc",
+    "summary": "Gregorian calendar date calculations"
+  },
+  {
+    "name": "perl-Date-Manip",
+    "summary": "Date manipulation routines"
+  },
+  {
+    "name": "perl-DB_File",
+    "summary": "Perl5 access to Berkeley DB version 1.x"
+  },
+  {
+    "name": "perl-DBD-MariaDB",
+    "summary": "MariaDB and MySQL driver for the Perl5 Database Interface (DBI)"
+  },
+  {
+    "name": "perl-DBD-MySQL",
+    "summary": "A MySQL interface for Perl"
+  },
+  {
+    "name": "perl-DBD-Pg",
+    "summary": "A PostgreSQL interface for Perl"
+  },
+  {
+    "name": "perl-DBD-SQLite",
+    "summary": "SQLite DBI Driver"
+  },
+  {
+    "name": "perl-DBI",
+    "summary": "A database access API for perl"
+  },
+  {
+    "name": "perl-DBM_Filter",
+    "summary": "Filter DBM keys and values"
+  },
+  {
+    "name": "perl-debugger",
+    "summary": "Perl debugger"
+  },
+  {
+    "name": "perl-deprecate",
+    "summary": "Perl pragma for deprecating the inclusion of a module in core"
+  },
+  {
+    "name": "perl-devel",
+    "summary": "Header files for use in perl development"
+  },
+  {
+    "name": "perl-Devel-Peek",
+    "summary": "A data debugging tool for the XS programmer"
+  },
+  {
+    "name": "perl-Devel-PPPort",
+    "summary": "Perl Pollution Portability header generator"
+  },
+  {
+    "name": "perl-Devel-SelfStubber",
+    "summary": "Generate stubs for a SelfLoading module"
+  },
+  {
+    "name": "perl-Devel-Size",
+    "summary": "Perl extension for finding the memory usage of Perl variables"
+  },
+  {
+    "name": "perl-diagnostics",
+    "summary": "Produce verbose warning diagnostics"
+  },
+  {
+    "name": "perl-Digest",
+    "summary": "Modules that calculate message digests"
+  },
+  {
+    "name": "perl-Digest-HMAC",
+    "summary": "Keyed-Hashing for Message Authentication"
+  },
+  {
+    "name": "perl-Digest-MD5",
+    "summary": "Perl interface to the MD5 algorithm"
+  },
+  {
+    "name": "perl-Digest-SHA",
+    "summary": "Perl extension for SHA-1/224/256/384/512"
+  },
+  {
+    "name": "perl-Digest-SHA1",
+    "summary": "Digest-SHA1 Perl module"
+  },
+  {
+    "name": "perl-DirHandle",
+    "summary": "Supply object methods for directory handles"
+  },
+  {
+    "name": "perl-doc",
+    "summary": "Perl language documentation"
+  },
+  {
+    "name": "perl-Dumpvalue",
+    "summary": "Screen dump of Perl data"
+  },
+  {
+    "name": "perl-DynaLoader",
+    "summary": "Dynamically load C libraries into Perl code"
+  },
+  {
+    "name": "perl-Encode",
+    "summary": "Character encodings in Perl"
+  },
+  {
+    "name": "perl-Encode-Detect",
+    "summary": "Encode::Encoding subclass that detects the encoding of data"
+  },
+  {
+    "name": "perl-Encode-devel",
+    "summary": "Perl Encode Module Generator"
+  },
+  {
+    "name": "perl-Encode-Locale",
+    "summary": "Determine the locale encoding"
+  },
+  {
+    "name": "perl-encoding",
+    "summary": "Write your Perl script in non-ASCII or non-UTF-8"
+  },
+  {
+    "name": "perl-encoding-warnings",
+    "summary": "Warn on implicit encoding conversions"
+  },
+  {
+    "name": "perl-English",
+    "summary": "Nice English or awk names for ugly punctuation variables"
+  },
+  {
+    "name": "perl-Env",
+    "summary": "Perl module that imports environment variables as scalars or arrays"
+  },
+  {
+    "name": "perl-Errno",
+    "summary": "System errno constants"
+  },
+  {
+    "name": "perl-Error",
+    "summary": "Error/exception handling in an OO-ish way"
+  },
+  {
+    "name": "perl-experimental",
+    "summary": "Experimental features made easy"
+  },
+  {
+    "name": "perl-Exporter",
+    "summary": "Implements default import method for modules"
+  },
+  {
+    "name": "perl-Exporter-Tiny",
+    "summary": "An exporter with the features of Sub::Exporter but only core dependencies"
+  },
+  {
+    "name": "perl-ExtUtils-CBuilder",
+    "summary": "Compile and link C code for Perl modules"
+  },
+  {
+    "name": "perl-ExtUtils-Command",
+    "summary": "Perl routines to replace common UNIX commands in Makefiles"
+  },
+  {
+    "name": "perl-ExtUtils-Constant",
+    "summary": "Generate XS code to import C header constants"
+  },
+  {
+    "name": "perl-ExtUtils-Embed",
+    "summary": "Utilities for embedding Perl in C/C++ applications"
+  },
+  {
+    "name": "perl-ExtUtils-Install",
+    "summary": "Install Perl files from here to there"
+  },
+  {
+    "name": "perl-ExtUtils-MakeMaker",
+    "summary": "Create a module Makefile"
+  },
+  {
+    "name": "perl-ExtUtils-Manifest",
+    "summary": "Utilities to write and check a MANIFEST file"
+  },
+  {
+    "name": "perl-ExtUtils-Miniperl",
+    "summary": "Write the C code for perlmain.c"
+  },
+  {
+    "name": "perl-ExtUtils-MM-Utils",
+    "summary": "ExtUtils::MM methods without dependency on ExtUtils::MakeMaker"
+  },
+  {
+    "name": "perl-ExtUtils-ParseXS",
+    "summary": "Module and a script for converting Perl XS code into C code"
+  },
+  {
+    "name": "perl-FCGI",
+    "summary": "FastCGI Perl bindings"
+  },
+  {
+    "name": "perl-Fcntl",
+    "summary": "File operation options"
+  },
+  {
+    "name": "perl-Fedora-VSP",
+    "summary": "Perl version normalization for RPM"
+  },
+  {
+    "name": "perl-fields",
+    "summary": "Compile-time class fields"
+  },
+  {
+    "name": "perl-File-Basename",
+    "summary": "Parse file paths into directory, file name, and suffix"
+  },
+  {
+    "name": "perl-File-Compare",
+    "summary": "Compare files or file handles"
+  },
+  {
+    "name": "perl-File-Copy",
+    "summary": "Copy files or file handles"
+  },
+  {
+    "name": "perl-File-DosGlob",
+    "summary": "DOS-like globbing"
+  },
+  {
+    "name": "perl-File-Fetch",
+    "summary": "Generic file fetching mechanism"
+  },
+  {
+    "name": "perl-File-Find",
+    "summary": "Traverse a directory tree"
+  },
+  {
+    "name": "perl-File-HomeDir",
+    "summary": "Find your home and other directories on any platform"
+  },
+  {
+    "name": "perl-File-Listing",
+    "summary": "Parse directory listing"
+  },
+  {
+    "name": "perl-File-Path",
+    "summary": "Create or remove directory trees"
+  },
+  {
+    "name": "perl-File-pushd",
+    "summary": "Change directory temporarily for a limited scope"
+  },
+  {
+    "name": "perl-File-ShareDir",
+    "summary": "Locate per-dist and per-module shared files"
+  },
+  {
+    "name": "perl-File-Slurp",
+    "summary": "Efficient Reading/Writing of Complete Files"
+  },
+  {
+    "name": "perl-File-stat",
+    "summary": "By-name interface to Perl built-in stat functions"
+  },
+  {
+    "name": "perl-File-Temp",
+    "summary": "Return name and handle of a temporary file safely"
+  },
+  {
+    "name": "perl-File-Which",
+    "summary": "Portable implementation of the 'which' utility"
+  },
+  {
+    "name": "perl-FileCache",
+    "summary": "Keep more files open than the system permits"
+  },
+  {
+    "name": "perl-FileHandle",
+    "summary": "Object methods for file handles"
+  },
+  {
+    "name": "perl-filetest",
+    "summary": "Perl pragma to control the filetest permission operators"
+  },
+  {
+    "name": "perl-Filter",
+    "summary": "Perl source filters"
+  },
+  {
+    "name": "perl-Filter-Simple",
+    "summary": "Simplified Perl source filtering"
+  },
+  {
+    "name": "perl-FindBin",
+    "summary": "Locate a directory of an original Perl script"
+  },
+  {
+    "name": "perl-GDBM_File",
+    "summary": "Perl5 access to the gdbm library"
+  },
+  {
+    "name": "perl-generators",
+    "summary": "RPM Perl dependencies generators"
+  },
+  {
+    "name": "perl-Getopt-Long",
+    "summary": "Extended processing of command line options"
+  },
+  {
+    "name": "perl-Getopt-Std",
+    "summary": "Process single-character switches with switch clustering"
+  },
+  {
+    "name": "perl-Git",
+    "summary": "Perl interface to Git"
+  },
+  {
+    "name": "perl-Git-SVN",
+    "summary": "Perl interface to Git::SVN"
+  },
+  {
+    "name": "perl-GSSAPI",
+    "summary": "Perl extension providing access to the GSSAPIv2 library"
+  },
+  {
+    "name": "perl-Hash-Util",
+    "summary": "General-utility hash subroutines"
+  },
+  {
+    "name": "perl-Hash-Util-FieldHash",
+    "summary": "Support for inside-out classes"
+  },
+  {
+    "name": "perl-hivex",
+    "summary": "Perl bindings for hivex"
+  },
+  {
+    "name": "perl-HTML-Parser",
+    "summary": "Perl module for parsing HTML"
+  },
+  {
+    "name": "perl-HTML-Tagset",
+    "summary": "HTML::Tagset - data tables useful in parsing HTML"
+  },
+  {
+    "name": "perl-HTTP-Cookies",
+    "summary": "HTTP cookie jars"
+  },
+  {
+    "name": "perl-HTTP-Date",
+    "summary": "Date conversion routines"
+  },
+  {
+    "name": "perl-HTTP-Message",
+    "summary": "HTTP style message"
+  },
+  {
+    "name": "perl-HTTP-Negotiate",
+    "summary": "Choose a variant to serve"
+  },
+  {
+    "name": "perl-HTTP-Tiny",
+    "summary": "Small, simple, correct HTTP/1.1 client"
+  },
+  {
+    "name": "perl-I18N-Collate",
+    "summary": "Compare 8-bit scalar data according to the current locale"
+  },
+  {
+    "name": "perl-I18N-Langinfo",
+    "summary": "Query locale information"
+  },
+  {
+    "name": "perl-I18N-LangTags",
+    "summary": "Functions for dealing with RFC 3066 language tags"
+  },
+  {
+    "name": "perl-if",
+    "summary": "Use a Perl module if a condition holds"
+  },
+  {
+    "name": "perl-Importer",
+    "summary": "Alternative interface to modules that export symbols"
+  },
+  {
+    "name": "perl-inc-latest",
+    "summary": "Use modules bundled in inc/ if they are newer than installed ones"
+  },
+  {
+    "name": "perl-interpreter",
+    "summary": "Standalone executable Perl interpreter"
+  },
+  {
+    "name": "perl-IO",
+    "summary": "Perl input/output modules"
+  },
+  {
+    "name": "perl-IO-Compress",
+    "summary": "Read and write compressed data"
+  },
+  {
+    "name": "perl-IO-Compress-Lzma",
+    "summary": "Read and write lzma compressed data"
+  },
+  {
+    "name": "perl-IO-HTML",
+    "summary": "Open an HTML file with automatic character set detection"
+  },
+  {
+    "name": "perl-IO-Multiplex",
+    "summary": "Manage IO on many file handles"
+  },
+  {
+    "name": "perl-IO-Socket-INET6",
+    "summary": "Perl Object interface for AF_INET|AF_INET6 domain sockets"
+  },
+  {
+    "name": "perl-IO-Socket-IP",
+    "summary": "Drop-in replacement for IO::Socket::INET supporting both IPv4 and IPv6"
+  },
+  {
+    "name": "perl-IO-Socket-SSL",
+    "summary": "Perl library for transparent SSL"
+  },
+  {
+    "name": "perl-IO-Zlib",
+    "summary": "Perl IO:: style interface to Compress::Zlib"
+  },
+  {
+    "name": "perl-IPC-Cmd",
+    "summary": "Finding and running system commands made easy"
+  },
+  {
+    "name": "perl-IPC-Open3",
+    "summary": "Open a process for reading, writing, and error handling"
+  },
+  {
+    "name": "perl-IPC-System-Simple",
+    "summary": "Run commands simply, with detailed diagnostics"
+  },
+  {
+    "name": "perl-IPC-SysV",
+    "summary": "Object interface to System V IPC"
+  },
+  {
+    "name": "perl-JSON",
+    "summary": "Parse and convert to JSON (JavaScript Object Notation)"
+  },
+  {
+    "name": "perl-JSON-PP",
+    "summary": "JSON::XS compatible pure-Perl module"
+  },
+  {
+    "name": "perl-LDAP",
+    "summary": "LDAP Perl module"
+  },
+  {
+    "name": "perl-less",
+    "summary": "Perl pragma to request less of something"
+  },
+  {
+    "name": "perl-lib",
+    "summary": "Manipulate @INC at compile time"
+  },
+  {
+    "name": "perl-libintl-perl",
+    "summary": "Internationalization library for Perl, compatible with gettext"
+  },
+  {
+    "name": "perl-libnet",
+    "summary": "Perl clients for various network protocols"
+  },
+  {
+    "name": "perl-libnetcfg",
+    "summary": "Configure libnet"
+  },
+  {
+    "name": "perl-libs",
+    "summary": "The libraries for the perl run-time"
+  },
+  {
+    "name": "perl-libwww-perl",
+    "summary": "A Perl interface to the World-Wide Web"
+  },
+  {
+    "name": "perl-List-MoreUtils",
+    "summary": "Provide the stuff missing in List::Util"
+  },
+  {
+    "name": "perl-List-MoreUtils-XS",
+    "summary": "Provide compiled List::MoreUtils functions"
+  },
+  {
+    "name": "perl-local-lib",
+    "summary": "Create and use a local lib/ for perl modules"
+  },
+  {
+    "name": "perl-locale",
+    "summary": "Pragma to use or avoid POSIX locales for built-in operations"
+  },
+  {
+    "name": "perl-Locale-Maketext",
+    "summary": "Framework for localization"
+  },
+  {
+    "name": "perl-Locale-Maketext-Simple",
+    "summary": "Simple interface to Locale::Maketext::Lexicon"
+  },
+  {
+    "name": "perl-LWP-MediaTypes",
+    "summary": "Guess media type for a file or a URL"
+  },
+  {
+    "name": "perl-LWP-Protocol-https",
+    "summary": "Provide HTTPS support for LWP::UserAgent"
+  },
+  {
+    "name": "perl-macros",
+    "summary": "Macros for rpmbuild"
+  },
+  {
+    "name": "perl-Mail-AuthenticationResults",
+    "summary": "Object Oriented Authentication-Results Headers"
+  },
+  {
+    "name": "perl-Mail-DKIM",
+    "summary": "Sign and verify Internet mail with DKIM/DomainKey signatures"
+  },
+  {
+    "name": "perl-Mail-Sender",
+    "summary": "Module for sending mails with attachments through an SMTP server"
+  },
+  {
+    "name": "perl-Mail-SPF",
+    "summary": "Object-oriented implementation of Sender Policy Framework"
+  },
+  {
+    "name": "perl-MailTools",
+    "summary": "Various ancient mail-related perl modules"
+  },
+  {
+    "name": "perl-Math-BigInt",
+    "summary": "Arbitrary-size integer and float mathematics"
+  },
+  {
+    "name": "perl-Math-BigInt-FastCalc",
+    "summary": "Math::BigInt::Calc with some XS for more speed"
+  },
+  {
+    "name": "perl-Math-BigRat",
+    "summary": "Arbitrary big rational numbers"
+  },
+  {
+    "name": "perl-Math-Complex",
+    "summary": "Complex numbers and trigonometric functions"
+  },
+  {
+    "name": "perl-Memoize",
+    "summary": "Transparently speed up functions by caching return values"
+  },
+  {
+    "name": "perl-meta-notation",
+    "summary": "Change nonprintable characters below 0x100 into printables"
+  },
+  {
+    "name": "perl-MIME-Base64",
+    "summary": "Encoding and decoding of Base64 and quoted-printable strings"
+  },
+  {
+    "name": "perl-MIME-Charset",
+    "summary": "Charset Informations for MIME"
+  },
+  {
+    "name": "perl-Module-Build",
+    "summary": "Build and install Perl modules"
+  },
+  {
+    "name": "perl-Module-CoreList",
+    "summary": "What modules are shipped with versions of perl"
+  },
+  {
+    "name": "perl-Module-CoreList-tools",
+    "summary": "Tool for listing modules shipped with perl"
+  },
+  {
+    "name": "perl-Module-CPANfile",
+    "summary": "Parse cpanfile"
+  },
+  {
+    "name": "perl-Module-Load",
+    "summary": "Run-time require of both modules and files"
+  },
+  {
+    "name": "perl-Module-Load-Conditional",
+    "summary": "Looking up module information / loading at run-time"
+  },
+  {
+    "name": "perl-Module-Loaded",
+    "summary": "Mark modules as loaded or unloaded"
+  },
+  {
+    "name": "perl-Module-Metadata",
+    "summary": "Gather package and POD information from perl module files"
+  },
+  {
+    "name": "perl-Module-Signature",
+    "summary": "CPAN signature management utilities and modules"
+  },
+  {
+    "name": "perl-Mozilla-CA",
+    "summary": "Mozilla's CA certificate bundle in PEM format"
+  },
+  {
+    "name": "perl-mro",
+    "summary": "Method resolution order"
+  },
+  {
+    "name": "perl-MRO-Compat",
+    "summary": "Mro::* interface compatibility for Perls < 5.9.5"
+  },
+  {
+    "name": "perl-NDBM_File",
+    "summary": "Tied access to ndbm files"
+  },
+  {
+    "name": "perl-Net",
+    "summary": "By-name interface to Perl built-in network resolver"
+  },
+  {
+    "name": "perl-Net-CIDR-Lite",
+    "summary": "Perl extension for merging IPv4 or IPv6 CIDR addresses"
+  },
+  {
+    "name": "perl-Net-DNS",
+    "summary": "DNS resolver modules for Perl"
+  },
+  {
+    "name": "perl-Net-HTTP",
+    "summary": "Low-level HTTP connection (client)"
+  },
+  {
+    "name": "perl-Net-Ping",
+    "summary": "Check a remote host for reachability"
+  },
+  {
+    "name": "perl-Net-Server",
+    "summary": "Extensible, general Perl server engine"
+  },
+  {
+    "name": "perl-Net-SMTP-SSL",
+    "summary": "SSL support for Net::SMTP"
+  },
+  {
+    "name": "perl-Net-SSLeay",
+    "summary": "Perl extension for using OpenSSL"
+  },
+  {
+    "name": "perl-NetAddr-IP",
+    "summary": "Manages IPv4 and IPv6 addresses and subnets"
+  },
+  {
+    "name": "perl-NEXT",
+    "summary": "Pseudo-class that allows method redispatch"
+  },
+  {
+    "name": "perl-NTLM",
+    "summary": "NTLM Perl module"
+  },
+  {
+    "name": "perl-Object-HashBase",
+    "summary": "Build hash-based classes"
+  },
+  {
+    "name": "perl-ODBM_File",
+    "summary": "Tied access to odbm files"
+  },
+  {
+    "name": "perl-Opcode",
+    "summary": "Disable named opcodes when compiling a perl code"
+  },
+  {
+    "name": "perl-open",
+    "summary": "Perl pragma to set default PerlIO layers for input and output"
+  },
+  {
+    "name": "perl-overload",
+    "summary": "Overloading Perl operations"
+  },
+  {
+    "name": "perl-overloading",
+    "summary": "Perl pragma to lexically control overloading"
+  },
+  {
+    "name": "perl-Package-Generator",
+    "summary": "Generate new packages quickly and easily"
+  },
+  {
+    "name": "perl-Params-Check",
+    "summary": "Generic input parsing/checking mechanism"
+  },
+  {
+    "name": "perl-Params-Util",
+    "summary": "Simple standalone parameter-checking functions"
+  },
+  {
+    "name": "perl-parent",
+    "summary": "Establish an ISA relationship with base classes at compile time"
+  },
+  {
+    "name": "perl-Parse-PMFile",
+    "summary": "Parses .pm file as PAUSE does"
+  },
+  {
+    "name": "perl-PathTools",
+    "summary": "PathTools Perl module (Cwd, File::Spec)"
+  },
+  {
+    "name": "perl-PCP-LogImport",
+    "summary": "Performance Co-Pilot (PCP) Perl bindings for importing external data into PCP archives"
+  },
+  {
+    "name": "perl-PCP-LogSummary",
+    "summary": "Performance Co-Pilot (PCP) Perl bindings for post-processing output of pmlogsummary"
+  },
+  {
+    "name": "perl-PCP-MMV",
+    "summary": "Performance Co-Pilot (PCP) Perl bindings for PCP Memory Mapped Values"
+  },
+  {
+    "name": "perl-PCP-PMDA",
+    "summary": "Performance Co-Pilot (PCP) Perl bindings and documentation"
+  },
+  {
+    "name": "perl-Perl-OSType",
+    "summary": "Map Perl operating system names to generic types"
+  },
+  {
+    "name": "perl-perlfaq",
+    "summary": "Frequently asked questions about Perl"
+  },
+  {
+    "name": "perl-PerlIO-via-QuotedPrint",
+    "summary": "PerlIO layer for quoted-printable strings"
+  },
+  {
+    "name": "perl-ph",
+    "summary": "Selected system header files converted to Perl headers"
+  },
+  {
+    "name": "perl-Pod-Checker",
+    "summary": "Check POD documents for syntax errors"
+  },
+  {
+    "name": "perl-Pod-Escapes",
+    "summary": "Resolve POD escape sequences"
+  },
+  {
+    "name": "perl-Pod-Functions",
+    "summary": "Group Perl functions as in perlfunc POD"
+  },
+  {
+    "name": "perl-Pod-Html",
+    "summary": "Convert POD files to HTML"
+  },
+  {
+    "name": "perl-Pod-Perldoc",
+    "summary": "Look up Perl documentation in Pod format"
+  },
+  {
+    "name": "perl-Pod-Simple",
+    "summary": "Framework for parsing POD documentation"
+  },
+  {
+    "name": "perl-Pod-Usage",
+    "summary": "Print a usage message from embedded POD documentation"
+  },
+  {
+    "name": "perl-podlators",
+    "summary": "Format POD source into various output formats"
+  },
+  {
+    "name": "perl-POSIX",
+    "summary": "Perl interface to IEEE Std 1003.1"
+  },
+  {
+    "name": "perl-Safe",
+    "summary": "Compile and execute code in restricted compartments"
+  },
+  {
+    "name": "perl-Scalar-List-Utils",
+    "summary": "A selection of general-utility scalar and list subroutines"
+  },
+  {
+    "name": "perl-Search-Dict",
+    "summary": "Search for a key in a dictionary file"
+  },
+  {
+    "name": "perl-SelectSaver",
+    "summary": "Save and restore selected file handle"
+  },
+  {
+    "name": "perl-SelfLoader",
+    "summary": "Load functions only on demand"
+  },
+  {
+    "name": "perl-sigtrap",
+    "summary": "Perl pragma to enable simple signal handling"
+  },
+  {
+    "name": "perl-SNMP_Session",
+    "summary": "SNMP support for Perl 5"
+  },
+  {
+    "name": "perl-Socket",
+    "summary": "Networking constants and support functions"
+  },
+  {
+    "name": "perl-Socket6",
+    "summary": "IPv6 related part of the C socket.h defines and structure manipulators"
+  },
+  {
+    "name": "perl-Software-License",
+    "summary": "Package that provides templated software licenses"
+  },
+  {
+    "name": "perl-sort",
+    "summary": "Perl pragma to control sort() behavior"
+  },
+  {
+    "name": "perl-srpm-macros",
+    "summary": "RPM macros for building Perl source package from source repository"
+  },
+  {
+    "name": "perl-Storable",
+    "summary": "Persistence for Perl data structures"
+  },
+  {
+    "name": "perl-String-ShellQuote",
+    "summary": "Perl module for quoting strings for passing through the shell"
+  },
+  {
+    "name": "perl-Sub-Exporter",
+    "summary": "Sophisticated exporter for custom-built routines"
+  },
+  {
+    "name": "perl-Sub-Install",
+    "summary": "Install subroutines into packages easily"
+  },
+  {
+    "name": "perl-subs",
+    "summary": "Perl pragma to predeclare subroutine names"
+  },
+  {
+    "name": "perl-Symbol",
+    "summary": "Manipulate Perl symbols and their names"
+  },
+  {
+    "name": "perl-Sys-CPU",
+    "summary": "Getting CPU information"
+  },
+  {
+    "name": "perl-Sys-Guestfs",
+    "summary": "Perl bindings for libguestfs (Sys::Guestfs)"
+  },
+  {
+    "name": "perl-Sys-Hostname",
+    "summary": "Try every conceivable way to get a hostname"
+  },
+  {
+    "name": "perl-Sys-MemInfo",
+    "summary": "Memory information as Perl module"
+  },
+  {
+    "name": "perl-Sys-Syslog",
+    "summary": "Perl interface to the UNIX syslog(3) calls"
+  },
+  {
+    "name": "perl-Term-ANSIColor",
+    "summary": "Color screen output using ANSI escape sequences"
+  },
+  {
+    "name": "perl-Term-Cap",
+    "summary": "Perl termcap interface"
+  },
+  {
+    "name": "perl-Term-Complete",
+    "summary": "Perl word completion"
+  },
+  {
+    "name": "perl-Term-ReadLine",
+    "summary": "Perl interface to various read-line packages"
+  },
+  {
+    "name": "perl-Term-Size-Any",
+    "summary": "Retrieve terminal size"
+  },
+  {
+    "name": "perl-Term-Size-Perl",
+    "summary": "Perl extension for retrieving terminal size (Perl version)"
+  },
+  {
+    "name": "perl-Term-Table",
+    "summary": "Format a header and rows into a table"
+  },
+  {
+    "name": "perl-TermReadKey",
+    "summary": "A perl module for simple terminal control"
+  },
+  {
+    "name": "perl-Test",
+    "summary": "Simple framework for writing test scripts"
+  },
+  {
+    "name": "perl-Test-Harness",
+    "summary": "Run Perl standard test scripts with statistics"
+  },
+  {
+    "name": "perl-Test-Simple",
+    "summary": "Basic utilities for writing tests"
+  },
+  {
+    "name": "perl-Text-Abbrev",
+    "summary": "Create an abbreviation table from a list"
+  },
+  {
+    "name": "perl-Text-Balanced",
+    "summary": "Extract delimited text sequences from strings"
+  },
+  {
+    "name": "perl-Text-Diff",
+    "summary": "Perform diffs on files and record sets"
+  },
+  {
+    "name": "perl-Text-Glob",
+    "summary": "Perl module to match globbing patterns against text"
+  },
+  {
+    "name": "perl-Text-ParseWords",
+    "summary": "Parse text into an array of tokens or array of arrays"
+  },
+  {
+    "name": "perl-Text-Soundex",
+    "summary": "Implementation of the soundex algorithm"
+  },
+  {
+    "name": "perl-Text-Tabs+Wrap",
+    "summary": "Expand tabs and do simple line wrapping"
+  },
+  {
+    "name": "perl-Text-Template",
+    "summary": "Expand template text with embedded Perl"
+  },
+  {
+    "name": "perl-Text-Unidecode",
+    "summary": "US-ASCII transliterations of Unicode text"
+  },
+  {
+    "name": "perl-Thread",
+    "summary": "Manipulate threads in Perl (for old code only)"
+  },
+  {
+    "name": "perl-Thread-Queue",
+    "summary": "Thread-safe queues"
+  },
+  {
+    "name": "perl-Thread-Semaphore",
+    "summary": "Thread-safe semaphores"
+  },
+  {
+    "name": "perl-threads",
+    "summary": "Perl interpreter-based threads"
+  },
+  {
+    "name": "perl-threads-shared",
+    "summary": "Perl extension for sharing data structures between threads"
+  },
+  {
+    "name": "perl-Tie",
+    "summary": "Base classes for tying variables"
+  },
+  {
+    "name": "perl-Tie-File",
+    "summary": "Access the lines of a disk file via a Perl array"
+  },
+  {
+    "name": "perl-Tie-Memoize",
+    "summary": "Add data to a hash when needed"
+  },
+  {
+    "name": "perl-Tie-RefHash",
+    "summary": "Use references as hash keys"
+  },
+  {
+    "name": "perl-Time",
+    "summary": "By-name interface to Perl built-in time functions"
+  },
+  {
+    "name": "perl-Time-HiRes",
+    "summary": "High resolution alarm, sleep, gettimeofday, interval timers"
+  },
+  {
+    "name": "perl-Time-Local",
+    "summary": "Efficiently compute time from local and GMT time"
+  },
+  {
+    "name": "perl-Time-Piece",
+    "summary": "Time objects from localtime and gmtime"
+  },
+  {
+    "name": "perl-TimeDate",
+    "summary": "A Perl module for time and date manipulation"
+  },
+  {
+    "name": "perl-Tk",
+    "summary": "Perl Graphical User Interface ToolKit"
+  },
+  {
+    "name": "perl-Try-Tiny",
+    "summary": "Minimal try/catch with proper localization of $@"
+  },
+  {
+    "name": "perl-Unicode-Collate",
+    "summary": "Unicode Collation Algorithm"
+  },
+  {
+    "name": "perl-Unicode-LineBreak",
+    "summary": "UAX #14 Unicode Line Breaking Algorithm"
+  },
+  {
+    "name": "perl-Unicode-Normalize",
+    "summary": "Unicode Normalization Forms"
+  },
+  {
+    "name": "perl-Unicode-UCD",
+    "summary": "Unicode character database"
+  },
+  {
+    "name": "perl-Unix-Syslog",
+    "summary": "Perl interface to the UNIX syslog(3) calls"
+  },
+  {
+    "name": "perl-URI",
+    "summary": "A Perl module implementing URI parsing and manipulation"
+  },
+  {
+    "name": "perl-User-pwent",
+    "summary": "By-name interface to Perl built-in user name resolver"
+  },
+  {
+    "name": "perl-utils",
+    "summary": "Utilities packaged with the Perl distribution"
+  },
+  {
+    "name": "perl-vars",
+    "summary": "Perl pragma to predeclare global variable names"
+  },
+  {
+    "name": "perl-version",
+    "summary": "Perl extension for Version Objects"
+  },
+  {
+    "name": "perl-vmsish",
+    "summary": "Perl pragma to control VMS-specific language features"
+  },
+  {
+    "name": "perl-WWW-RobotRules",
+    "summary": "Database of robots.txt-derived permissions"
+  },
+  {
+    "name": "perl-XML-Catalog",
+    "summary": "Resolve public identifiers and remap system identifiers"
+  },
+  {
+    "name": "perl-XML-LibXML",
+    "summary": "Perl interface to the libxml2 library"
+  },
+  {
+    "name": "perl-XML-NamespaceSupport",
+    "summary": "A simple generic name space support class"
+  },
+  {
+    "name": "perl-XML-Parser",
+    "summary": "Perl module for parsing XML documents"
+  },
+  {
+    "name": "perl-XML-SAX",
+    "summary": "SAX parser access API for Perl"
+  },
+  {
+    "name": "perl-XML-SAX-Base",
+    "summary": "Base class SAX drivers and filters"
+  },
+  {
+    "name": "perl-XML-Simple",
+    "summary": "Easy API to maintain XML in Perl"
+  },
+  {
+    "name": "perl-XML-TokeParser",
+    "summary": "Simplified interface to XML::Parser"
+  },
+  {
+    "name": "perl-XML-XPath",
+    "summary": "XPath parser and evaluator for Perl"
+  },
+  {
+    "name": "perl-YAML",
+    "summary": "YAML Ain't Markup Language (tm)"
+  },
+  {
+    "name": "pesign",
+    "summary": "Signing utility for UEFI binaries"
+  },
+  {
+    "name": "pf-bb-config",
+    "summary": "PF BBDEV (baseband device) Configuration Application"
+  },
+  {
+    "name": "pg_repack",
+    "summary": "Reorganize tables in PostgreSQL databases without any locks"
+  },
+  {
+    "name": "pgaudit",
+    "summary": "PostgreSQL Audit Extension"
+  },
+  {
+    "name": "php",
+    "summary": "PHP scripting language for creating dynamic web sites"
+  },
+  {
+    "name": "php-bcmath",
+    "summary": "A module for PHP applications for using the bcmath library"
+  },
+  {
+    "name": "php-cli",
+    "summary": "Command-line interface for PHP"
+  },
+  {
+    "name": "php-common",
+    "summary": "Common files for PHP"
+  },
+  {
+    "name": "php-dba",
+    "summary": "A database abstraction layer module for PHP applications"
+  },
+  {
+    "name": "php-dbg",
+    "summary": "The interactive PHP debugger"
+  },
+  {
+    "name": "php-devel",
+    "summary": "Files needed for building PHP extensions"
+  },
+  {
+    "name": "php-embedded",
+    "summary": "PHP library for embedding in applications"
+  },
+  {
+    "name": "php-enchant",
+    "summary": "Enchant spelling extension for PHP applications"
+  },
+  {
+    "name": "php-ffi",
+    "summary": "Foreign Function Interface"
+  },
+  {
+    "name": "php-fpm",
+    "summary": "PHP FastCGI Process Manager"
+  },
+  {
+    "name": "php-gd",
+    "summary": "A module for PHP applications for using the gd graphics library"
+  },
+  {
+    "name": "php-gmp",
+    "summary": "A module for PHP applications for using the GNU MP library"
+  },
+  {
+    "name": "php-intl",
+    "summary": "Internationalization extension for PHP applications"
+  },
+  {
+    "name": "php-ldap",
+    "summary": "A module for PHP applications that use LDAP"
+  },
+  {
+    "name": "php-mbstring",
+    "summary": "A module for PHP applications which need multi-byte string handling"
+  },
+  {
+    "name": "php-mysqlnd",
+    "summary": "A module for PHP applications that use MySQL databases"
+  },
+  {
+    "name": "php-odbc",
+    "summary": "A module for PHP applications that use ODBC databases"
+  },
+  {
+    "name": "php-opcache",
+    "summary": "The Zend OPcache"
+  },
+  {
+    "name": "php-pdo",
+    "summary": "A database access abstraction module for PHP applications"
+  },
+  {
+    "name": "php-pear",
+    "summary": "PHP Extension and Application Repository framework"
+  },
+  {
+    "name": "php-pecl-apcu",
+    "summary": "APC User Cache"
+  },
+  {
+    "name": "php-pecl-apcu-devel",
+    "summary": "APCu developer files (header)"
+  },
+  {
+    "name": "php-pecl-rrd",
+    "summary": "PHP Bindings for rrdtool"
+  },
+  {
+    "name": "php-pecl-xdebug3",
+    "summary": "Provides functions for function traces and profiling"
+  },
+  {
+    "name": "php-pecl-zip",
+    "summary": "A ZIP archive management extension"
+  },
+  {
+    "name": "php-pgsql",
+    "summary": "A PostgreSQL database module for PHP"
+  },
+  {
+    "name": "php-process",
+    "summary": "Modules for PHP script using system process interfaces"
+  },
+  {
+    "name": "php-snmp",
+    "summary": "A module for PHP applications that query SNMP-managed devices"
+  },
+  {
+    "name": "php-soap",
+    "summary": "A module for PHP applications that use the SOAP protocol"
+  },
+  {
+    "name": "php-xml",
+    "summary": "A module for PHP applications which use XML"
+  },
+  {
+    "name": "pinentry",
+    "summary": "Collection of simple PIN or passphrase entry dialogs"
+  },
+  {
+    "name": "pinentry-gnome3",
+    "summary": "Passphrase/PIN entry dialog for GNOME 3"
+  },
+  {
+    "name": "pinentry-tty",
+    "summary": "Passphrase/PIN entry dialog in tty"
+  },
+  {
+    "name": "pinfo",
+    "summary": "An info file viewer"
+  },
+  {
+    "name": "pipewire",
+    "summary": "Media Sharing Server"
+  },
+  {
+    "name": "pipewire-alsa",
+    "summary": "PipeWire media server ALSA support"
+  },
+  {
+    "name": "pipewire-devel",
+    "summary": "Headers and libraries for PipeWire client development"
+  },
+  {
+    "name": "pipewire-gstreamer",
+    "summary": "GStreamer elements for PipeWire"
+  },
+  {
+    "name": "pipewire-jack-audio-connection-kit",
+    "summary": "PipeWire JACK implementation"
+  },
+  {
+    "name": "pipewire-jack-audio-connection-kit-devel",
+    "summary": "Development files for pipewire-jack-audio-connection-kit"
+  },
+  {
+    "name": "pipewire-jack-audio-connection-kit-libs",
+    "summary": "PipeWire JACK implementation libraries"
+  },
+  {
+    "name": "pipewire-libs",
+    "summary": "Libraries for PipeWire clients"
+  },
+  {
+    "name": "pipewire-module-x11",
+    "summary": "PipeWire media server x11 support"
+  },
+  {
+    "name": "pipewire-pulseaudio",
+    "summary": "PipeWire PulseAudio implementation"
+  },
+  {
+    "name": "pipewire-utils",
+    "summary": "PipeWire media server utilities"
+  },
+  {
+    "name": "pixman",
+    "summary": "Pixel manipulation library"
+  },
+  {
+    "name": "pixman-devel",
+    "summary": "Pixel manipulation library development package"
+  },
+  {
+    "name": "pkgconf",
+    "summary": "Package compiler and linker metadata toolkit"
+  },
+  {
+    "name": "pki-acme",
+    "summary": "PKI ACME Package"
+  },
+  {
+    "name": "pki-base",
+    "summary": "PKI Base Package"
+  },
+  {
+    "name": "pki-base-java",
+    "summary": "PKI Base Java Package"
+  },
+  {
+    "name": "pki-ca",
+    "summary": "PKI CA Package"
+  },
+  {
+    "name": "pki-jackson-annotations",
+    "summary": "Core annotations for Jackson data processor"
+  },
+  {
+    "name": "pki-jackson-core",
+    "summary": "Core part of Jackson"
+  },
+  {
+    "name": "pki-jackson-databind",
+    "summary": "General data-binding package for Jackson (2.x)"
+  },
+  {
+    "name": "pki-jackson-jaxrs-json-provider",
+    "summary": "Jackson-JAXRS-JSON"
+  },
+  {
+    "name": "pki-jackson-jaxrs-providers",
+    "summary": "Jackson JAX-RS providers"
+  },
+  {
+    "name": "pki-jackson-module-jaxb-annotations",
+    "summary": "Support for using JAXB annotations as an alternative to \"native\" Jackson annotations"
+  },
+  {
+    "name": "pki-kra",
+    "summary": "PKI KRA Package"
+  },
+  {
+    "name": "pki-resteasy",
+    "summary": "Framework for RESTful Web services and Java applications"
+  },
+  {
+    "name": "pki-resteasy-client",
+    "summary": "Client for resteasy"
+  },
+  {
+    "name": "pki-resteasy-core",
+    "summary": "Core modules for resteasy"
+  },
+  {
+    "name": "pki-resteasy-jackson2-provider",
+    "summary": "Module jackson2-provider for resteasy"
+  },
+  {
+    "name": "pki-resteasy-servlet-initializer",
+    "summary": "resteasy Servlet Initializer"
+  },
+  {
+    "name": "pki-server",
+    "summary": "PKI Server Package"
+  },
+  {
+    "name": "pki-servlet-4.0-api",
+    "summary": "Apache Tomcat Java Servlet v4.0 API Implementation Classes"
+  },
+  {
+    "name": "pki-servlet-engine",
+    "summary": "Apache Servlet/JSP Engine, RI for Servlet 4.0/JSP 2.3 API"
+  },
+  {
+    "name": "pki-symkey",
+    "summary": "PKI Symmetric Key Package"
+  },
+  {
+    "name": "pki-tools",
+    "summary": "PKI Tools Package"
+  },
+  {
+    "name": "plexus-cipher",
+    "summary": "Plexus Cipher: encryption/decryption Component"
+  },
+  {
+    "name": "plexus-classworlds",
+    "summary": "Plexus Classworlds Classloader Framework"
+  },
+  {
+    "name": "plexus-containers-component-annotations",
+    "summary": "Component API from plexus-containers"
+  },
+  {
+    "name": "plexus-interpolation",
+    "summary": "Plexus Interpolation API"
+  },
+  {
+    "name": "plexus-sec-dispatcher",
+    "summary": "Plexus Security Dispatcher Component"
+  },
+  {
+    "name": "plexus-utils",
+    "summary": "Plexus Common Utilities"
+  },
+  {
+    "name": "plotnetcfg",
+    "summary": "A tool to plot network configuration"
+  },
+  {
+    "name": "plotutils",
+    "summary": "GNU vector and raster graphics utilities and libraries"
+  },
+  {
+    "name": "plymouth",
+    "summary": "Graphical Boot Animation and Logger"
+  },
+  {
+    "name": "plymouth-core-libs",
+    "summary": "Plymouth core libraries"
+  },
+  {
+    "name": "plymouth-graphics-libs",
+    "summary": "Plymouth graphics libraries"
+  },
+  {
+    "name": "plymouth-plugin-fade-throbber",
+    "summary": "Plymouth \"Fade-Throbber\" plugin"
+  },
+  {
+    "name": "plymouth-plugin-label",
+    "summary": "Plymouth label plugin"
+  },
+  {
+    "name": "plymouth-plugin-script",
+    "summary": "Plymouth \"script\" plugin"
+  },
+  {
+    "name": "plymouth-plugin-space-flares",
+    "summary": "Plymouth \"space-flares\" plugin"
+  },
+  {
+    "name": "plymouth-plugin-two-step",
+    "summary": "Plymouth \"two-step\" plugin"
+  },
+  {
+    "name": "plymouth-scripts",
+    "summary": "Plymouth related scripts"
+  },
+  {
+    "name": "plymouth-system-theme",
+    "summary": "Plymouth default theme"
+  },
+  {
+    "name": "plymouth-theme-charge",
+    "summary": "Plymouth \"Charge\" plugin"
+  },
+  {
+    "name": "plymouth-theme-fade-in",
+    "summary": "Plymouth \"Fade-In\" theme"
+  },
+  {
+    "name": "plymouth-theme-script",
+    "summary": "Plymouth \"Script\" plugin"
+  },
+  {
+    "name": "plymouth-theme-solar",
+    "summary": "Plymouth \"Solar\" theme"
+  },
+  {
+    "name": "plymouth-theme-spinfinity",
+    "summary": "Plymouth \"Spinfinity\" theme"
+  },
+  {
+    "name": "plymouth-theme-spinner",
+    "summary": "Plymouth \"Spinner\" theme"
+  },
+  {
+    "name": "pmdk-convert",
+    "summary": "Conversion tool for PMDK pools"
+  },
+  {
+    "name": "pmempool",
+    "summary": "Utilities for Persistent Memory"
+  },
+  {
+    "name": "pmix",
+    "summary": "Process Management Interface Exascale (PMIx)"
+  },
+  {
+    "name": "pmix-devel",
+    "summary": "Development files for pmix"
+  },
+  {
+    "name": "pmix-pmi",
+    "summary": "The pmix implementation of libpmi and libpmi2"
+  },
+  {
+    "name": "pmix-tools",
+    "summary": "Tools for pmix"
+  },
+  {
+    "name": "pnm2ppa",
+    "summary": "Drivers for printing to HP PPA printers"
+  },
+  {
+    "name": "podman",
+    "summary": "Manage Pods, Containers and Container Images"
+  },
+  {
+    "name": "podman-catatonit",
+    "summary": "A signal-forwarding process manager for containers"
+  },
+  {
+    "name": "podman-docker",
+    "summary": "Emulate Docker CLI using podman"
+  },
+  {
+    "name": "podman-gvproxy",
+    "summary": "Go replacement for libslirp and VPNKit"
+  },
+  {
+    "name": "podman-plugins",
+    "summary": "Plugins for podman"
+  },
+  {
+    "name": "podman-remote",
+    "summary": "A remote CLI for Podman: A Simple management tool for pods, containers and images"
+  },
+  {
+    "name": "podman-tests",
+    "summary": "Tests for podman"
+  },
+  {
+    "name": "policycoreutils-dbus",
+    "summary": "SELinux policy core DBUS api"
+  },
+  {
+    "name": "policycoreutils-devel",
+    "summary": "SELinux policy core policy devel utilities"
+  },
+  {
+    "name": "policycoreutils-gui",
+    "summary": "SELinux configuration GUI"
+  },
+  {
+    "name": "policycoreutils-python-utils",
+    "summary": "SELinux policy core python utilities"
+  },
+  {
+    "name": "policycoreutils-sandbox",
+    "summary": "SELinux sandbox utilities"
+  },
+  {
+    "name": "polkit-devel",
+    "summary": "Development files for polkit"
+  },
+  {
+    "name": "polkit-docs",
+    "summary": "Development documentation for polkit"
+  },
+  {
+    "name": "poppler",
+    "summary": "PDF rendering library"
+  },
+  {
+    "name": "poppler-cpp",
+    "summary": "Pure C++ wrapper for poppler"
+  },
+  {
+    "name": "poppler-data",
+    "summary": "Encoding files for use with poppler"
+  },
+  {
+    "name": "poppler-glib",
+    "summary": "Glib wrapper for poppler"
+  },
+  {
+    "name": "poppler-qt5",
+    "summary": "Qt5 wrapper for poppler"
+  },
+  {
+    "name": "poppler-utils",
+    "summary": "Command line utilities for converting PDF files"
+  },
+  {
+    "name": "popt-devel",
+    "summary": "Development files for the popt library"
+  },
+  {
+    "name": "postfix",
+    "summary": "Postfix Mail Transport Agent"
+  },
+  {
+    "name": "postfix-cdb",
+    "summary": "Postfix CDB map support"
+  },
+  {
+    "name": "postfix-ldap",
+    "summary": "Postfix LDAP map support"
+  },
+  {
+    "name": "postfix-lmdb",
+    "summary": "Postfix LDMB map support"
+  },
+  {
+    "name": "postfix-mysql",
+    "summary": "Postfix MySQL map support"
+  },
+  {
+    "name": "postfix-pcre",
+    "summary": "Postfix PCRE map support"
+  },
+  {
+    "name": "postfix-perl-scripts",
+    "summary": "Postfix utilities written in perl"
+  },
+  {
+    "name": "postfix-pgsql",
+    "summary": "Postfix PostgreSQL map support"
+  },
+  {
+    "name": "postfix-sqlite",
+    "summary": "Postfix SQLite map support"
+  },
+  {
+    "name": "postgres-decoderbufs",
+    "summary": "PostgreSQL Protocol Buffers logical decoder plugin"
+  },
+  {
+    "name": "postgresql",
+    "summary": "PostgreSQL client programs"
+  },
+  {
+    "name": "postgresql-contrib",
+    "summary": "Extension modules distributed with PostgreSQL"
+  },
+  {
+    "name": "postgresql-jdbc",
+    "summary": "JDBC driver for PostgreSQL"
+  },
+  {
+    "name": "postgresql-odbc",
+    "summary": "PostgreSQL ODBC driver"
+  },
+  {
+    "name": "postgresql-plperl",
+    "summary": "The Perl procedural language for PostgreSQL"
+  },
+  {
+    "name": "postgresql-plpython3",
+    "summary": "The Python3 procedural language for PostgreSQL"
+  },
+  {
+    "name": "postgresql-pltcl",
+    "summary": "The Tcl procedural language for PostgreSQL"
+  },
+  {
+    "name": "postgresql-private-libs",
+    "summary": "The shared libraries required only for this build of PostgreSQL server"
+  },
+  {
+    "name": "postgresql-server",
+    "summary": "The programs needed to create and run a PostgreSQL server"
+  },
+  {
+    "name": "postgresql-upgrade",
+    "summary": "Support for upgrading from the previous major release of PostgreSQL"
+  },
+  {
+    "name": "potrace",
+    "summary": "Transform bitmaps into vector graphics"
+  },
+  {
+    "name": "power-profiles-daemon",
+    "summary": "Makes power profiles handling available over D-Bus"
+  },
+  {
+    "name": "powertop",
+    "summary": "Power consumption monitor"
+  },
+  {
+    "name": "pptp",
+    "summary": "Point-to-Point Tunneling Protocol (PPTP) Client"
+  },
+  {
+    "name": "procmail",
+    "summary": "Mail processing program"
+  },
+  {
+    "name": "protobuf",
+    "summary": "Protocol Buffers - Google's data interchange format"
+  },
+  {
+    "name": "protobuf-c",
+    "summary": "C bindings for Google's Protocol Buffers"
+  },
+  {
+    "name": "protobuf-lite",
+    "summary": "Protocol Buffers LITE_RUNTIME libraries"
+  },
+  {
+    "name": "ps_mem",
+    "summary": "Memory profiling tool"
+  },
+  {
+    "name": "pt-sans-fonts",
+    "summary": "PT Sans, a grotesque pan-Cyrillic font family"
+  },
+  {
+    "name": "publicsuffix-list",
+    "summary": "Cross-vendor public domain suffix database"
+  },
+  {
+    "name": "pulseaudio",
+    "summary": "Improved Linux Sound Server"
+  },
+  {
+    "name": "pulseaudio-libs",
+    "summary": "Libraries for PulseAudio clients"
+  },
+  {
+    "name": "pulseaudio-libs-devel",
+    "summary": "Headers and libraries for PulseAudio client development"
+  },
+  {
+    "name": "pulseaudio-libs-glib2",
+    "summary": "GLIB 2.x bindings for PulseAudio clients"
+  },
+  {
+    "name": "pulseaudio-module-bluetooth",
+    "summary": "Bluetooth support for the PulseAudio sound server"
+  },
+  {
+    "name": "pulseaudio-module-x11",
+    "summary": "X11 support for the PulseAudio sound server"
+  },
+  {
+    "name": "pulseaudio-utils",
+    "summary": "PulseAudio sound server utilities"
+  },
+  {
+    "name": "pykickstart",
+    "summary": "Python utilities for manipulating kickstart files."
+  },
+  {
+    "name": "pyproject-srpm-macros",
+    "summary": "Minimal implementation of %pyproject_buildrequires"
+  },
+  {
+    "name": "python-cups-doc",
+    "summary": "Documentation for python-cups"
+  },
+  {
+    "name": "python-qt5-rpm-macros",
+    "summary": "RPM macros python-qt5"
+  },
+  {
+    "name": "python-rpm-macros",
+    "summary": "The common Python RPM macros"
+  },
+  {
+    "name": "python-srpm-macros",
+    "summary": "RPM macros for building Python source packages"
+  },
+  {
+    "name": "python-unversioned-command",
+    "summary": "The \"python\" command that runs Python 3"
+  },
+  {
+    "name": "python3-alembic",
+    "summary": "Database migration tool for SQLAlchemy"
+  },
+  {
+    "name": "python3-appdirs",
+    "summary": "Python module for determining platform-specific directories"
+  },
+  {
+    "name": "python3-argcomplete",
+    "summary": "Bash tab completion for argparse"
+  },
+  {
+    "name": "python3-attrs",
+    "summary": "Python attributes without boilerplate"
+  },
+  {
+    "name": "python3-audit",
+    "summary": "Python3 bindings for libaudit"
+  },
+  {
+    "name": "python3-augeas",
+    "summary": "Python 3 bindings to augeas"
+  },
+  {
+    "name": "python3-awscrt",
+    "summary": "Python bindings for the AWS Common Runtime"
+  },
+  {
+    "name": "python3-babel",
+    "summary": "Library for internationalizing Python applications"
+  },
+  {
+    "name": "python3-bcc",
+    "summary": "Python3 bindings for BPF Compiler Collection (BCC)"
+  },
+  {
+    "name": "python3-bind",
+    "summary": "A module allowing rndc commands to be sent from Python programs"
+  },
+  {
+    "name": "python3-blivet",
+    "summary": "A python3 package for examining and modifying storage configuration."
+  },
+  {
+    "name": "python3-blockdev",
+    "summary": "Python3 gobject-introspection bindings for libblockdev"
+  },
+  {
+    "name": "python3-boom",
+    "summary": "A set of libraries and tools for managing boot loader entries"
+  },
+  {
+    "name": "python3-brlapi",
+    "summary": "Python 3 binding for BrlAPI"
+  },
+  {
+    "name": "python3-brotli",
+    "summary": "Lossless compression algorithm (python 3)"
+  },
+  {
+    "name": "python3-bytesize",
+    "summary": "Python 3 bindings for libbytesize"
+  },
+  {
+    "name": "python3-cairo",
+    "summary": "Python 3 bindings for the cairo library"
+  },
+  {
+    "name": "python3-cepces",
+    "summary": "Python part of cepces"
+  },
+  {
+    "name": "python3-cffi",
+    "summary": "Foreign Function Interface for Python 3 to call C code"
+  },
+  {
+    "name": "python3-clang",
+    "summary": "Python3 bindings for clang"
+  },
+  {
+    "name": "python3-colorama",
+    "summary": "Cross-platform colored terminal text"
+  },
+  {
+    "name": "python3-configobj",
+    "summary": "Config file reading, writing, and validation"
+  },
+  {
+    "name": "python3-createrepo_c",
+    "summary": "Python 3 bindings for the createrepo_c library"
+  },
+  {
+    "name": "python3-criu",
+    "summary": "Python bindings for criu"
+  },
+  {
+    "name": "python3-cryptography",
+    "summary": "PyCA's cryptography library"
+  },
+  {
+    "name": "python3-cups",
+    "summary": "Python3 bindings for CUPS API, known as pycups."
+  },
+  {
+    "name": "python3-dasbus",
+    "summary": "DBus library in Python 3"
+  },
+  {
+    "name": "python3-dbus-client-gen",
+    "summary": "Library for Generating D-Bus Client Code"
+  },
+  {
+    "name": "python3-dbus-python-client-gen",
+    "summary": "Python Library for Generating dbus-python Client Code"
+  },
+  {
+    "name": "python3-dbus-signature-pyparsing",
+    "summary": "Parser for a D-Bus Signature"
+  },
+  {
+    "name": "python3-devel",
+    "summary": "Libraries and header files needed for Python development"
+  },
+  {
+    "name": "python3-distro",
+    "summary": "Linux Distribution - a Linux OS platform information API"
+  },
+  {
+    "name": "python3-dnf-plugin-leaves",
+    "summary": "Leaves Plugin for DNF"
+  },
+  {
+    "name": "python3-dnf-plugin-modulesync",
+    "summary": "Download module metadata and packages and create repository"
+  },
+  {
+    "name": "python3-dnf-plugin-show-leaves",
+    "summary": "Show-leaves Plugin for DNF"
+  },
+  {
+    "name": "python3-docutils",
+    "summary": "System for processing plaintext documentation"
+  },
+  {
+    "name": "python3-enchant",
+    "summary": "Python 3 bindings for Enchant spellchecking library"
+  },
+  {
+    "name": "python3-file-magic",
+    "summary": "Python 3 bindings for the libmagic API"
+  },
+  {
+    "name": "python3-freeradius",
+    "summary": "Python 3 support for freeradius"
+  },
+  {
+    "name": "python3-gluster",
+    "summary": "GlusterFS python library"
+  },
+  {
+    "name": "python3-gobject",
+    "summary": "Python 3 bindings for GObject Introspection"
+  },
+  {
+    "name": "python3-greenlet",
+    "summary": "Lightweight in-process concurrent programming"
+  },
+  {
+    "name": "python3-gssapi",
+    "summary": "Python 3 Bindings for GSSAPI (RFC 2743/2744 and extensions)"
+  },
+  {
+    "name": "python3-i2c-tools",
+    "summary": "Python 3 bindings for Linux SMBus access through i2c-dev"
+  },
+  {
+    "name": "python3-idm-pki",
+    "summary": "IDM PKI Python 3 Package"
+  },
+  {
+    "name": "python3-imath",
+    "summary": "Python module for Imath"
+  },
+  {
+    "name": "python3-iniconfig",
+    "summary": "Brain-dead simple parsing of ini files"
+  },
+  {
+    "name": "python3-into-dbus-python",
+    "summary": "Transformer to dbus-python types"
+  },
+  {
+    "name": "python3-ipaclient",
+    "summary": "Python libraries used by IPA client"
+  },
+  {
+    "name": "python3-ipalib",
+    "summary": "Python3 libraries used by IPA"
+  },
+  {
+    "name": "python3-ipaserver",
+    "summary": "Python libraries used by IPA server"
+  },
+  {
+    "name": "python3-iscsi-initiator-utils",
+    "summary": "Python 3.9 bindings to iscsi-initiator-utils"
+  },
+  {
+    "name": "python3-jinja2",
+    "summary": "General purpose template engine for python3"
+  },
+  {
+    "name": "python3-jmespath",
+    "summary": "JSON Matching Expressions"
+  },
+  {
+    "name": "python3-jsonpatch",
+    "summary": "Applying JSON Patches in Python 3"
+  },
+  {
+    "name": "python3-jsonpointer",
+    "summary": "Resolve JSON Pointers in Python"
+  },
+  {
+    "name": "python3-jsonschema",
+    "summary": "Implementation of JSON Schema validation for Python"
+  },
+  {
+    "name": "python3-justbases",
+    "summary": "A small library for precise conversion between arbitrary bases"
+  },
+  {
+    "name": "python3-justbytes",
+    "summary": "Library for handling computation with address ranges in bytes"
+  },
+  {
+    "name": "python3-jwcrypto",
+    "summary": "Implements JWK, JWS, JWE specifications using python-cryptography"
+  },
+  {
+    "name": "python3-kdcproxy",
+    "summary": "MS-KKDCP (kerberos proxy) WSGI module"
+  },
+  {
+    "name": "python3-keycloak-httpd-client-install",
+    "summary": "Tools to configure Apache HTTPD as Keycloak client"
+  },
+  {
+    "name": "python3-keylime",
+    "summary": "The Python Keylime module"
+  },
+  {
+    "name": "python3-kickstart",
+    "summary": "Python 3 library for manipulating kickstart files."
+  },
+  {
+    "name": "python3-langtable",
+    "summary": "Python module to query the langtable-data"
+  },
+  {
+    "name": "python3-lark-parser",
+    "summary": "Lark is a modern general-purpose parsing library for Python"
+  },
+  {
+    "name": "python3-lasso",
+    "summary": "Liberty Alliance Single Sign On (lasso) Python bindings"
+  },
+  {
+    "name": "python3-ldap",
+    "summary": "An object-oriented API to access LDAP directory servers"
+  },
+  {
+    "name": "python3-leapp",
+    "summary": "OS & Application modernization framework"
+  },
+  {
+    "name": "python3-lib389",
+    "summary": "A library for accessing, testing, and configuring the 389 Directory Server"
+  },
+  {
+    "name": "python3-libevdev",
+    "summary": "Python bindings to the libevdev evdev device wrapper library"
+  },
+  {
+    "name": "python3-libgpiod",
+    "summary": "Python 3 bindings for libgpiod"
+  },
+  {
+    "name": "python3-libguestfs",
+    "summary": "Python 3 bindings for libguestfs"
+  },
+  {
+    "name": "python3-libmodulemd",
+    "summary": "Python 3 bindings for libmodulemd"
+  },
+  {
+    "name": "python3-libmount",
+    "summary": "Python bindings for the libmount library"
+  },
+  {
+    "name": "python3-libnbd",
+    "summary": "Python 3 bindings for libnbd"
+  },
+  {
+    "name": "python3-libnmstate",
+    "summary": "nmstate Python 3 API library"
+  },
+  {
+    "name": "python3-libnvme",
+    "summary": "Python3 bindings for libnvme"
+  },
+  {
+    "name": "python3-libproxy",
+    "summary": "Binding for libproxy and python3"
+  },
+  {
+    "name": "python3-libreport",
+    "summary": "Python 3 bindings for report-libs"
+  },
+  {
+    "name": "python3-libselinux",
+    "summary": "SELinux python 3 bindings for libselinux"
+  },
+  {
+    "name": "python3-libsemanage",
+    "summary": "semanage python 3 bindings for libsemanage"
+  },
+  {
+    "name": "python3-libstoragemgmt",
+    "summary": "Python 3 client libraries and plug-in support for libstoragemgmt"
+  },
+  {
+    "name": "python3-libvirt",
+    "summary": "The libvirt virtualization API python3 binding"
+  },
+  {
+    "name": "python3-libvoikko",
+    "summary": "Python interface to libvoikko"
+  },
+  {
+    "name": "python3-lit",
+    "summary": "LLVM lit test runner for Python 3"
+  },
+  {
+    "name": "python3-lldb",
+    "summary": "Python module for LLDB"
+  },
+  {
+    "name": "python3-louis",
+    "summary": "Python 3 language bindings for liblouis"
+  },
+  {
+    "name": "python3-lxml",
+    "summary": "XML processing library combining libxml2/libxslt with the ElementTree API"
+  },
+  {
+    "name": "python3-mako",
+    "summary": "Mako template library for Python"
+  },
+  {
+    "name": "python3-markupsafe",
+    "summary": "Implements a XML/HTML/XHTML Markup safe string for Python 3"
+  },
+  {
+    "name": "python3-meh",
+    "summary": "A python 3 library for handling exceptions"
+  },
+  {
+    "name": "python3-meh-gui",
+    "summary": "Graphical user interface for the python3-meh library"
+  },
+  {
+    "name": "python3-mod_wsgi",
+    "summary": "A WSGI interface for Python web applications in Apache"
+  },
+  {
+    "name": "python3-net-snmp",
+    "summary": "The Python 'netsnmp' module for the Net-SNMP"
+  },
+  {
+    "name": "python3-netaddr",
+    "summary": "A pure Python network address representation and manipulation library"
+  },
+  {
+    "name": "python3-netifaces",
+    "summary": "Python 3 library to retrieve information about network interfaces"
+  },
+  {
+    "name": "python3-networkx",
+    "summary": "Creates and Manipulates Graphs and Networks"
+  },
+  {
+    "name": "python3-newt",
+    "summary": "Python 3 bindings for newt"
+  },
+  {
+    "name": "python3-nispor",
+    "summary": "API for network status querying"
+  },
+  {
+    "name": "python3-numpy",
+    "summary": "A fast multidimensional array facility for Python"
+  },
+  {
+    "name": "python3-numpy-f2py",
+    "summary": "f2py for numpy"
+  },
+  {
+    "name": "python3-oauthlib",
+    "summary": "An implementation of the OAuth request-signing logic"
+  },
+  {
+    "name": "python3-osbuild",
+    "summary": "A build system for OS images"
+  },
+  {
+    "name": "python3-packaging",
+    "summary": "Core utilities for Python packages"
+  },
+  {
+    "name": "python3-pcp",
+    "summary": "Performance Co-Pilot (PCP) Python3 bindings and documentation"
+  },
+  {
+    "name": "python3-pefile",
+    "summary": "Python PE parsing module"
+  },
+  {
+    "name": "python3-perf",
+    "summary": "Python bindings for apps which will manipulate perf events"
+  },
+  {
+    "name": "python3-pid",
+    "summary": "PID file management library"
+  },
+  {
+    "name": "python3-pip",
+    "summary": "A tool for installing and managing Python3 packages"
+  },
+  {
+    "name": "python3-pki",
+    "summary": "PKI Python 3 Package"
+  },
+  {
+    "name": "python3-pluggy",
+    "summary": "The plugin manager stripped of pytest specific details"
+  },
+  {
+    "name": "python3-ply",
+    "summary": "Python Lex-Yacc"
+  },
+  {
+    "name": "python3-podman",
+    "summary": "RESTful API for Podman"
+  },
+  {
+    "name": "python3-policycoreutils",
+    "summary": "SELinux policy core python3 interfaces"
+  },
+  {
+    "name": "python3-prettytable",
+    "summary": "Python library to display tabular data in tables"
+  },
+  {
+    "name": "python3-productmd",
+    "summary": "Library providing parsers for metadata related to OS installation"
+  },
+  {
+    "name": "python3-prompt-toolkit",
+    "summary": "Library for building powerful interactive command line applications in Python"
+  },
+  {
+    "name": "python3-protobuf",
+    "summary": "Python 3 bindings for Google Protocol Buffers"
+  },
+  {
+    "name": "python3-psutil",
+    "summary": "A process and system utilities module for Python"
+  },
+  {
+    "name": "python3-psycopg2",
+    "summary": "A PostgreSQL database adapter for Python 3"
+  },
+  {
+    "name": "python3-pwquality",
+    "summary": "Python bindings for the libpwquality library"
+  },
+  {
+    "name": "python3-py",
+    "summary": "Library with cross-python path, ini-parsing, io, code, log facilities"
+  },
+  {
+    "name": "python3-pyasn1",
+    "summary": "ASN.1 tools for Python 3"
+  },
+  {
+    "name": "python3-pyasn1-modules",
+    "summary": "Modules for pyasn1"
+  },
+  {
+    "name": "python3-pyatspi",
+    "summary": "Python3 bindings for at-spi"
+  },
+  {
+    "name": "python3-pycdlib",
+    "summary": "A pure python ISO9660 read and write library"
+  },
+  {
+    "name": "python3-pycparser",
+    "summary": "C parser and AST generator written in Python"
+  },
+  {
+    "name": "python3-pycurl",
+    "summary": "Python interface to libcurl for Python 3"
+  },
+  {
+    "name": "python3-pyelftools",
+    "summary": "Pure-Python library for parsing and analyzing ELF files"
+  },
+  {
+    "name": "python3-pyghmi",
+    "summary": "Python General Hardware Management Initiative (IPMI and others)"
+  },
+  {
+    "name": "python3-PyMySQL",
+    "summary": "Pure-Python MySQL client library"
+  },
+  {
+    "name": "python3-pyodbc",
+    "summary": "Python DB API 2.0 Module for ODBC"
+  },
+  {
+    "name": "python3-pyparted",
+    "summary": "Python 3 module for GNU parted"
+  },
+  {
+    "name": "python3-pyqt5-sip",
+    "summary": "SIP - Python 3/C++ Bindings Generator for pyqt5"
+  },
+  {
+    "name": "python3-pyrsistent",
+    "summary": "Persistent/Functional/Immutable data structures"
+  },
+  {
+    "name": "python3-pyserial",
+    "summary": "Python serial port access library"
+  },
+  {
+    "name": "python3-pytest",
+    "summary": "Simple powerful testing with Python"
+  },
+  {
+    "name": "python3-pytz",
+    "summary": "World Timezone Definitions for Python"
+  },
+  {
+    "name": "python3-pyusb",
+    "summary": "Python bindings for libusb"
+  },
+  {
+    "name": "python3-pyverbs",
+    "summary": "Python3 API over IB verbs"
+  },
+  {
+    "name": "python3-pywbem",
+    "summary": "Python3 WBEM Client and Provider Interface"
+  },
+  {
+    "name": "python3-pyxdg",
+    "summary": "Python3 library to access freedesktop.org standards"
+  },
+  {
+    "name": "python3-qrcode-core",
+    "summary": "Python 3 QR Code image generator (core library)"
+  },
+  {
+    "name": "python3-qt5",
+    "summary": "Python 3 bindings for Qt5"
+  },
+  {
+    "name": "python3-qt5-base",
+    "summary": "Python 3 bindings for Qt5 base"
+  },
+  {
+    "name": "python3-requests+security",
+    "summary": "Metapackage for python3-requests: security extras"
+  },
+  {
+    "name": "python3-requests+socks",
+    "summary": "Metapackage for python3-requests: socks extras"
+  },
+  {
+    "name": "python3-requests-file",
+    "summary": "Transport adapter for using file:// URLs with python3-requests"
+  },
+  {
+    "name": "python3-requests-ftp",
+    "summary": "FTP transport adapter for python3-requests"
+  },
+  {
+    "name": "python3-requests-gssapi",
+    "summary": "A GSSAPI/SPNEGO authentication handler for python-requests"
+  },
+  {
+    "name": "python3-requests-oauthlib",
+    "summary": "OAuthlib authentication support for Requests."
+  },
+  {
+    "name": "python3-resolvelib",
+    "summary": "Resolve abstract dependencies into concrete ones"
+  },
+  {
+    "name": "python3-rpm-generators",
+    "summary": "Dependency generators for Python RPMs"
+  },
+  {
+    "name": "python3-rpm-macros",
+    "summary": "RPM macros for building Python 3 packages"
+  },
+  {
+    "name": "python3-rtslib",
+    "summary": "API for Linux kernel LIO SCSI target"
+  },
+  {
+    "name": "python3-ruamel-yaml",
+    "summary": "YAML 1.2 loader/dumper package for Python"
+  },
+  {
+    "name": "python3-ruamel-yaml-clib",
+    "summary": "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+  },
+  {
+    "name": "python3-sanlock",
+    "summary": "Python bindings for the sanlock library"
+  },
+  {
+    "name": "python3-scapy",
+    "summary": "Interactive packet manipulation tool and network scanner"
+  },
+  {
+    "name": "python3-scipy",
+    "summary": "Scientific Tools for Python"
+  },
+  {
+    "name": "python3-scour",
+    "summary": "An SVG scrubber"
+  },
+  {
+    "name": "python3-simpleline",
+    "summary": "A Python3 library for creating text UI"
+  },
+  {
+    "name": "python3-snapm",
+    "summary": "A set of tools for managing snapshots"
+  },
+  {
+    "name": "python3-snapm-doc",
+    "summary": "A set of tools for managing snapshots"
+  },
+  {
+    "name": "python3-solv",
+    "summary": "Python bindings for the libsolv library"
+  },
+  {
+    "name": "python3-speechd",
+    "summary": "Python 3 Client API for speech-dispatcher"
+  },
+  {
+    "name": "python3-sqlalchemy",
+    "summary": "Modular and flexible ORM library for Python"
+  },
+  {
+    "name": "python3-subversion",
+    "summary": "Python bindings for Subversion Version Control system"
+  },
+  {
+    "name": "python3-tbb",
+    "summary": "Python 3 TBB module"
+  },
+  {
+    "name": "python3-tdb",
+    "summary": "Python3 bindings for the Tdb library"
+  },
+  {
+    "name": "python3-tkinter",
+    "summary": "A GUI toolkit for Python"
+  },
+  {
+    "name": "python3-toml",
+    "summary": "Python Library for Tom's Obvious, Minimal Language"
+  },
+  {
+    "name": "python3-tomli",
+    "summary": "A little TOML parser for Python"
+  },
+  {
+    "name": "python3-tornado",
+    "summary": "Scalable, non-blocking web server and tools"
+  },
+  {
+    "name": "python3-tracer",
+    "summary": "Common files for tracer"
+  },
+  {
+    "name": "python3-unbound",
+    "summary": "Python 3 modules and extensions for unbound"
+  },
+  {
+    "name": "python3-urllib-gssapi",
+    "summary": "A GSSAPI/SPNEGO authentication handler for urllib/urllib2"
+  },
+  {
+    "name": "python3-virt-firmware",
+    "summary": "Tools for virtual machine firmware volumes"
+  },
+  {
+    "name": "python3-volume_key",
+    "summary": "Python 3 bindings for libvolume_key"
+  },
+  {
+    "name": "python3-wcwidth",
+    "summary": "Measures number of Terminal column cells of wide-character codes"
+  },
+  {
+    "name": "python3-websockets",
+    "summary": "Implementation of the WebSocket Protocol for Python"
+  },
+  {
+    "name": "python3-wx-siplib",
+    "summary": "SIP - Python 3/C++ Bindings Generator for wx"
+  },
+  {
+    "name": "python3-yubico",
+    "summary": "Pure-python library for interacting with Yubikeys"
+  },
+  {
+    "name": "python3.11",
+    "summary": "Version 3.11 of the Python interpreter"
+  },
+  {
+    "name": "python3.11-cffi",
+    "summary": "Foreign Function Interface for Python to call C code"
+  },
+  {
+    "name": "python3.11-charset-normalizer",
+    "summary": "The Real First Universal Charset Detector"
+  },
+  {
+    "name": "python3.11-cryptography",
+    "summary": "PyCA's cryptography library"
+  },
+  {
+    "name": "python3.11-devel",
+    "summary": "Libraries and header files needed for Python development"
+  },
+  {
+    "name": "python3.11-idna",
+    "summary": "Internationalized Domain Names in Applications (IDNA)"
+  },
+  {
+    "name": "python3.11-libs",
+    "summary": "Python runtime libraries"
+  },
+  {
+    "name": "python3.11-lxml",
+    "summary": "XML processing library combining libxml2/libxslt with the ElementTree API"
+  },
+  {
+    "name": "python3.11-mod_wsgi",
+    "summary": "A WSGI interface for Python web applications in Apache"
+  },
+  {
+    "name": "python3.11-numpy",
+    "summary": "A fast multidimensional array facility for Python"
+  },
+  {
+    "name": "python3.11-numpy-f2py",
+    "summary": "f2py for numpy"
+  },
+  {
+    "name": "python3.11-pip",
+    "summary": "A tool for installing and managing Python packages"
+  },
+  {
+    "name": "python3.11-pip-wheel",
+    "summary": "The pip wheel"
+  },
+  {
+    "name": "python3.11-ply",
+    "summary": "Python Lex-Yacc"
+  },
+  {
+    "name": "python3.11-psycopg2",
+    "summary": "A PostgreSQL database adapter for Python"
+  },
+  {
+    "name": "python3.11-pycparser",
+    "summary": "C parser and AST generator written in Python"
+  },
+  {
+    "name": "python3.11-PyMySQL",
+    "summary": "Pure-Python MySQL client library"
+  },
+  {
+    "name": "python3.11-PyMySQL+rsa",
+    "summary": "Metapackage for python3.11-PyMySQL: rsa extras"
+  },
+  {
+    "name": "python3.11-pysocks",
+    "summary": "A Python SOCKS client module"
+  },
+  {
+    "name": "python3.11-pyyaml",
+    "summary": "YAML parser and emitter for Python"
+  },
+  {
+    "name": "python3.11-requests",
+    "summary": "HTTP library, written in Python, for human beings"
+  },
+  {
+    "name": "python3.11-requests+security",
+    "summary": "Metapackage for python3.11-requests: security extras"
+  },
+  {
+    "name": "python3.11-requests+socks",
+    "summary": "Metapackage for python3.11-requests: socks extras"
+  },
+  {
+    "name": "python3.11-scipy",
+    "summary": "Scientific Tools for Python"
+  },
+  {
+    "name": "python3.11-setuptools",
+    "summary": "Easily build and distribute Python packages"
+  },
+  {
+    "name": "python3.11-setuptools-wheel",
+    "summary": "The setuptools wheel"
+  },
+  {
+    "name": "python3.11-six",
+    "summary": "Python 2 and 3 compatibility utilities"
+  },
+  {
+    "name": "python3.11-tkinter",
+    "summary": "A GUI toolkit for Python"
+  },
+  {
+    "name": "python3.11-urllib3",
+    "summary": "Python HTTP library with thread-safe connection pooling and file post"
+  },
+  {
+    "name": "python3.11-wheel",
+    "summary": "Built-package format for Python"
+  },
+  {
+    "name": "python3.12",
+    "summary": "Version 3.12 of the Python interpreter"
+  },
+  {
+    "name": "python3.12-cffi",
+    "summary": "Foreign Function Interface for Python to call C code"
+  },
+  {
+    "name": "python3.12-charset-normalizer",
+    "summary": "The Real First Universal Charset Detector"
+  },
+  {
+    "name": "python3.12-cryptography",
+    "summary": "PyCA's cryptography library"
+  },
+  {
+    "name": "python3.12-devel",
+    "summary": "Libraries and header files needed for Python development"
+  },
+  {
+    "name": "python3.12-idna",
+    "summary": "Internationalized Domain Names in Applications (IDNA)"
+  },
+  {
+    "name": "python3.12-libs",
+    "summary": "Python runtime libraries"
+  },
+  {
+    "name": "python3.12-lxml",
+    "summary": "XML processing library combining libxml2/libxslt with the ElementTree API"
+  },
+  {
+    "name": "python3.12-mod_wsgi",
+    "summary": "A WSGI interface for Python web applications in Apache"
+  },
+  {
+    "name": "python3.12-numpy",
+    "summary": "A fast multidimensional array facility for Python"
+  },
+  {
+    "name": "python3.12-numpy-f2py",
+    "summary": "f2py for numpy"
+  },
+  {
+    "name": "python3.12-pip",
+    "summary": "A tool for installing and managing Python packages"
+  },
+  {
+    "name": "python3.12-pip-wheel",
+    "summary": "The pip wheel"
+  },
+  {
+    "name": "python3.12-ply",
+    "summary": "Python Lex-Yacc"
+  },
+  {
+    "name": "python3.12-psycopg2",
+    "summary": "A PostgreSQL database adapter for Python"
+  },
+  {
+    "name": "python3.12-pycparser",
+    "summary": "C parser and AST generator written in Python"
+  },
+  {
+    "name": "python3.12-PyMySQL",
+    "summary": "Pure-Python MySQL client library"
+  },
+  {
+    "name": "python3.12-PyMySQL+rsa",
+    "summary": "Metapackage for python3.12-PyMySQL: rsa extras"
+  },
+  {
+    "name": "python3.12-pyyaml",
+    "summary": "YAML parser and emitter for Python"
+  },
+  {
+    "name": "python3.12-requests",
+    "summary": "HTTP library, written in Python, for human beings"
+  },
+  {
+    "name": "python3.12-scipy",
+    "summary": "Scientific Tools for Python"
+  },
+  {
+    "name": "python3.12-setuptools",
+    "summary": "Easily build and distribute Python packages"
+  },
+  {
+    "name": "python3.12-tkinter",
+    "summary": "A GUI toolkit for Python"
+  },
+  {
+    "name": "python3.12-urllib3",
+    "summary": "HTTP library with thread-safe connection pooling, file post, and more"
+  },
+  {
+    "name": "python3.12-wheel",
+    "summary": "Built-package format for Python"
+  },
+  {
+    "name": "qat-zstd-plugin",
+    "summary": "Intel QuickAssist Technology ZSTD Plugin"
+  },
+  {
+    "name": "qat-zstd-plugin-devel",
+    "summary": "Development files for qat-zstd-plugin"
+  },
+  {
+    "name": "qatengine",
+    "summary": "Intel QuickAssist Technology (QAT) OpenSSL Engine"
+  },
+  {
+    "name": "qatlib",
+    "summary": "Intel QuickAssist user space library"
+  },
+  {
+    "name": "qatlib-service",
+    "summary": "A daemon for qatlib resources management"
+  },
+  {
+    "name": "qatzip",
+    "summary": "Intel QuickAssist Technology (QAT) QATzip Library"
+  },
+  {
+    "name": "qatzip-libs",
+    "summary": "Libraries for the qatzip package"
+  },
+  {
+    "name": "qemu-ga-win",
+    "summary": "Qemus Guest agent for Windows"
+  },
+  {
+    "name": "qemu-guest-agent",
+    "summary": "QEMU guest agent"
+  },
+  {
+    "name": "qemu-img",
+    "summary": "QEMU command line tool for manipulating disk images"
+  },
+  {
+    "name": "qemu-kvm",
+    "summary": "QEMU is a machine emulator and virtualizer"
+  },
+  {
+    "name": "qemu-kvm-audio-pa",
+    "summary": "QEMU PulseAudio audio driver"
+  },
+  {
+    "name": "qemu-kvm-block-blkio",
+    "summary": "QEMU libblkio block drivers"
+  },
+  {
+    "name": "qemu-kvm-block-curl",
+    "summary": "QEMU CURL block driver"
+  },
+  {
+    "name": "qemu-kvm-block-rbd",
+    "summary": "QEMU Ceph/RBD block driver"
+  },
+  {
+    "name": "qemu-kvm-common",
+    "summary": "QEMU common files needed by all QEMU targets"
+  },
+  {
+    "name": "qemu-kvm-core",
+    "summary": "qemu-kvm core components"
+  },
+  {
+    "name": "qemu-kvm-device-display-virtio-gpu",
+    "summary": "QEMU virtio-gpu display device"
+  },
+  {
+    "name": "qemu-kvm-device-display-virtio-gpu-gl",
+    "summary": "QEMU virtio-gpu-gl display device"
+  },
+  {
+    "name": "qemu-kvm-device-display-virtio-gpu-pci",
+    "summary": "QEMU virtio-gpu-pci display device"
+  },
+  {
+    "name": "qemu-kvm-device-display-virtio-gpu-pci-gl",
+    "summary": "QEMU virtio-gpu-pci-gl display device"
+  },
+  {
+    "name": "qemu-kvm-device-display-virtio-vga",
+    "summary": "QEMU virtio-vga display device"
+  },
+  {
+    "name": "qemu-kvm-device-display-virtio-vga-gl",
+    "summary": "QEMU virtio-vga-gl display device"
+  },
+  {
+    "name": "qemu-kvm-device-usb-host",
+    "summary": "QEMU usb host device"
+  },
+  {
+    "name": "qemu-kvm-device-usb-redirect",
+    "summary": "QEMU usbredir support"
+  },
+  {
+    "name": "qemu-kvm-docs",
+    "summary": "qemu-kvm documentation"
+  },
+  {
+    "name": "qemu-kvm-tools",
+    "summary": "qemu-kvm support tools"
+  },
+  {
+    "name": "qemu-kvm-ui-egl-headless",
+    "summary": "QEMU EGL headless driver"
+  },
+  {
+    "name": "qemu-kvm-ui-opengl",
+    "summary": "QEMU opengl support"
+  },
+  {
+    "name": "qemu-pr-helper",
+    "summary": "qemu-pr-helper utility for qemu-kvm"
+  },
+  {
+    "name": "qgnomeplatform",
+    "summary": "Qt Platform Theme aimed to accommodate Gnome settings"
+  },
+  {
+    "name": "qpdf-libs",
+    "summary": "QPDF library for transforming PDF files"
+  },
+  {
+    "name": "qt5",
+    "summary": "Qt5 meta package"
+  },
+  {
+    "name": "qt5-assistant",
+    "summary": "Documentation browser for Qt5"
+  },
+  {
+    "name": "qt5-designer",
+    "summary": "Design GUIs for Qt5 applications"
+  },
+  {
+    "name": "qt5-doc",
+    "summary": "Qt5 - Complete documentation"
+  },
+  {
+    "name": "qt5-doctools",
+    "summary": "Qt5 doc tools package"
+  },
+  {
+    "name": "qt5-linguist",
+    "summary": "Qt5 Linguist Tools"
+  },
+  {
+    "name": "qt5-qdbusviewer",
+    "summary": "D-Bus debugger and viewer"
+  },
+  {
+    "name": "qt5-qt3d",
+    "summary": "Qt5 - Qt3D QML bindings and C++ APIs"
+  },
+  {
+    "name": "qt5-qt3d-devel",
+    "summary": "Development files for qt5-qt3d"
+  },
+  {
+    "name": "qt5-qt3d-doc",
+    "summary": "Documentation for qt3d"
+  },
+  {
+    "name": "qt5-qt3d-examples",
+    "summary": "Programming examples for qt5-qt3d"
+  },
+  {
+    "name": "qt5-qtbase",
+    "summary": "Qt5 - QtBase components"
+  },
+  {
+    "name": "qt5-qtbase-common",
+    "summary": "Common files for Qt5"
+  },
+  {
+    "name": "qt5-qtbase-devel",
+    "summary": "Development files for qt5-qtbase"
+  },
+  {
+    "name": "qt5-qtbase-doc",
+    "summary": "Documentation for qtbase"
+  },
+  {
+    "name": "qt5-qtbase-examples",
+    "summary": "Programming examples for qt5-qtbase"
+  },
+  {
+    "name": "qt5-qtbase-gui",
+    "summary": "Qt5 GUI-related libraries"
+  },
+  {
+    "name": "qt5-qtbase-mysql",
+    "summary": "MySQL driver for Qt5's SQL classes"
+  },
+  {
+    "name": "qt5-qtbase-odbc",
+    "summary": "ODBC driver for Qt5's SQL classes"
+  },
+  {
+    "name": "qt5-qtbase-postgresql",
+    "summary": "PostgreSQL driver for Qt5's SQL classes"
+  },
+  {
+    "name": "qt5-qtbase-private-devel",
+    "summary": "Development files for qt5-qtbase private APIs"
+  },
+  {
+    "name": "qt5-qtcharts-doc",
+    "summary": "Documentation for qtcharts"
+  },
+  {
+    "name": "qt5-qtconnectivity",
+    "summary": "Qt5 - Connectivity components"
+  },
+  {
+    "name": "qt5-qtconnectivity-devel",
+    "summary": "Development files for qt5-qtconnectivity"
+  },
+  {
+    "name": "qt5-qtconnectivity-doc",
+    "summary": "Documentation for qtconnectivity"
+  },
+  {
+    "name": "qt5-qtconnectivity-examples",
+    "summary": "Programming examples for qt5-qtconnectivity"
+  },
+  {
+    "name": "qt5-qtdatavis3d-doc",
+    "summary": "Documentation for qtdatavis3d"
+  },
+  {
+    "name": "qt5-qtdeclarative",
+    "summary": "Qt5 - QtDeclarative component"
+  },
+  {
+    "name": "qt5-qtdeclarative-devel",
+    "summary": "Development files for qt5-qtdeclarative"
+  },
+  {
+    "name": "qt5-qtdeclarative-doc",
+    "summary": "Documentation for qtdeclarative"
+  },
+  {
+    "name": "qt5-qtdeclarative-examples",
+    "summary": "Programming examples for qt5-qtdeclarative"
+  },
+  {
+    "name": "qt5-qtdoc",
+    "summary": "Main Qt5 Reference Documentation"
+  },
+  {
+    "name": "qt5-qtgamepad-doc",
+    "summary": "Documentation for qtgamepad"
+  },
+  {
+    "name": "qt5-qtgraphicaleffects",
+    "summary": "Qt5 - QtGraphicalEffects component"
+  },
+  {
+    "name": "qt5-qtgraphicaleffects-doc",
+    "summary": "Documentation for qtgraphicaleffects"
+  },
+  {
+    "name": "qt5-qtimageformats",
+    "summary": "Qt5 - QtImageFormats component"
+  },
+  {
+    "name": "qt5-qtimageformats-doc",
+    "summary": "Documentation for qtimageformats"
+  },
+  {
+    "name": "qt5-qtlocation",
+    "summary": "Qt5 - Location component"
+  },
+  {
+    "name": "qt5-qtlocation-devel",
+    "summary": "Development files for qt5-qtlocation"
+  },
+  {
+    "name": "qt5-qtlocation-doc",
+    "summary": "Documentation for qtlocation"
+  },
+  {
+    "name": "qt5-qtlocation-examples",
+    "summary": "Programming examples for qt5-qtlocation"
+  },
+  {
+    "name": "qt5-qtmultimedia",
+    "summary": "Qt5 - Multimedia support"
+  },
+  {
+    "name": "qt5-qtmultimedia-devel",
+    "summary": "Development files for qt5-qtmultimedia"
+  },
+  {
+    "name": "qt5-qtmultimedia-doc",
+    "summary": "Documentation for qtmultimedia"
+  },
+  {
+    "name": "qt5-qtmultimedia-examples",
+    "summary": "Programming examples for qt5-qtmultimedia"
+  },
+  {
+    "name": "qt5-qtpurchasing-doc",
+    "summary": "Documentation for qtpurchasing"
+  },
+  {
+    "name": "qt5-qtquickcontrols",
+    "summary": "Qt5 - module with set of QtQuick controls"
+  },
+  {
+    "name": "qt5-qtquickcontrols-doc",
+    "summary": "Documentation for qtquickcontrols"
+  },
+  {
+    "name": "qt5-qtquickcontrols-examples",
+    "summary": "Programming examples for qt5-qtquickcontrols"
+  },
+  {
+    "name": "qt5-qtquickcontrols2",
+    "summary": "Qt5 - module with set of QtQuick controls for embedded"
+  },
+  {
+    "name": "qt5-qtquickcontrols2-devel",
+    "summary": "Development files for qt5-qtquickcontrols2"
+  },
+  {
+    "name": "qt5-qtquickcontrols2-doc",
+    "summary": "Documentation for qtquickcontrols2"
+  },
+  {
+    "name": "qt5-qtquickcontrols2-examples",
+    "summary": "Examples for qt5-qtquickcontrols2"
+  },
+  {
+    "name": "qt5-qtremoteobjects-doc",
+    "summary": "Documentation for qtremoteobjects"
+  },
+  {
+    "name": "qt5-qtscript",
+    "summary": "Qt5 - QtScript component"
+  },
+  {
+    "name": "qt5-qtscript-devel",
+    "summary": "Development files for qt5-qtscript"
+  },
+  {
+    "name": "qt5-qtscript-doc",
+    "summary": "Documentation for qtscript"
+  },
+  {
+    "name": "qt5-qtscript-examples",
+    "summary": "Programming examples for qt5-qtscript"
+  },
+  {
+    "name": "qt5-qtscxml-doc",
+    "summary": "Documentation for qtscxml"
+  },
+  {
+    "name": "qt5-qtsensors",
+    "summary": "Qt5 - Sensors component"
+  },
+  {
+    "name": "qt5-qtsensors-devel",
+    "summary": "Development files for qt5-qtsensors"
+  },
+  {
+    "name": "qt5-qtsensors-doc",
+    "summary": "Documentation for qtsensors"
+  },
+  {
+    "name": "qt5-qtsensors-examples",
+    "summary": "Programming examples for qt5-qtsensors"
+  },
+  {
+    "name": "qt5-qtserialbus",
+    "summary": "Qt5 - SerialBus component"
+  },
+  {
+    "name": "qt5-qtserialbus-devel",
+    "summary": "Development files for qt5-qtserialbus"
+  },
+  {
+    "name": "qt5-qtserialbus-doc",
+    "summary": "Documentation for qtserialbus"
+  },
+  {
+    "name": "qt5-qtserialbus-examples",
+    "summary": "Programming examples for qt5-qtserialbus"
+  },
+  {
+    "name": "qt5-qtserialport",
+    "summary": "Qt5 - SerialPort component"
+  },
+  {
+    "name": "qt5-qtserialport-devel",
+    "summary": "Development files for qt5-qtserialport"
+  },
+  {
+    "name": "qt5-qtserialport-doc",
+    "summary": "Documentation for qtserialport"
+  },
+  {
+    "name": "qt5-qtserialport-examples",
+    "summary": "Programming examples for qt5-qtserialport"
+  },
+  {
+    "name": "qt5-qtspeech-doc",
+    "summary": "Documentation for qtspeech"
+  },
+  {
+    "name": "qt5-qtsvg",
+    "summary": "Qt5 - Support for rendering and displaying SVG"
+  },
+  {
+    "name": "qt5-qtsvg-devel",
+    "summary": "Development files for qt5-qtsvg"
+  },
+  {
+    "name": "qt5-qtsvg-doc",
+    "summary": "Documentation for qtsvg"
+  },
+  {
+    "name": "qt5-qtsvg-examples",
+    "summary": "Programming examples for qt5-qtsvg"
+  },
+  {
+    "name": "qt5-qttools",
+    "summary": "Qt5 - QtTool components"
+  },
+  {
+    "name": "qt5-qttools-common",
+    "summary": "Common files for qt5-qttools"
+  },
+  {
+    "name": "qt5-qttools-devel",
+    "summary": "Development files for qt5-qttools"
+  },
+  {
+    "name": "qt5-qttools-doc",
+    "summary": "Documentation for qttools"
+  },
+  {
+    "name": "qt5-qttools-examples",
+    "summary": "Programming examples for qt5-qttools"
+  },
+  {
+    "name": "qt5-qttools-libs-designer",
+    "summary": "Qt5 Designer runtime library"
+  },
+  {
+    "name": "qt5-qttools-libs-designercomponents",
+    "summary": "Qt5 Designer Components runtime library"
+  },
+  {
+    "name": "qt5-qttools-libs-help",
+    "summary": "Qt5 Help runtime library"
+  },
+  {
+    "name": "qt5-qttranslations",
+    "summary": "Qt5 - QtTranslations module"
+  },
+  {
+    "name": "qt5-qtvirtualkeyboard-doc",
+    "summary": "Documentation for qtvirtualkeyboard"
+  },
+  {
+    "name": "qt5-qtwayland",
+    "summary": "Qt5 - Wayland platform support and QtCompositor module"
+  },
+  {
+    "name": "qt5-qtwayland-devel",
+    "summary": "Development files for qt5-qtwayland"
+  },
+  {
+    "name": "qt5-qtwayland-doc",
+    "summary": "Documentation for qtwayland"
+  },
+  {
+    "name": "qt5-qtwayland-examples",
+    "summary": "Programming examples for qt5-qtwayland"
+  },
+  {
+    "name": "qt5-qtwebchannel",
+    "summary": "Qt5 - WebChannel component"
+  },
+  {
+    "name": "qt5-qtwebchannel-devel",
+    "summary": "Development files for qt5-qtwebchannel"
+  },
+  {
+    "name": "qt5-qtwebchannel-doc",
+    "summary": "Documentation for qtwebchannel"
+  },
+  {
+    "name": "qt5-qtwebchannel-examples",
+    "summary": "Programming examples for qt5-qtwebchannel"
+  },
+  {
+    "name": "qt5-qtwebsockets",
+    "summary": "Qt5 - WebSockets component"
+  },
+  {
+    "name": "qt5-qtwebsockets-devel",
+    "summary": "Development files for qt5-qtwebsockets"
+  },
+  {
+    "name": "qt5-qtwebsockets-doc",
+    "summary": "Documentation for qtwebsockets"
+  },
+  {
+    "name": "qt5-qtwebsockets-examples",
+    "summary": "Programming examples for qt5-qtwebsockets"
+  },
+  {
+    "name": "qt5-qtwebview-doc",
+    "summary": "Documentation for qtwebview"
+  },
+  {
+    "name": "qt5-qtx11extras",
+    "summary": "Qt5 - X11 support library"
+  },
+  {
+    "name": "qt5-qtx11extras-devel",
+    "summary": "Development files for qt5-qtx11extras"
+  },
+  {
+    "name": "qt5-qtx11extras-doc",
+    "summary": "Documentation for qtx11extras"
+  },
+  {
+    "name": "qt5-qtxmlpatterns",
+    "summary": "Qt5 - QtXmlPatterns component"
+  },
+  {
+    "name": "qt5-qtxmlpatterns-devel",
+    "summary": "Development files for qt5-qtxmlpatterns"
+  },
+  {
+    "name": "qt5-qtxmlpatterns-doc",
+    "summary": "Documentation for qtxmlpatterns"
+  },
+  {
+    "name": "qt5-qtxmlpatterns-examples",
+    "summary": "Programming examples for qt5-qtxmlpatterns"
+  },
+  {
+    "name": "qt5-rpm-macros",
+    "summary": "RPM macros for building Qt5 and KDE Frameworks 5 packages"
+  },
+  {
+    "name": "qt5-srpm-macros",
+    "summary": "RPM macros for source Qt5 packages"
+  },
+  {
+    "name": "quota-doc",
+    "summary": "Additional documentation for disk quotas"
+  },
+  {
+    "name": "quota-nld",
+    "summary": "quota_nld daemon"
+  },
+  {
+    "name": "quota-rpc",
+    "summary": "RPC quota daemon"
+  },
+  {
+    "name": "quota-warnquota",
+    "summary": "Send e-mail to users over quota"
+  },
+  {
+    "name": "radvd",
+    "summary": "A Router Advertisement daemon"
+  },
+  {
+    "name": "raptor2",
+    "summary": "RDF Parser Toolkit for Redland"
+  },
+  {
+    "name": "rasdaemon",
+    "summary": "Utility to receive RAS error tracings"
+  },
+  {
+    "name": "rasqal",
+    "summary": "RDF Query Library"
+  },
+  {
+    "name": "rdma-core-devel",
+    "summary": "RDMA core development libraries and headers"
+  },
+  {
+    "name": "readline-devel",
+    "summary": "Files needed to develop programs which use the readline library"
+  },
+  {
+    "name": "realtime-tests",
+    "summary": "Programs that test various rt-features"
+  },
+  {
+    "name": "rear",
+    "summary": "Relax-and-Recover is a Linux disaster recovery and system migration tool"
+  },
+  {
+    "name": "redfish-finder",
+    "summary": "Utility for parsing SMBIOS information and configuring canonical BMC access"
+  },
+  {
+    "name": "redhat-backgrounds",
+    "summary": "Red Hat-related desktop backgrounds"
+  },
+  {
+    "name": "redhat-cloud-client-configuration",
+    "summary": "Red Hat cloud client configuration"
+  },
+  {
+    "name": "redhat-cloud-client-configuration-cdn",
+    "summary": "Red Hat cloud client configuration - CDN"
+  },
+  {
+    "name": "redhat-display-fonts",
+    "summary": "Red Hat Display fonts"
+  },
+  {
+    "name": "redhat-indexhtml",
+    "summary": "Browser default start page for Red Hat Enterprise Linux"
+  },
+  {
+    "name": "redhat-logos",
+    "summary": "Red Hat-related icons and pictures"
+  },
+  {
+    "name": "redhat-logos-httpd",
+    "summary": "Red Hat-related icons and pictures used by httpd"
+  },
+  {
+    "name": "redhat-logos-ipa",
+    "summary": "Red Hat-related icons and pictures used by ipa"
+  },
+  {
+    "name": "redhat-mono-fonts",
+    "summary": "Red Hat Mono fonts"
+  },
+  {
+    "name": "redhat-rpm-config",
+    "summary": "Red Hat specific rpm configuration files"
+  },
+  {
+    "name": "redhat-text-fonts",
+    "summary": "Red Hat Text fonts"
+  },
+  {
+    "name": "redis",
+    "summary": "A persistent key-value database"
+  },
+  {
+    "name": "redis-devel",
+    "summary": "Development header for Redis module development"
+  },
+  {
+    "name": "redis-doc",
+    "summary": "Documentation for Redis including man pages"
+  },
+  {
+    "name": "redland",
+    "summary": "RDF Application Framework"
+  },
+  {
+    "name": "regexp",
+    "summary": "Simple regular expressions API"
+  },
+  {
+    "name": "rest",
+    "summary": "A library for access to RESTful web services"
+  },
+  {
+    "name": "rhc",
+    "summary": "rhc connects the system to Red Hat hosted services"
+  },
+  {
+    "name": "rhc-worker-playbook",
+    "summary": "Python worker for Red Hat connector that launches Ansible Runner"
+  },
+  {
+    "name": "rhel-system-roles",
+    "summary": "Set of interfaces for unified system management"
+  },
+  {
+    "name": "rig",
+    "summary": "Monitor a system for events and trigger specific actions"
+  },
+  {
+    "name": "rls",
+    "summary": "Rust Language Server for IDE integration"
+  },
+  {
+    "name": "rpcgen",
+    "summary": "RPC protocol compiler"
+  },
+  {
+    "name": "rpm-apidocs",
+    "summary": "API documentation for RPM libraries"
+  },
+  {
+    "name": "rpm-build",
+    "summary": "Scripts and executable programs used to build packages"
+  },
+  {
+    "name": "rpm-cron",
+    "summary": "Create daily logs of installed packages."
+  },
+  {
+    "name": "rpm-devel",
+    "summary": "Development files for manipulating RPM packages"
+  },
+  {
+    "name": "rpm-mpi-hooks",
+    "summary": "RPM dependency generator hooks for MPI packages"
+  },
+  {
+    "name": "rpm-ostree",
+    "summary": "Hybrid image/package system"
+  },
+  {
+    "name": "rpm-ostree-libs",
+    "summary": "Shared library for rpm-ostree"
+  },
+  {
+    "name": "rpm-plugin-fapolicyd",
+    "summary": "Rpm plugin for fapolicyd functionality"
+  },
+  {
+    "name": "rpm-plugin-ima",
+    "summary": "Rpm plugin ima file signatures"
+  },
+  {
+    "name": "rpm-plugin-syslog",
+    "summary": "Rpm plugin for syslog functionality"
+  },
+  {
+    "name": "rpm-plugin-systemd-inhibit",
+    "summary": "Rpm plugin for systemd inhibit functionality"
+  },
+  {
+    "name": "rpmdevtools",
+    "summary": "RPM Development Tools"
+  },
+  {
+    "name": "rpmlint",
+    "summary": "Tool for checking common errors in RPM packages"
+  },
+  {
+    "name": "rrdtool",
+    "summary": "Round Robin Database Tool to store and display time-series data"
+  },
+  {
+    "name": "rrdtool-perl",
+    "summary": "Perl RRDtool bindings"
+  },
+  {
+    "name": "rshim",
+    "summary": "User-space driver for Mellanox BlueField SoC"
+  },
+  {
+    "name": "rsync-daemon",
+    "summary": "Service for anonymous access to rsync"
+  },
+  {
+    "name": "rsync-rrsync",
+    "summary": "A script to setup restricted rsync users via ssh logins"
+  },
+  {
+    "name": "rsyslog",
+    "summary": "Enhanced system logging and kernel message trapping daemon"
+  },
+  {
+    "name": "rsyslog-crypto",
+    "summary": "Encryption support"
+  },
+  {
+    "name": "rsyslog-doc",
+    "summary": "HTML documentation for rsyslog"
+  },
+  {
+    "name": "rsyslog-elasticsearch",
+    "summary": "ElasticSearch output module for rsyslog"
+  },
+  {
+    "name": "rsyslog-gnutls",
+    "summary": "TLS protocol support for rsyslog via GnuTLS library"
+  },
+  {
+    "name": "rsyslog-gssapi",
+    "summary": "GSSAPI authentication and encryption support for rsyslog"
+  },
+  {
+    "name": "rsyslog-kafka",
+    "summary": "Provides the omkafka module"
+  },
+  {
+    "name": "rsyslog-logrotate",
+    "summary": "Log rotation for rsyslog"
+  },
+  {
+    "name": "rsyslog-mmaudit",
+    "summary": "Message modification module supporting Linux audit format"
+  },
+  {
+    "name": "rsyslog-mmfields",
+    "summary": "Fields extraction module"
+  },
+  {
+    "name": "rsyslog-mmjsonparse",
+    "summary": "JSON enhanced logging support"
+  },
+  {
+    "name": "rsyslog-mmkubernetes",
+    "summary": "Provides the mmkubernetes module"
+  },
+  {
+    "name": "rsyslog-mmnormalize",
+    "summary": "Log normalization support for rsyslog"
+  },
+  {
+    "name": "rsyslog-mmsnmptrapd",
+    "summary": "Message modification module for snmptrapd generated messages"
+  },
+  {
+    "name": "rsyslog-mysql",
+    "summary": "MySQL support for rsyslog"
+  },
+  {
+    "name": "rsyslog-omamqp1",
+    "summary": "Provides the omamqp1 module"
+  },
+  {
+    "name": "rsyslog-openssl",
+    "summary": "TLS protocol support for rsyslog via OpenSSL library"
+  },
+  {
+    "name": "rsyslog-pgsql",
+    "summary": "PostgresSQL support for rsyslog"
+  },
+  {
+    "name": "rsyslog-relp",
+    "summary": "RELP protocol support for rsyslog"
+  },
+  {
+    "name": "rsyslog-snmp",
+    "summary": "SNMP protocol support for rsyslog"
+  },
+  {
+    "name": "rsyslog-udpspoof",
+    "summary": "Provides the omudpspoof module"
+  },
+  {
+    "name": "rtkit",
+    "summary": "Realtime Policy and Watchdog Daemon"
+  },
+  {
+    "name": "rtla",
+    "summary": "Real-Time Linux Analysis tools"
+  },
+  {
+    "name": "ruby",
+    "summary": "An interpreter of object-oriented scripting language"
+  },
+  {
+    "name": "ruby-default-gems",
+    "summary": "Default gems which are part of Ruby StdLib"
+  },
+  {
+    "name": "ruby-devel",
+    "summary": "A Ruby development environment"
+  },
+  {
+    "name": "ruby-libs",
+    "summary": "Libraries necessary to run Ruby"
+  },
+  {
+    "name": "rubygem-bigdecimal",
+    "summary": "BigDecimal provides arbitrary-precision floating point decimal arithmetic"
+  },
+  {
+    "name": "rubygem-bundler",
+    "summary": "Library and utilities to manage a Ruby application's gem dependencies"
+  },
+  {
+    "name": "rubygem-io-console",
+    "summary": "IO/Console is a simple console utilizing library"
+  },
+  {
+    "name": "rubygem-irb",
+    "summary": "The Interactive Ruby"
+  },
+  {
+    "name": "rubygem-json",
+    "summary": "This is a JSON implementation as a Ruby extension in C"
+  },
+  {
+    "name": "rubygem-minitest",
+    "summary": "Minitest provides a complete suite of testing facilities"
+  },
+  {
+    "name": "rubygem-mysql2",
+    "summary": "A simple, fast Mysql library for Ruby, binding to libmysql"
+  },
+  {
+    "name": "rubygem-pg",
+    "summary": "A Ruby interface to the PostgreSQL RDBMS"
+  },
+  {
+    "name": "rubygem-power_assert",
+    "summary": "Power Assert for Ruby"
+  },
+  {
+    "name": "rubygem-psych",
+    "summary": "A libyaml wrapper for Ruby"
+  },
+  {
+    "name": "rubygem-rake",
+    "summary": "Ruby based make-like utility"
+  },
+  {
+    "name": "rubygem-rbs",
+    "summary": "Type signature for Ruby"
+  },
+  {
+    "name": "rubygem-rdoc",
+    "summary": "A tool to generate HTML and command-line documentation for Ruby projects"
+  },
+  {
+    "name": "rubygem-rexml",
+    "summary": "An XML toolkit for Ruby"
+  },
+  {
+    "name": "rubygem-rss",
+    "summary": "Family of libraries that support various formats of XML \"feeds\""
+  },
+  {
+    "name": "rubygem-test-unit",
+    "summary": "An xUnit family unit testing framework for Ruby"
+  },
+  {
+    "name": "rubygem-typeprof",
+    "summary": "TypeProf is a type analysis tool for Ruby code based on abstract interpretation"
+  },
+  {
+    "name": "rubygems",
+    "summary": "The Ruby standard for packaging ruby libraries"
+  },
+  {
+    "name": "rubygems-devel",
+    "summary": "Macros and development tools for packaging RubyGems"
+  },
+  {
+    "name": "runc",
+    "summary": "CLI for running Open Containers"
+  },
+  {
+    "name": "rust",
+    "summary": "The Rust Programming Language"
+  },
+  {
+    "name": "rust-analysis",
+    "summary": "Compiler analysis data for the Rust standard library"
+  },
+  {
+    "name": "rust-analyzer",
+    "summary": "Rust implementation of the Language Server Protocol"
+  },
+  {
+    "name": "rust-debugger-common",
+    "summary": "Common debugger pretty printers for Rust"
+  },
+  {
+    "name": "rust-doc",
+    "summary": "Documentation for Rust"
+  },
+  {
+    "name": "rust-gdb",
+    "summary": "GDB pretty printers for Rust"
+  },
+  {
+    "name": "rust-lldb",
+    "summary": "LLDB pretty printers for Rust"
+  },
+  {
+    "name": "rust-src",
+    "summary": "Sources for the Rust standard library"
+  },
+  {
+    "name": "rust-srpm-macros",
+    "summary": "RPM macros for building Rust source packages"
+  },
+  {
+    "name": "rust-std-static",
+    "summary": "Standard library for Rust"
+  },
+  {
+    "name": "rust-std-static-wasm32-unknown-unknown",
+    "summary": "Standard library for Rust wasm32-unknown-unknown"
+  },
+  {
+    "name": "rust-std-static-wasm32-wasi",
+    "summary": "Standard library for Rust wasm32-wasi"
+  },
+  {
+    "name": "rust-std-static-wasm32-wasip1",
+    "summary": "Standard library for Rust wasm32-wasip1"
+  },
+  {
+    "name": "rust-toolset",
+    "summary": "Package that installs rust-toolset"
+  },
+  {
+    "name": "rustfmt",
+    "summary": "Tool to find and fix Rust formatting issues"
+  },
+  {
+    "name": "rv",
+    "summary": "RV: Runtime Verification"
+  },
+  {
+    "name": "s-nail",
+    "summary": "Environment for sending and receiving mail"
+  },
+  {
+    "name": "s390utils",
+    "summary": "Utilities and daemons for IBM z Systems"
+  },
+  {
+    "name": "s390utils-se-data",
+    "summary": "Data for Secure Execution"
+  },
+  {
+    "name": "saab-fonts",
+    "summary": "Free Punjabi Unicode OpenType Serif Font"
+  },
+  {
+    "name": "sac",
+    "summary": "Java standard interface for CSS parser"
+  },
+  {
+    "name": "samba-client",
+    "summary": "Samba client programs"
+  },
+  {
+    "name": "samba-gpupdate",
+    "summary": "Samba GPO support for clients"
+  },
+  {
+    "name": "samba-krb5-printing",
+    "summary": "Samba CUPS backend for printing with Kerberos"
+  },
+  {
+    "name": "samba-vfs-iouring",
+    "summary": "Samba VFS module for io_uring"
+  },
+  {
+    "name": "samba-winbind-clients",
+    "summary": "Samba winbind clients"
+  },
+  {
+    "name": "samba-winbind-krb5-locator",
+    "summary": "Samba winbind krb5 locator"
+  },
+  {
+    "name": "samba-winexe",
+    "summary": "Samba Winexe Windows Binary"
+  },
+  {
+    "name": "sane-airscan",
+    "summary": "SANE backend for AirScan (eSCL) and WSD document scanners"
+  },
+  {
+    "name": "sane-backends",
+    "summary": "Scanner access software"
+  },
+  {
+    "name": "sane-backends-daemon",
+    "summary": "Scanner network daemon"
+  },
+  {
+    "name": "sane-backends-devel",
+    "summary": "SANE development toolkit"
+  },
+  {
+    "name": "sane-backends-doc",
+    "summary": "SANE backends documentation"
+  },
+  {
+    "name": "sane-backends-drivers-cameras",
+    "summary": "Scanner backend drivers for digital cameras"
+  },
+  {
+    "name": "sane-backends-drivers-scanners",
+    "summary": "SANE backend drivers for scanners"
+  },
+  {
+    "name": "sane-backends-libs",
+    "summary": "SANE libraries"
+  },
+  {
+    "name": "sanlock",
+    "summary": "A shared storage lock manager"
+  },
+  {
+    "name": "sanlock-lib",
+    "summary": "A shared storage lock manager library"
+  },
+  {
+    "name": "satyr",
+    "summary": "Tools to create anonymous, machine-friendly problem reports"
+  },
+  {
+    "name": "sbc",
+    "summary": "Sub Band Codec used by bluetooth A2DP"
+  },
+  {
+    "name": "sbd",
+    "summary": "Storage-based death"
+  },
+  {
+    "name": "sblim-cmpi-base",
+    "summary": "SBLIM CMPI Base Providers"
+  },
+  {
+    "name": "sblim-indication_helper",
+    "summary": "Toolkit for CMPI indication providers"
+  },
+  {
+    "name": "sblim-sfcb",
+    "summary": "Small Footprint CIM Broker"
+  },
+  {
+    "name": "sblim-sfcc",
+    "summary": "Small Footprint CIM Client Library"
+  },
+  {
+    "name": "sblim-sfcCommon",
+    "summary": "Common functions for SBLIM Small Footprint CIM Broker and CIM Client Library."
+  },
+  {
+    "name": "sblim-wbemcli",
+    "summary": "SBLIM WBEM Command Line Interface"
+  },
+  {
+    "name": "scap-security-guide",
+    "summary": "Security guidance and baselines in SCAP formats"
+  },
+  {
+    "name": "scap-security-guide-doc",
+    "summary": "HTML formatted security guides generated from XCCDF benchmarks"
+  },
+  {
+    "name": "scap-workbench",
+    "summary": "Scanning, tailoring, editing and validation tool for SCAP content"
+  },
+  {
+    "name": "scl-utils",
+    "summary": "Utilities for alternative packaging"
+  },
+  {
+    "name": "scl-utils-build",
+    "summary": "RPM build macros for alternative packaging"
+  },
+  {
+    "name": "scrub",
+    "summary": "Disk scrubbing program"
+  },
+  {
+    "name": "sdl12-compat",
+    "summary": "SDL 1.2 runtime compatibility library using SDL 2.0"
+  },
+  {
+    "name": "SDL2",
+    "summary": "Cross-platform multimedia library"
+  },
+  {
+    "name": "SDL2-devel",
+    "summary": "Files needed to develop Simple DirectMedia Layer applications"
+  },
+  {
+    "name": "seabios",
+    "summary": "Open-source legacy BIOS implementation"
+  },
+  {
+    "name": "seabios-bin",
+    "summary": "Seabios for x86"
+  },
+  {
+    "name": "seahorse",
+    "summary": "A GNOME application for managing encryption keys"
+  },
+  {
+    "name": "seavgabios-bin",
+    "summary": "Seavgabios for x86"
+  },
+  {
+    "name": "selinux-policy-devel",
+    "summary": "SELinux policy development files"
+  },
+  {
+    "name": "sendmail",
+    "summary": "A widely used Mail Transport Agent (MTA)"
+  },
+  {
+    "name": "sendmail-cf",
+    "summary": "The files needed to reconfigure Sendmail"
+  },
+  {
+    "name": "sendmail-doc",
+    "summary": "Documentation about the Sendmail Mail Transport Agent program"
+  },
+  {
+    "name": "setools",
+    "summary": "Policy analysis tools for SELinux"
+  },
+  {
+    "name": "setools-console-analyses",
+    "summary": "Policy analysis command-line tools for SELinux"
+  },
+  {
+    "name": "setools-gui",
+    "summary": "Policy analysis graphical tools for SELinux"
+  },
+  {
+    "name": "setroubleshoot",
+    "summary": "Helps troubleshoot SELinux problems"
+  },
+  {
+    "name": "setroubleshoot-plugins",
+    "summary": "Analysis plugins for use with setroubleshoot"
+  },
+  {
+    "name": "setroubleshoot-server",
+    "summary": "SELinux troubleshoot server"
+  },
+  {
+    "name": "setxkbmap",
+    "summary": "X11 keymap client"
+  },
+  {
+    "name": "sevctl",
+    "summary": "Administrative utility for AMD SEV"
+  },
+  {
+    "name": "sgabios",
+    "summary": "Serial graphics BIOS option rom"
+  },
+  {
+    "name": "sgabios-bin",
+    "summary": "Sgabios for x86"
+  },
+  {
+    "name": "sgml-common",
+    "summary": "Common SGML catalog and DTD files"
+  },
+  {
+    "name": "sgpio",
+    "summary": "SGPIO captive backplane tool"
+  },
+  {
+    "name": "sid",
+    "summary": "Storage Instantiation Daemon (SID)"
+  },
+  {
+    "name": "sid-base-libs",
+    "summary": "Libraries for Storage Instantiation Daemon (SID) base"
+  },
+  {
+    "name": "sid-iface-libs",
+    "summary": "Libraries for Storage Instantiation Daemon (SID) interfaces"
+  },
+  {
+    "name": "sid-log-libs",
+    "summary": "Libraries for Storage Instantiation Daemon (SID) logging"
+  },
+  {
+    "name": "sid-mod-block-blkid",
+    "summary": "Blkid block module for Storage Instantiation Daemon (SID)"
+  },
+  {
+    "name": "sid-mod-block-dm-mpath",
+    "summary": "Device-mapper multipath block module for Storage Instantiation Daemon (SID)"
+  },
+  {
+    "name": "sid-mod-dummies",
+    "summary": "Dummy block and type module for Storage Instantiation Daemon (SID)"
+  },
+  {
+    "name": "sid-resource-libs",
+    "summary": "Libraries for Storage Instantiation Daemon (SID) resources"
+  },
+  {
+    "name": "sid-tools",
+    "summary": "Storage Instantiation Daemon (SID) supporting tools"
+  },
+  {
+    "name": "sil-abyssinica-fonts",
+    "summary": "SIL Abyssinica fonts"
+  },
+  {
+    "name": "sil-nuosu-fonts",
+    "summary": "The Nuosu SIL Font"
+  },
+  {
+    "name": "sil-padauk-fonts",
+    "summary": "A font for Burmese and the Myanmar script"
+  },
+  {
+    "name": "sil-scheherazade-fonts",
+    "summary": "An Arabic script unicode font"
+  },
+  {
+    "name": "sip6",
+    "summary": "SIP - Python/C++ Bindings Generator"
+  },
+  {
+    "name": "sisu",
+    "summary": "Eclipse dependency injection framework"
+  },
+  {
+    "name": "skopeo",
+    "summary": "Inspect container images and repositories on registries"
+  },
+  {
+    "name": "skopeo-tests",
+    "summary": "Tests for skopeo"
+  },
+  {
+    "name": "slang-devel",
+    "summary": "Development files for the S-Lang extension language"
+  },
+  {
+    "name": "slapi-nis",
+    "summary": "NIS Server and Schema Compatibility plugins for Directory Server"
+  },
+  {
+    "name": "slf4j",
+    "summary": "Simple Logging Facade for Java"
+  },
+  {
+    "name": "slf4j-jdk14",
+    "summary": "SLF4J JDK14 Binding"
+  },
+  {
+    "name": "slirp4netns",
+    "summary": "slirp for network namespaces"
+  },
+  {
+    "name": "smc-meera-fonts",
+    "summary": "Open Type Fonts for Malayalam script"
+  },
+  {
+    "name": "smc-rachana-fonts",
+    "summary": "Open Type Fonts for Malayalam script"
+  },
+  {
+    "name": "smc-tools",
+    "summary": "Shared Memory Communication Tools"
+  },
+  {
+    "name": "snapm",
+    "summary": "A set of tools for managing snapshots"
+  },
+  {
+    "name": "snappy-devel",
+    "summary": "Development files for snappy"
+  },
+  {
+    "name": "snpguest",
+    "summary": "A CLI tool for interacting with SEV-SNP guest environment"
+  },
+  {
+    "name": "snphost",
+    "summary": "Administrative utility for AMD SEV-SNP"
+  },
+  {
+    "name": "socat",
+    "summary": "Bidirectional data relay between two data channels ('netcat++')"
+  },
+  {
+    "name": "softhsm",
+    "summary": "Software version of a PKCS#11 Hardware Security Module"
+  },
+  {
+    "name": "sombok",
+    "summary": "Unicode Text Segmentation Package"
+  },
+  {
+    "name": "sound-theme-freedesktop",
+    "summary": "freedesktop.org sound theme"
+  },
+  {
+    "name": "soundtouch",
+    "summary": "Audio Processing library for changing Tempo, Pitch and Playback Rates"
+  },
+  {
+    "name": "source-highlight",
+    "summary": "Produces a document with syntax highlighting"
+  },
+  {
+    "name": "spamassassin",
+    "summary": "Spam filter for email which can be invoked from mail delivery agents"
+  },
+  {
+    "name": "speech-dispatcher",
+    "summary": "To provide a high-level device independent layer for speech synthesis"
+  },
+  {
+    "name": "speech-dispatcher-doc",
+    "summary": "Documentation for speech-dispatcher"
+  },
+  {
+    "name": "speech-dispatcher-espeak-ng",
+    "summary": "Speech Dispatcher espeak-ng module"
+  },
+  {
+    "name": "speech-tools-libs",
+    "summary": "Edinburgh speech tools libraries"
+  },
+  {
+    "name": "speex",
+    "summary": "A voice compression format (codec)"
+  },
+  {
+    "name": "speexdsp",
+    "summary": "A voice compression format (DSP)"
+  },
+  {
+    "name": "spice-vdagent",
+    "summary": "Agent for Spice guests"
+  },
+  {
+    "name": "spirv-tools",
+    "summary": "API and commands for processing SPIR-V modules"
+  },
+  {
+    "name": "spirv-tools-libs",
+    "summary": "Library files for spirv-tools"
+  },
+  {
+    "name": "splix",
+    "summary": "Driver for QPDL/SPL2 printers (Samsung and several Xerox printers)"
+  },
+  {
+    "name": "sqlite",
+    "summary": "Library that implements an embeddable SQL database engine"
+  },
+  {
+    "name": "sqlite-devel",
+    "summary": "Development tools for the sqlite3 embeddable SQL database engine"
+  },
+  {
+    "name": "squid",
+    "summary": "The Squid proxy caching server"
+  },
+  {
+    "name": "sscg",
+    "summary": "Simple SSL certificate generator"
+  },
+  {
+    "name": "ssh-key-dir",
+    "summary": "sshd AuthorizedKeysCommand to read ~/.ssh/authorized_keys.d"
+  },
+  {
+    "name": "sshpass",
+    "summary": "Non-interactive SSH authentication utility"
+  },
+  {
+    "name": "sssd-idp",
+    "summary": "Kerberos plugins and OIDC helper for external identity providers."
+  },
+  {
+    "name": "stalld",
+    "summary": "Daemon that finds starving tasks and gives them a temporary boost"
+  },
+  {
+    "name": "startup-notification",
+    "summary": "Library for tracking application startup"
+  },
+  {
+    "name": "startup-notification-devel",
+    "summary": "Development portions of startup-notification"
+  },
+  {
+    "name": "stix-fonts",
+    "summary": "STIX, a scientific and engineering font family"
+  },
+  {
+    "name": "stratis-cli",
+    "summary": "Command-line tool for interacting with the Stratis daemon"
+  },
+  {
+    "name": "stratisd",
+    "summary": "Daemon that manages block devices to create filesystems"
+  },
+  {
+    "name": "stratisd-dracut",
+    "summary": "Dracut modules for use with stratisd"
+  },
+  {
+    "name": "stratisd-tools",
+    "summary": "Tools that support Stratis operation"
+  },
+  {
+    "name": "stress-ng",
+    "summary": "Stress test a computer system in various ways"
+  },
+  {
+    "name": "subversion",
+    "summary": "A Modern Concurrent Version Control System"
+  },
+  {
+    "name": "subversion-devel",
+    "summary": "Development package for the Subversion libraries"
+  },
+  {
+    "name": "subversion-gnome",
+    "summary": "GNOME Keyring support for Subversion"
+  },
+  {
+    "name": "subversion-libs",
+    "summary": "Libraries for Subversion Version Control system"
+  },
+  {
+    "name": "subversion-perl",
+    "summary": "Perl bindings to the Subversion libraries"
+  },
+  {
+    "name": "subversion-tools",
+    "summary": "Supplementary tools for Subversion"
+  },
+  {
+    "name": "sudo-python-plugin",
+    "summary": "Python plugin for sudo"
+  },
+  {
+    "name": "suitesparse",
+    "summary": "A collection of sparse matrix libraries"
+  },
+  {
+    "name": "supermin",
+    "summary": "Tool for creating supermin appliances"
+  },
+  {
+    "name": "sushi",
+    "summary": "A quick previewer for Nautilus"
+  },
+  {
+    "name": "switcheroo-control",
+    "summary": "D-Bus service to check the availability of dual-GPU"
+  },
+  {
+    "name": "swtpm",
+    "summary": "TPM Emulator"
+  },
+  {
+    "name": "swtpm-libs",
+    "summary": "Private libraries for swtpm TPM emulators"
+  },
+  {
+    "name": "swtpm-tools",
+    "summary": "Tools for the TPM emulator"
+  },
+  {
+    "name": "synce4l",
+    "summary": "SyncE implementation for Linux"
+  },
+  {
+    "name": "sysfsutils",
+    "summary": "Utilities for interfacing with sysfs"
+  },
+  {
+    "name": "syslinux-tftpboot",
+    "summary": "SYSLINUX modules in /tftpboot, available for network booting"
+  },
+  {
+    "name": "sysprof-capture-devel",
+    "summary": "Development files for sysprof-capture static library"
+  },
+  {
+    "name": "sysstat",
+    "summary": "Collection of performance monitoring tools for Linux"
+  },
+  {
+    "name": "system-config-printer-libs",
+    "summary": "Libraries and shared code for printer administration tool"
+  },
+  {
+    "name": "system-config-printer-udev",
+    "summary": "Rules for udev for automatic configuration of USB printers"
+  },
+  {
+    "name": "system-reinstall-bootc",
+    "summary": "Utility to reinstall the current system using bootc"
+  },
+  {
+    "name": "systemd-boot-unsigned",
+    "summary": "UEFI boot manager (unsigned version)"
+  },
+  {
+    "name": "systemd-devel",
+    "summary": "Development headers for systemd"
+  },
+  {
+    "name": "systemd-journal-remote",
+    "summary": "Tools to send journal events over the network"
+  },
+  {
+    "name": "systemd-ukify",
+    "summary": "Tool to build Unified Kernel Images"
+  },
+  {
+    "name": "systemtap",
+    "summary": "Programmable system-wide instrumentation system"
+  },
+  {
+    "name": "systemtap-client",
+    "summary": "Programmable system-wide instrumentation system - client"
+  },
+  {
+    "name": "systemtap-devel",
+    "summary": "Programmable system-wide instrumentation system - development headers, tools"
+  },
+  {
+    "name": "systemtap-exporter",
+    "summary": "Systemtap-prometheus interoperation mechanism"
+  },
+  {
+    "name": "systemtap-initscript",
+    "summary": "Systemtap Initscripts"
+  },
+  {
+    "name": "systemtap-runtime",
+    "summary": "Programmable system-wide instrumentation system - runtime"
+  },
+  {
+    "name": "systemtap-runtime-java",
+    "summary": "Systemtap Java Runtime Support"
+  },
+  {
+    "name": "systemtap-runtime-python3",
+    "summary": "Systemtap Python 3 Runtime Support"
+  },
+  {
+    "name": "systemtap-runtime-virtguest",
+    "summary": "Systemtap Cross-VM Instrumentation - guest"
+  },
+  {
+    "name": "systemtap-runtime-virthost",
+    "summary": "Systemtap Cross-VM Instrumentation - host"
+  },
+  {
+    "name": "systemtap-sdt-devel",
+    "summary": "Static probe support tools"
+  },
+  {
+    "name": "systemtap-sdt-dtrace",
+    "summary": "Static probe support dtrace tool"
+  },
+  {
+    "name": "systemtap-server",
+    "summary": "Instrumentation System Server"
+  },
+  {
+    "name": "taglib",
+    "summary": "Audio Meta-Data Library"
+  },
+  {
+    "name": "tang",
+    "summary": "Network Presence Binding Daemon"
+  },
+  {
+    "name": "target-restore",
+    "summary": "Systemd service for targetcli/rtslib"
+  },
+  {
+    "name": "targetcli",
+    "summary": "An administration shell for storage targets"
+  },
+  {
+    "name": "tbb",
+    "summary": "The Threading Building Blocks library abstracts low-level threading details"
+  },
+  {
+    "name": "tbb-devel",
+    "summary": "The Threading Building Blocks C++ headers and shared development libraries"
+  },
+  {
+    "name": "tbb-doc",
+    "summary": "The Threading Building Blocks documentation"
+  },
+  {
+    "name": "tcl-devel",
+    "summary": "Tcl scripting language development environment"
+  },
+  {
+    "name": "tcl-doc",
+    "summary": "Tcl documentation"
+  },
+  {
+    "name": "tcpdump",
+    "summary": "A network traffic monitoring tool"
+  },
+  {
+    "name": "tcsh",
+    "summary": "An enhanced version of csh, the C shell"
+  },
+  {
+    "name": "tdb-tools",
+    "summary": "Developer tools for the Tdb library"
+  },
+  {
+    "name": "teckit",
+    "summary": "Conversion library and mapping compiler"
+  },
+  {
+    "name": "telnet",
+    "summary": "The client program for the Telnet remote login protocol"
+  },
+  {
+    "name": "telnet-server",
+    "summary": "The server program for the Telnet remote login protocol"
+  },
+  {
+    "name": "tesseract",
+    "summary": "Raw OCR Engine"
+  },
+  {
+    "name": "tesseract-langpack-afr",
+    "summary": "Afrikaans language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-amh",
+    "summary": "Amharic language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ara",
+    "summary": "Arabic language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-asm",
+    "summary": "Assamese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-aze",
+    "summary": "Azerbaijani language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-aze_cyrl",
+    "summary": "Azerbaijani (Cyrillic) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-bel",
+    "summary": "Belarusian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ben",
+    "summary": "Bengali language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-bod",
+    "summary": "Tibetan (Standard) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-bos",
+    "summary": "Bosnian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-bre",
+    "summary": "Breton language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-bul",
+    "summary": "Bulgarian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-cat",
+    "summary": "Catalan language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ceb",
+    "summary": "Cebuano language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ces",
+    "summary": "Czech language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-chi_sim",
+    "summary": "Chinese (Simplified) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-chi_sim_vert",
+    "summary": "Chinese (Simplified, Vertical) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-chi_tra",
+    "summary": "Chinese (Traditional) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-chi_tra_vert",
+    "summary": "Chinese (Traditional, Vertical) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-chr",
+    "summary": "Cherokee language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-cos",
+    "summary": "Corsican language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-cym",
+    "summary": "Welsh language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-dan",
+    "summary": "Danish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-deu",
+    "summary": "German language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-div",
+    "summary": "Dhivehi; Maldivian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-dzo",
+    "summary": "Dzongkha language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ell",
+    "summary": "Greek language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-eng",
+    "summary": "English language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-enm",
+    "summary": "Middle English (1100-1500) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-epo",
+    "summary": "Esperanto language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-est",
+    "summary": "Estonian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-eus",
+    "summary": "Basque language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-fao",
+    "summary": "Faroese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-fas",
+    "summary": "Persian (Farsi) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-fil",
+    "summary": "Filipino; Pilipino language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-fin",
+    "summary": "Finnish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-fra",
+    "summary": "French language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-frk",
+    "summary": "Fraktur language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-frm",
+    "summary": "Middle French (ca. 1400-1600) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-fry",
+    "summary": "Western Frisian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-gla",
+    "summary": "Gaelic; Scottish Gaelic language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-gle",
+    "summary": "Irish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-glg",
+    "summary": "Galician language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-grc",
+    "summary": "Ancient Greek language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-guj",
+    "summary": "Gujarati language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-hat",
+    "summary": "Haitian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-heb",
+    "summary": "Hebrew language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-hin",
+    "summary": "Hindi language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-hrv",
+    "summary": "Croatian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-hun",
+    "summary": "Hungarian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-hye",
+    "summary": "Armenian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-iku",
+    "summary": "Inuktitut language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ind",
+    "summary": "Indonesian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-isl",
+    "summary": "Icelandic language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ita",
+    "summary": "Italian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ita_old",
+    "summary": "Italian (Old) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-jav",
+    "summary": "Javanese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-jpn",
+    "summary": "Japanese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-jpn_vert",
+    "summary": "\"Japanese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kan",
+    "summary": "Kannada language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kat",
+    "summary": "Georgian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kat_old",
+    "summary": "Georgian (Old) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kaz",
+    "summary": "Kazakh language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-khm",
+    "summary": "Khmer language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kir",
+    "summary": "Kyrgyz language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kmr",
+    "summary": "Kurmanji language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kor",
+    "summary": "Korean language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-kor_vert",
+    "summary": "\"Korean language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-lao",
+    "summary": "Lao language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-lat",
+    "summary": "Latin language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-lav",
+    "summary": "Latvian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-lit",
+    "summary": "Lithuanian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ltz",
+    "summary": "Luxembourgish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mal",
+    "summary": "Malayalam language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mar",
+    "summary": "Marathi language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mkd",
+    "summary": "Macedonian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mlt",
+    "summary": "Maltese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mon",
+    "summary": "Mongolian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mri",
+    "summary": "Maori language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-msa",
+    "summary": "Malay language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-mya",
+    "summary": "Burmese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-nep",
+    "summary": "Nepali language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-nld",
+    "summary": "Dutch language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-nor",
+    "summary": "Norwegian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-oci",
+    "summary": "Occitan language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ori",
+    "summary": "Oriya language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-pan",
+    "summary": "Panjabi language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-pol",
+    "summary": "Polish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-por",
+    "summary": "Portuguese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-pus",
+    "summary": "Pashto language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-que",
+    "summary": "Quechuan language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ron",
+    "summary": "Romanian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-rus",
+    "summary": "Russian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-san",
+    "summary": "Sanskrit language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-sin",
+    "summary": "Sinhala language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-slk",
+    "summary": "Slovakian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-slv",
+    "summary": "Slovenian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-snd",
+    "summary": "Sindhi language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-spa",
+    "summary": "Spanish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-spa_old",
+    "summary": "Spanish (Old) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-sqi",
+    "summary": "Albanian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-srp",
+    "summary": "Serbian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-srp_latn",
+    "summary": "Serbian (Latin) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-sun",
+    "summary": "Sundanese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-swa",
+    "summary": "Swahili language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-swe",
+    "summary": "Swedish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-syr",
+    "summary": "Syriac language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tam",
+    "summary": "Tamil language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tat",
+    "summary": "Tatar language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tel",
+    "summary": "Telugu language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tgk",
+    "summary": "Tajik language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tha",
+    "summary": "Thai language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tir",
+    "summary": "Tigrinya language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ton",
+    "summary": "Tongan language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-tur",
+    "summary": "Turkish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-uig",
+    "summary": "Uyghur language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-ukr",
+    "summary": "Ukrainian language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-urd",
+    "summary": "Urdu language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-uzb",
+    "summary": "Uzbek language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-uzb_cyrl",
+    "summary": "Uzbek (Cyrillic) language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-vie",
+    "summary": "Vietnamese language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-yid",
+    "summary": "Yiddish language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-langpack-yor",
+    "summary": "Yoruba language data for tesseract-tessdata"
+  },
+  {
+    "name": "tesseract-tessdata-doc",
+    "summary": "Documentation for tesseract-tessdata"
+  },
+  {
+    "name": "tex-fonts-hebrew",
+    "summary": "Culmus Hebrew fonts support for LaTeX"
+  },
+  {
+    "name": "tex-preview",
+    "summary": "Preview style files for LaTeX"
+  },
+  {
+    "name": "texlive",
+    "summary": "TeX formatting system"
+  },
+  {
+    "name": "texlive-adjustbox",
+    "summary": "adjustbox package"
+  },
+  {
+    "name": "texlive-ae",
+    "summary": "Virtual fonts for T1 encoded CMR-fonts"
+  },
+  {
+    "name": "texlive-algorithms",
+    "summary": "A suite of tools for typesetting algorithms in pseudo-code"
+  },
+  {
+    "name": "texlive-alphalph",
+    "summary": "Convert numbers to letters"
+  },
+  {
+    "name": "texlive-amscls",
+    "summary": "AMS document classes for LaTeX"
+  },
+  {
+    "name": "texlive-amsfonts",
+    "summary": "TeX fonts from the American Mathematical Society"
+  },
+  {
+    "name": "texlive-amsmath",
+    "summary": "AMS mathematical facilities for LaTeX"
+  },
+  {
+    "name": "texlive-anyfontsize",
+    "summary": "Select any font size in LaTeX"
+  },
+  {
+    "name": "texlive-anysize",
+    "summary": "A simple package to set up document margins"
+  },
+  {
+    "name": "texlive-appendix",
+    "summary": "Extra control of appendices"
+  },
+  {
+    "name": "texlive-arabxetex",
+    "summary": "An ArabTeX-like interface for XeLaTeX"
+  },
+  {
+    "name": "texlive-arphic",
+    "summary": "Arphic (Chinese) font packages"
+  },
+  {
+    "name": "texlive-atbegshi",
+    "summary": "Execute stuff at \\shipout time"
+  },
+  {
+    "name": "texlive-attachfile",
+    "summary": "Attach arbitrary files to a PDF document"
+  },
+  {
+    "name": "texlive-attachfile2",
+    "summary": "Attach files into PDF"
+  },
+  {
+    "name": "texlive-atveryend",
+    "summary": "Hooks at the very end of a document"
+  },
+  {
+    "name": "texlive-auxhook",
+    "summary": "Hooks for auxiliary files"
+  },
+  {
+    "name": "texlive-avantgar",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-awesomebox",
+    "summary": "raw admonition blocks in your documents, illustrated with FontAwesome icons"
+  },
+  {
+    "name": "texlive-babel",
+    "summary": "Multilingual support for Plain TeX or LaTeX"
+  },
+  {
+    "name": "texlive-babel-english",
+    "summary": "Babel support for English"
+  },
+  {
+    "name": "texlive-babelbib",
+    "summary": "Multilingual bibliographies"
+  },
+  {
+    "name": "texlive-base",
+    "summary": "TeX Live filesystem, metadata and licenses shipped in text form"
+  },
+  {
+    "name": "texlive-beamer",
+    "summary": "A LaTeX class for producing presentations and slides"
+  },
+  {
+    "name": "texlive-bera",
+    "summary": "Bera fonts"
+  },
+  {
+    "name": "texlive-beton",
+    "summary": "Use Concrete fonts"
+  },
+  {
+    "name": "texlive-bibtex",
+    "summary": "Process bibliographies for LaTeX, etc"
+  },
+  {
+    "name": "texlive-bibtopic",
+    "summary": "Include multiple bibliographies in a document"
+  },
+  {
+    "name": "texlive-bidi",
+    "summary": "Support for bidirectional typesetting in plain TeX and LaTeX"
+  },
+  {
+    "name": "texlive-bigfoot",
+    "summary": "Footnotes for critical editions"
+  },
+  {
+    "name": "texlive-bigintcalc",
+    "summary": "Integer calculations on very large numbers"
+  },
+  {
+    "name": "texlive-bitset",
+    "summary": "Handle bit-vector datatype"
+  },
+  {
+    "name": "texlive-bookman",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-bookmark",
+    "summary": "A new bookmark (outline) organization for hyperref"
+  },
+  {
+    "name": "texlive-booktabs",
+    "summary": "Publication quality tables in LaTeX"
+  },
+  {
+    "name": "texlive-breakurl",
+    "summary": "Line-breakable \\url-like links in hyperref when compiling via dvips/ps2pdf"
+  },
+  {
+    "name": "texlive-breqn",
+    "summary": "Automatic line breaking of displayed equations"
+  },
+  {
+    "name": "texlive-capt-of",
+    "summary": "Captions on more than floats"
+  },
+  {
+    "name": "texlive-caption",
+    "summary": "Customising captions in floating environments"
+  },
+  {
+    "name": "texlive-carlisle",
+    "summary": "David Carlisle's small packages"
+  },
+  {
+    "name": "texlive-catchfile",
+    "summary": "Catch an external file into a macro"
+  },
+  {
+    "name": "texlive-changebar",
+    "summary": "Generate changebars in LaTeX documents"
+  },
+  {
+    "name": "texlive-changepage",
+    "summary": "Margin adjustment and detection of odd/even pages"
+  },
+  {
+    "name": "texlive-charter",
+    "summary": "Charter fonts"
+  },
+  {
+    "name": "texlive-chngcntr",
+    "summary": "Change the resetting of counters"
+  },
+  {
+    "name": "texlive-cite",
+    "summary": "Improved citation handling in LaTeX"
+  },
+  {
+    "name": "texlive-cjk",
+    "summary": "CJK language support"
+  },
+  {
+    "name": "texlive-classpack",
+    "summary": "XML mastering for LaTeX classes and packages"
+  },
+  {
+    "name": "texlive-cm",
+    "summary": "Computer Modern fonts"
+  },
+  {
+    "name": "texlive-cm-lgc",
+    "summary": "Type 1 CM-based fonts for Latin, Greek and Cyrillic"
+  },
+  {
+    "name": "texlive-cm-super",
+    "summary": "CM-Super family of fonts"
+  },
+  {
+    "name": "texlive-cmap",
+    "summary": "cmap package"
+  },
+  {
+    "name": "texlive-cmextra",
+    "summary": "cmextra package"
+  },
+  {
+    "name": "texlive-cns",
+    "summary": "cns package"
+  },
+  {
+    "name": "texlive-collectbox",
+    "summary": "collectbox package"
+  },
+  {
+    "name": "texlive-collection-basic",
+    "summary": "Essential programs and files"
+  },
+  {
+    "name": "texlive-collection-fontsrecommended",
+    "summary": "Recommended fonts"
+  },
+  {
+    "name": "texlive-collection-htmlxml",
+    "summary": "HTML/SGML/XML support"
+  },
+  {
+    "name": "texlive-collection-latex",
+    "summary": "Basic LaTeX packages"
+  },
+  {
+    "name": "texlive-collection-latexrecommended",
+    "summary": "LaTeX recommended packages"
+  },
+  {
+    "name": "texlive-collection-xetex",
+    "summary": "XeTeX packages"
+  },
+  {
+    "name": "texlive-colorprofiles",
+    "summary": "Collection of free ICC profiles"
+  },
+  {
+    "name": "texlive-colortbl",
+    "summary": "Add colour to LaTeX tables"
+  },
+  {
+    "name": "texlive-context",
+    "summary": "The ConTeXt macro package"
+  },
+  {
+    "name": "texlive-courier",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-crop",
+    "summary": "Support for cropmarks"
+  },
+  {
+    "name": "texlive-csquotes",
+    "summary": "Context sensitive quotation facilities"
+  },
+  {
+    "name": "texlive-ctable",
+    "summary": "Easily typeset centered tables"
+  },
+  {
+    "name": "texlive-ctablestack",
+    "summary": "Catcode table stable support"
+  },
+  {
+    "name": "texlive-currfile",
+    "summary": "Provide file name and path of input files"
+  },
+  {
+    "name": "texlive-datetime",
+    "summary": "Change format of \\today with commands for current time"
+  },
+  {
+    "name": "texlive-dehyph",
+    "summary": "German hyphenation patterns for traditional orthography"
+  },
+  {
+    "name": "texlive-dvipdfmx",
+    "summary": "An extended version of dvipdfm"
+  },
+  {
+    "name": "texlive-dvipng",
+    "summary": "A fast DVI to PNG/GIF converter"
+  },
+  {
+    "name": "texlive-dvips",
+    "summary": "A DVI to PostScript driver"
+  },
+  {
+    "name": "texlive-dvisvgm",
+    "summary": "Convert DVI files to Scalable Vector Graphics format (SVG)"
+  },
+  {
+    "name": "texlive-ec",
+    "summary": "Computer modern fonts in T1 and TS1 encodings"
+  },
+  {
+    "name": "texlive-eepic",
+    "summary": "Extensions to epic and the LaTeX drawing tools"
+  },
+  {
+    "name": "texlive-enctex",
+    "summary": "A TeX extension that translates input on its way into TeX"
+  },
+  {
+    "name": "texlive-enumitem",
+    "summary": "Control layout of itemize, enumerate, description"
+  },
+  {
+    "name": "texlive-environ",
+    "summary": "A new interface for environments in LaTeX"
+  },
+  {
+    "name": "texlive-epsf",
+    "summary": "Simple macros for EPS inclusion"
+  },
+  {
+    "name": "texlive-epstopdf",
+    "summary": "Convert EPS to 'encapsulated' PDF using Ghostscript"
+  },
+  {
+    "name": "texlive-epstopdf-pkg",
+    "summary": "Call epstopdf \"on the fly\""
+  },
+  {
+    "name": "texlive-eqparbox",
+    "summary": "Create equal-widthed parboxes"
+  },
+  {
+    "name": "texlive-eso-pic",
+    "summary": "Add picture commands (or backgrounds) to every page"
+  },
+  {
+    "name": "texlive-etex",
+    "summary": "An extended version of TeX, from the NTS project"
+  },
+  {
+    "name": "texlive-etex-pkg",
+    "summary": "E-TeX support package"
+  },
+  {
+    "name": "texlive-etexcmds",
+    "summary": "Avoid name clashes with e-TeX commands"
+  },
+  {
+    "name": "texlive-etoc",
+    "summary": "Completely customisable TOCs"
+  },
+  {
+    "name": "texlive-etoolbox",
+    "summary": "Tool-box for LaTeX programmers using e-TeX"
+  },
+  {
+    "name": "texlive-euenc",
+    "summary": "Unicode font encoding definitions for XeTeX"
+  },
+  {
+    "name": "texlive-euler",
+    "summary": "Use AMS Euler fonts for math"
+  },
+  {
+    "name": "texlive-euro",
+    "summary": "Provide Euro values for national currency amounts"
+  },
+  {
+    "name": "texlive-eurosym",
+    "summary": "MetaFont and macros for Euro sign"
+  },
+  {
+    "name": "texlive-extsizes",
+    "summary": "Extend the standard classes' size options"
+  },
+  {
+    "name": "texlive-fancybox",
+    "summary": "Variants of \\fbox and other games with boxes"
+  },
+  {
+    "name": "texlive-fancyhdr",
+    "summary": "Extensive control of page headers and footers in LaTeX2e"
+  },
+  {
+    "name": "texlive-fancyref",
+    "summary": "A LaTeX package for fancy cross-referencing"
+  },
+  {
+    "name": "texlive-fancyvrb",
+    "summary": "Sophisticated verbatim text"
+  },
+  {
+    "name": "texlive-filecontents",
+    "summary": "Extended filecontents and filecontents* environments"
+  },
+  {
+    "name": "texlive-filehook",
+    "summary": "Hooks for input files"
+  },
+  {
+    "name": "texlive-finstrut",
+    "summary": "Adjust behaviour of the ends of footnotes"
+  },
+  {
+    "name": "texlive-fix2col",
+    "summary": "Fix miscellaneous two column mode features"
+  },
+  {
+    "name": "texlive-fixlatvian",
+    "summary": "Improve Latvian language support in XeLaTeX"
+  },
+  {
+    "name": "texlive-float",
+    "summary": "Improved interface for floating objects"
+  },
+  {
+    "name": "texlive-fmtcount",
+    "summary": "Display the value of a LaTeX counter in a variety of formats"
+  },
+  {
+    "name": "texlive-fncychap",
+    "summary": "Seven predefined chapter heading styles"
+  },
+  {
+    "name": "texlive-fontawesome",
+    "summary": "Font containing web-related icons"
+  },
+  {
+    "name": "texlive-fontbook",
+    "summary": "Generate a font book"
+  },
+  {
+    "name": "texlive-fonts-tlwg",
+    "summary": "Thai fonts for LaTeX from TLWG"
+  },
+  {
+    "name": "texlive-fontspec",
+    "summary": "Advanced font selection in XeLaTeX and LuaLaTeX"
+  },
+  {
+    "name": "texlive-fontware",
+    "summary": "fontware package"
+  },
+  {
+    "name": "texlive-fontwrap",
+    "summary": "Bind fonts to specific unicode blocks"
+  },
+  {
+    "name": "texlive-footmisc",
+    "summary": "A range of footnote options"
+  },
+  {
+    "name": "texlive-footnotehyper",
+    "summary": "hyperref aware footnote.sty"
+  },
+  {
+    "name": "texlive-fp",
+    "summary": "Fixed point arithmetic"
+  },
+  {
+    "name": "texlive-fpl",
+    "summary": "SC and OsF fonts for URW Palladio L"
+  },
+  {
+    "name": "texlive-framed",
+    "summary": "Framed or shaded regions that can break across pages"
+  },
+  {
+    "name": "texlive-garuda-c90",
+    "summary": "TeX support (from CJK) for the garuda font"
+  },
+  {
+    "name": "texlive-geometry",
+    "summary": "Flexible and complete interface to document dimensions"
+  },
+  {
+    "name": "texlive-gettitlestring",
+    "summary": "Clean up title references"
+  },
+  {
+    "name": "texlive-glyphlist",
+    "summary": "glyphlist package"
+  },
+  {
+    "name": "texlive-graphics",
+    "summary": "Standard LaTeX graphics"
+  },
+  {
+    "name": "texlive-graphics-cfg",
+    "summary": "Sample configuration files for LaTeX color and graphics"
+  },
+  {
+    "name": "texlive-graphics-def",
+    "summary": "Colour and graphics option files"
+  },
+  {
+    "name": "texlive-grfext",
+    "summary": "Manipulate the graphics package's list of extensions"
+  },
+  {
+    "name": "texlive-grffile",
+    "summary": "Extended file name support for graphics (legacy package)"
+  },
+  {
+    "name": "texlive-gsftopk",
+    "summary": "Convert \"ghostscript fonts\" to PK files"
+  },
+  {
+    "name": "texlive-hanging",
+    "summary": "Hanging paragraphs"
+  },
+  {
+    "name": "texlive-helvetic",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-hobsub",
+    "summary": "Construct package bundles"
+  },
+  {
+    "name": "texlive-hologo",
+    "summary": "A collection of logos with bookmark support"
+  },
+  {
+    "name": "texlive-hycolor",
+    "summary": "Implements colour for packages hyperref and bookmark"
+  },
+  {
+    "name": "texlive-hyperref",
+    "summary": "Extensive support for hypertext in LaTeX"
+  },
+  {
+    "name": "texlive-hyph-utf8",
+    "summary": "Hyphenation patterns expressed in UTF-8"
+  },
+  {
+    "name": "texlive-hyphen-base",
+    "summary": "hyphen-base package"
+  },
+  {
+    "name": "texlive-hyphenat",
+    "summary": "Disable/enable hypenation"
+  },
+  {
+    "name": "texlive-hyphenex",
+    "summary": "US English hyphenation exceptions file"
+  },
+  {
+    "name": "texlive-ifmtarg",
+    "summary": "If-then-else command for processing potentially empty arguments"
+  },
+  {
+    "name": "texlive-ifoddpage",
+    "summary": "ifoddpage package"
+  },
+  {
+    "name": "texlive-ifplatform",
+    "summary": "Conditionals to test which platform is being used"
+  },
+  {
+    "name": "texlive-iftex",
+    "summary": "Am I running under pdfTeX, XeTeX or LuaTeX?"
+  },
+  {
+    "name": "texlive-import",
+    "summary": "Establish input relative to a directory"
+  },
+  {
+    "name": "texlive-index",
+    "summary": "Extended index for LaTeX including multiple indexes"
+  },
+  {
+    "name": "texlive-infwarerr",
+    "summary": "Complete set of information/warning/error message macros"
+  },
+  {
+    "name": "texlive-intcalc",
+    "summary": "Expandable arithmetic operations with integers"
+  },
+  {
+    "name": "texlive-jadetex",
+    "summary": "Macros supporting Jade DSSSL output"
+  },
+  {
+    "name": "texlive-jknapltx",
+    "summary": "Miscellaneous packages by Joerg Knappen"
+  },
+  {
+    "name": "texlive-kastrup",
+    "summary": "kastrup package"
+  },
+  {
+    "name": "texlive-kerkis",
+    "summary": "Kerkis (Greek) font family"
+  },
+  {
+    "name": "texlive-knuth-lib",
+    "summary": "A small library of MetaFont sources"
+  },
+  {
+    "name": "texlive-knuth-local",
+    "summary": "Knuth's local information"
+  },
+  {
+    "name": "texlive-koma-script",
+    "summary": "A bundle of versatile classes and packages"
+  },
+  {
+    "name": "texlive-kpathsea",
+    "summary": "Path searching library for TeX-related files"
+  },
+  {
+    "name": "texlive-kvdefinekeys",
+    "summary": "Define keys for use in the kvsetkeys package"
+  },
+  {
+    "name": "texlive-kvoptions",
+    "summary": "Key value format for package options"
+  },
+  {
+    "name": "texlive-kvsetkeys",
+    "summary": "Key value parser with default handler support"
+  },
+  {
+    "name": "texlive-l3backend",
+    "summary": "LaTeX3 backend drivers"
+  },
+  {
+    "name": "texlive-l3experimental",
+    "summary": "Experimental LaTeX3 concepts"
+  },
+  {
+    "name": "texlive-l3kernel",
+    "summary": "LaTeX3 programming conventions"
+  },
+  {
+    "name": "texlive-l3packages",
+    "summary": "High-level LaTeX3 concepts"
+  },
+  {
+    "name": "texlive-lastpage",
+    "summary": "Reference last page for Page N of M type footers"
+  },
+  {
+    "name": "texlive-latex",
+    "summary": "A TeX macro package that defines LaTeX"
+  },
+  {
+    "name": "texlive-latex-fonts",
+    "summary": "A collection of fonts used in LaTeX distributions"
+  },
+  {
+    "name": "texlive-latex2man",
+    "summary": "Translate LaTeX-based manual pages into Unix man format"
+  },
+  {
+    "name": "texlive-latexbug",
+    "summary": "Bug-classification for LaTeX related bugs"
+  },
+  {
+    "name": "texlive-latexconfig",
+    "summary": "latexconfig package"
+  },
+  {
+    "name": "texlive-letltxmacro",
+    "summary": "Let assignment for LaTeX macros"
+  },
+  {
+    "name": "texlive-lettrine",
+    "summary": "Typeset dropped capitals"
+  },
+  {
+    "name": "texlive-lib",
+    "summary": "Shared libraries for TeX-related files"
+  },
+  {
+    "name": "texlive-linegoal",
+    "summary": "A \"dimen\" that returns the space left on the line"
+  },
+  {
+    "name": "texlive-lineno",
+    "summary": "Line numbers on paragraphs"
+  },
+  {
+    "name": "texlive-listings",
+    "summary": "Typeset source code listings using LaTeX"
+  },
+  {
+    "name": "texlive-listofitems",
+    "summary": "Grab items in lists using user-specified sep char"
+  },
+  {
+    "name": "texlive-lm",
+    "summary": "Latin modern fonts in outline formats"
+  },
+  {
+    "name": "texlive-lm-math",
+    "summary": "OpenType maths fonts for Latin Modern"
+  },
+  {
+    "name": "texlive-ltabptch",
+    "summary": "Bug fix for longtable"
+  },
+  {
+    "name": "texlive-ltxcmds",
+    "summary": "Some LaTeX kernel commands for general use"
+  },
+  {
+    "name": "texlive-ltxmisc",
+    "summary": "Miscellaneous LaTeX packages, etc"
+  },
+  {
+    "name": "texlive-lua-alt-getopt",
+    "summary": "Process application arguments the same way as getopt_long"
+  },
+  {
+    "name": "texlive-luahbtex",
+    "summary": "LuaTeX with HarfBuzz library for glyph shaping"
+  },
+  {
+    "name": "texlive-lualatex-math",
+    "summary": "Fixes for mathematics-related LuaLaTeX issues"
+  },
+  {
+    "name": "texlive-lualibs",
+    "summary": "Additional Lua functions for LuaTeX macro programmers"
+  },
+  {
+    "name": "texlive-luaotfload",
+    "summary": "OpenType 'loader' for Plain TeX and LaTeX"
+  },
+  {
+    "name": "texlive-luatex",
+    "summary": "The LuaTeX engine"
+  },
+  {
+    "name": "texlive-luatex85",
+    "summary": "pdfTeX aliases for LuaTeX"
+  },
+  {
+    "name": "texlive-luatexbase",
+    "summary": "Basic resource management for LuaTeX code"
+  },
+  {
+    "name": "texlive-lwarp",
+    "summary": "Converts LaTeX to HTML"
+  },
+  {
+    "name": "texlive-makecmds",
+    "summary": "The new \\makecommand command always (re)defines a command"
+  },
+  {
+    "name": "texlive-makeindex",
+    "summary": "Process index output to produce typesettable code"
+  },
+  {
+    "name": "texlive-manfnt-font",
+    "summary": "manfnt-font package"
+  },
+  {
+    "name": "texlive-marginnote",
+    "summary": "Notes in the margin, even where \\marginpar fails"
+  },
+  {
+    "name": "texlive-marvosym",
+    "summary": "Martin Vogel's Symbols (marvosym) font"
+  },
+  {
+    "name": "texlive-mathpazo",
+    "summary": "Fonts to typeset mathematics to match Palatino"
+  },
+  {
+    "name": "texlive-mathspec",
+    "summary": "Specify arbitrary fonts for mathematics in XeTeX"
+  },
+  {
+    "name": "texlive-mathtools",
+    "summary": "Mathematical tools to use with amsmath"
+  },
+  {
+    "name": "texlive-mdwtools",
+    "summary": "Miscellaneous tools by Mark Wooding"
+  },
+  {
+    "name": "texlive-memoir",
+    "summary": "Typeset fiction, non-fiction and mathematical books"
+  },
+  {
+    "name": "texlive-metafont",
+    "summary": "A system for specifying fonts"
+  },
+  {
+    "name": "texlive-metalogo",
+    "summary": "Extended TeX logo macros"
+  },
+  {
+    "name": "texlive-metapost",
+    "summary": "A development of Metafont for creating graphics"
+  },
+  {
+    "name": "texlive-mflogo",
+    "summary": "LaTeX support for MetaFont logo fonts"
+  },
+  {
+    "name": "texlive-mflogo-font",
+    "summary": "Metafont logo font"
+  },
+  {
+    "name": "texlive-mfnfss",
+    "summary": "Packages to typeset oldgerman and pandora fonts in LaTeX"
+  },
+  {
+    "name": "texlive-mfware",
+    "summary": "Supporting tools for use with Metafont"
+  },
+  {
+    "name": "texlive-microtype",
+    "summary": "Subliminal refinements towards typographical perfection"
+  },
+  {
+    "name": "texlive-minitoc",
+    "summary": "Produce a table of contents for each chapter, part or section"
+  },
+  {
+    "name": "texlive-mnsymbol",
+    "summary": "Mathematical symbol font for Adobe MinionPro"
+  },
+  {
+    "name": "texlive-modes",
+    "summary": "A collection of Metafont mode_def's"
+  },
+  {
+    "name": "texlive-mparhack",
+    "summary": "A workaround for a LaTeX bug in marginpars"
+  },
+  {
+    "name": "texlive-mptopdf",
+    "summary": "mpost to PDF, native MetaPost graphics inclusion"
+  },
+  {
+    "name": "texlive-ms",
+    "summary": "Various LaTeX packages by Martin Schroder"
+  },
+  {
+    "name": "texlive-multido",
+    "summary": "A loop facility for Generic TeX"
+  },
+  {
+    "name": "texlive-multirow",
+    "summary": "Create tabular cells spanning multiple rows"
+  },
+  {
+    "name": "texlive-natbib",
+    "summary": "Flexible bibliography support"
+  },
+  {
+    "name": "texlive-ncctools",
+    "summary": "A collection of general packages for LaTeX"
+  },
+  {
+    "name": "texlive-ncntrsbk",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-needspace",
+    "summary": "Insert pagebreak if not enough space"
+  },
+  {
+    "name": "texlive-newfloat",
+    "summary": "Define new floating environments"
+  },
+  {
+    "name": "texlive-newunicodechar",
+    "summary": "Definitions of the meaning of Unicode characters"
+  },
+  {
+    "name": "texlive-norasi-c90",
+    "summary": "TeX support (from CJK) for the norasi font in thailatex"
+  },
+  {
+    "name": "texlive-notoccite",
+    "summary": "Prevent trouble from citations in table of contents, etc"
+  },
+  {
+    "name": "texlive-ntgclass",
+    "summary": "\"European\" versions of standard classes"
+  },
+  {
+    "name": "texlive-oberdiek",
+    "summary": "A bundle of packages submitted by Heiko Oberdiek"
+  },
+  {
+    "name": "texlive-obsolete",
+    "summary": "This package handles obsolete texlive subpackages"
+  },
+  {
+    "name": "texlive-overpic",
+    "summary": "Combine LaTeX commands over included graphics"
+  },
+  {
+    "name": "texlive-palatino",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-paralist",
+    "summary": "Enumerate and itemize within paragraphs"
+  },
+  {
+    "name": "texlive-parallel",
+    "summary": "Typeset parallel texts"
+  },
+  {
+    "name": "texlive-parskip",
+    "summary": "Layout with zero \\parindent, non-zero \\parskip"
+  },
+  {
+    "name": "texlive-passivetex",
+    "summary": "Support package for XML/SGML typesetting"
+  },
+  {
+    "name": "texlive-pdfcolmk",
+    "summary": "Improved colour support under pdfTeX (legacy stub)"
+  },
+  {
+    "name": "texlive-pdfescape",
+    "summary": "Implements pdfTeX's escape features using TeX or e-TeX"
+  },
+  {
+    "name": "texlive-pdflscape",
+    "summary": "Make landscape pages display as landscape"
+  },
+  {
+    "name": "texlive-pdfpages",
+    "summary": "Include PDF documents in LaTeX"
+  },
+  {
+    "name": "texlive-pdftex",
+    "summary": "A TeX extension for direct creation of PDF"
+  },
+  {
+    "name": "texlive-pdftexcmds",
+    "summary": "LuaTeX support for pdfTeX utility functions"
+  },
+  {
+    "name": "texlive-pgf",
+    "summary": "Create PostScript and PDF graphics in TeX"
+  },
+  {
+    "name": "texlive-philokalia",
+    "summary": "A font to typeset the Philokalia Books"
+  },
+  {
+    "name": "texlive-placeins",
+    "summary": "Control float placement"
+  },
+  {
+    "name": "texlive-plain",
+    "summary": "plain package"
+  },
+  {
+    "name": "texlive-polyglossia",
+    "summary": "Modern multilingual typesetting with XeLaTeX"
+  },
+  {
+    "name": "texlive-powerdot",
+    "summary": "A presentation class"
+  },
+  {
+    "name": "texlive-preprint",
+    "summary": "A bundle of packages provided \"as is\""
+  },
+  {
+    "name": "texlive-psfrag",
+    "summary": "Replace strings in encapsulated PostScript figures"
+  },
+  {
+    "name": "texlive-pslatex",
+    "summary": "Use PostScript fonts by default"
+  },
+  {
+    "name": "texlive-psnfss",
+    "summary": "Font support for common PostScript fonts"
+  },
+  {
+    "name": "texlive-pspicture",
+    "summary": "PostScript picture support"
+  },
+  {
+    "name": "texlive-pst-3d",
+    "summary": "A PSTricks package for tilting and other pseudo-3D tricks"
+  },
+  {
+    "name": "texlive-pst-arrow",
+    "summary": "special arrows for PSTricks"
+  },
+  {
+    "name": "texlive-pst-blur",
+    "summary": "PSTricks package for \"blurred\" shadows"
+  },
+  {
+    "name": "texlive-pst-coil",
+    "summary": "A PSTricks package for coils, etc"
+  },
+  {
+    "name": "texlive-pst-eps",
+    "summary": "Create EPS files from PSTricks figures"
+  },
+  {
+    "name": "texlive-pst-fill",
+    "summary": "Fill or tile areas with PSTricks"
+  },
+  {
+    "name": "texlive-pst-grad",
+    "summary": "Filling with colour gradients, using PStricks"
+  },
+  {
+    "name": "texlive-pst-math",
+    "summary": "Enhancement of PostScript math operators to use with pstricks"
+  },
+  {
+    "name": "texlive-pst-node",
+    "summary": "Draw connections using pstricks"
+  },
+  {
+    "name": "texlive-pst-plot",
+    "summary": "Plot data using PSTricks"
+  },
+  {
+    "name": "texlive-pst-slpe",
+    "summary": "Sophisticated colour gradients"
+  },
+  {
+    "name": "texlive-pst-text",
+    "summary": "Text and character manipulation in PSTricks"
+  },
+  {
+    "name": "texlive-pst-tools",
+    "summary": "PStricks support functions"
+  },
+  {
+    "name": "texlive-pst-tree",
+    "summary": "Trees, using pstricks"
+  },
+  {
+    "name": "texlive-pstricks",
+    "summary": "PostScript macros for TeX"
+  },
+  {
+    "name": "texlive-pstricks-add",
+    "summary": "A collection of add-ons and bugfixes for PSTricks"
+  },
+  {
+    "name": "texlive-ptext",
+    "summary": "A 'lipsum' for Persian"
+  },
+  {
+    "name": "texlive-pxfonts",
+    "summary": "Palatino-like fonts in support of mathematics"
+  },
+  {
+    "name": "texlive-qstest",
+    "summary": "Bundle for unit tests and pattern matching"
+  },
+  {
+    "name": "texlive-ragged2e",
+    "summary": "Alternative versions of \"ragged\"-type commands"
+  },
+  {
+    "name": "texlive-rcs",
+    "summary": "Use RCS (revision control system) tags in LaTeX documents"
+  },
+  {
+    "name": "texlive-realscripts",
+    "summary": "Access OpenType subscript and superscript glyphs"
+  },
+  {
+    "name": "texlive-refcount",
+    "summary": "Counter operations with label references"
+  },
+  {
+    "name": "texlive-rerunfilecheck",
+    "summary": "Checksum based rerun checks on auxiliary files"
+  },
+  {
+    "name": "texlive-rsfs",
+    "summary": "Ralph Smith's Formal Script font"
+  },
+  {
+    "name": "texlive-sansmath",
+    "summary": "Maths in a sans font"
+  },
+  {
+    "name": "texlive-sansmathaccent",
+    "summary": "Correct placement of accents in sans-serif maths"
+  },
+  {
+    "name": "texlive-sauerj",
+    "summary": "A bundle of utilities by Jonathan Sauer"
+  },
+  {
+    "name": "texlive-scheme-basic",
+    "summary": "basic scheme (plain and latex)"
+  },
+  {
+    "name": "texlive-section",
+    "summary": "Modifying section commands in LaTeX"
+  },
+  {
+    "name": "texlive-sectsty",
+    "summary": "Control sectional headers"
+  },
+  {
+    "name": "texlive-seminar",
+    "summary": "Make overhead slides"
+  },
+  {
+    "name": "texlive-sepnum",
+    "summary": "Print numbers in a \"friendly\" format"
+  },
+  {
+    "name": "texlive-setspace",
+    "summary": "Set space between lines"
+  },
+  {
+    "name": "texlive-showexpl",
+    "summary": "Typesetting LaTeX source code"
+  },
+  {
+    "name": "texlive-soul",
+    "summary": "Hyphenation for letterspacing, underlining, and more"
+  },
+  {
+    "name": "texlive-stackengine",
+    "summary": "Highly customised stacking of objects, insets, baseline changes, etc"
+  },
+  {
+    "name": "texlive-stmaryrd",
+    "summary": "St Mary Road symbols for theoretical computer science"
+  },
+  {
+    "name": "texlive-stringenc",
+    "summary": "Converting a string between different encodings"
+  },
+  {
+    "name": "texlive-subfig",
+    "summary": "Figures broken into subfigures"
+  },
+  {
+    "name": "texlive-subfigure",
+    "summary": "Deprecated: Figures divided into subfigures"
+  },
+  {
+    "name": "texlive-svn-prov",
+    "summary": "Subversion variants of \\Provides... macros"
+  },
+  {
+    "name": "texlive-symbol",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-t2",
+    "summary": "Support for using T2 encoding"
+  },
+  {
+    "name": "texlive-tabu",
+    "summary": "Flexible LaTeX tabulars"
+  },
+  {
+    "name": "texlive-tabulary",
+    "summary": "Tabular with variable width columns balanced"
+  },
+  {
+    "name": "texlive-tex",
+    "summary": "A sophisticated typesetting engine"
+  },
+  {
+    "name": "texlive-tex-gyre",
+    "summary": "TeX Fonts extending freely available URW fonts"
+  },
+  {
+    "name": "texlive-tex-gyre-math",
+    "summary": "Maths fonts to match tex-gyre text fonts"
+  },
+  {
+    "name": "texlive-tex-ini-files",
+    "summary": "Model TeX format creation files"
+  },
+  {
+    "name": "texlive-tex4ht",
+    "summary": "Convert (La)TeX to HTML/XML"
+  },
+  {
+    "name": "texlive-texlive-common-doc",
+    "summary": "Documentation for texlive-common"
+  },
+  {
+    "name": "texlive-texlive-docindex",
+    "summary": "top-level TeX Live doc.html, etc"
+  },
+  {
+    "name": "texlive-texlive-en",
+    "summary": "TeX Live manual (English)"
+  },
+  {
+    "name": "texlive-texlive-msg-translations",
+    "summary": "translations of the TeX Live installer and TeX Live Manager"
+  },
+  {
+    "name": "texlive-texlive-scripts",
+    "summary": "TeX Live infrastructure programs"
+  },
+  {
+    "name": "texlive-texlive-scripts-extra",
+    "summary": "TeX Live scripts"
+  },
+  {
+    "name": "texlive-texlive.infra",
+    "summary": "basic TeX Live infrastructure"
+  },
+  {
+    "name": "texlive-textcase",
+    "summary": "Case conversion ignoring mathematics, etc"
+  },
+  {
+    "name": "texlive-textpos",
+    "summary": "Place boxes at arbitrary positions on the LaTeX page"
+  },
+  {
+    "name": "texlive-threeparttable",
+    "summary": "Tables with captions and notes all the same width"
+  },
+  {
+    "name": "texlive-thumbpdf",
+    "summary": "Thumbnails for pdfTeX and dvips/ps2pdf"
+  },
+  {
+    "name": "texlive-times",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-tipa",
+    "summary": "Fonts and macros for IPA phonetics characters"
+  },
+  {
+    "name": "texlive-titlesec",
+    "summary": "Select alternative section titles"
+  },
+  {
+    "name": "texlive-titling",
+    "summary": "Control over the typesetting of the \\maketitle command"
+  },
+  {
+    "name": "texlive-tocloft",
+    "summary": "Control table of contents, figures, etc"
+  },
+  {
+    "name": "texlive-tools",
+    "summary": "The LaTeX standard tools bundle"
+  },
+  {
+    "name": "texlive-translator",
+    "summary": "Easy translation of strings in LaTeX"
+  },
+  {
+    "name": "texlive-trimspaces",
+    "summary": "Trim spaces around an argument or within a macro"
+  },
+  {
+    "name": "texlive-txfonts",
+    "summary": "Times-like fonts in support of mathematics"
+  },
+  {
+    "name": "texlive-type1cm",
+    "summary": "Arbitrary size font selection in LaTeX"
+  },
+  {
+    "name": "texlive-typehtml",
+    "summary": "Typeset HTML directly from LaTeX"
+  },
+  {
+    "name": "texlive-ucharcat",
+    "summary": "Implementation of the (new in 2015) XeTeX \\Ucharcat command in lua, for LuaTeX"
+  },
+  {
+    "name": "texlive-ucharclasses",
+    "summary": "Switch fonts in XeTeX according to what is being processed"
+  },
+  {
+    "name": "texlive-ucs",
+    "summary": "Extended UTF-8 input encoding support for LaTeX"
+  },
+  {
+    "name": "texlive-uhc",
+    "summary": "Fonts for the Korean language"
+  },
+  {
+    "name": "texlive-ulem",
+    "summary": "Package for underlining"
+  },
+  {
+    "name": "texlive-underscore",
+    "summary": "Control the behaviour of \"_\" in text"
+  },
+  {
+    "name": "texlive-unicode-data",
+    "summary": "Unicode data and loaders for TeX"
+  },
+  {
+    "name": "texlive-unicode-math",
+    "summary": "Unicode mathematics support for XeTeX and LuaTeX"
+  },
+  {
+    "name": "texlive-uniquecounter",
+    "summary": "Provides unlimited unique counter"
+  },
+  {
+    "name": "texlive-unisugar",
+    "summary": "Define syntactic sugar for Unicode LaTeX"
+  },
+  {
+    "name": "texlive-updmap-map",
+    "summary": "Font maps"
+  },
+  {
+    "name": "texlive-upquote",
+    "summary": "Show \"realistic\" quotes in verbatim"
+  },
+  {
+    "name": "texlive-url",
+    "summary": "Verbatim with URL-sensitive line breaks"
+  },
+  {
+    "name": "texlive-utopia",
+    "summary": "Adobe Utopia fonts"
+  },
+  {
+    "name": "texlive-varwidth",
+    "summary": "A variable-width minipage"
+  },
+  {
+    "name": "texlive-wadalab",
+    "summary": "Wadalab (Japanese) font packages"
+  },
+  {
+    "name": "texlive-was",
+    "summary": "A collection of small packages by Walter Schmidt"
+  },
+  {
+    "name": "texlive-wasy",
+    "summary": "The wasy fonts (Waldi symbol fonts)"
+  },
+  {
+    "name": "texlive-wasy-type1",
+    "summary": "Type 1 versions of wasy fonts"
+  },
+  {
+    "name": "texlive-wasysym",
+    "summary": "LaTeX support file to use the WASY2 fonts"
+  },
+  {
+    "name": "texlive-wrapfig",
+    "summary": "Produces figures which text can flow around"
+  },
+  {
+    "name": "texlive-xcolor",
+    "summary": "Driver-independent color extensions for LaTeX and pdfLaTeX"
+  },
+  {
+    "name": "texlive-xdvi",
+    "summary": "A DVI previewer for the X Window System"
+  },
+  {
+    "name": "texlive-xecjk",
+    "summary": "Support for CJK documents in XeLaTeX"
+  },
+  {
+    "name": "texlive-xecolor",
+    "summary": "Support for color in XeLaTeX"
+  },
+  {
+    "name": "texlive-xecyr",
+    "summary": "Using Cyrillic languages in XeTeX"
+  },
+  {
+    "name": "texlive-xeindex",
+    "summary": "Automatic index generation for XeLaTeX"
+  },
+  {
+    "name": "texlive-xepersian",
+    "summary": "Persian for LaTeX, using XeTeX"
+  },
+  {
+    "name": "texlive-xesearch",
+    "summary": "A string finder for XeTeX"
+  },
+  {
+    "name": "texlive-xetex",
+    "summary": "Unicode and OpenType-enabled TeX engine"
+  },
+  {
+    "name": "texlive-xetex-itrans",
+    "summary": "Itrans input maps for use with XeLaTeX"
+  },
+  {
+    "name": "texlive-xetex-pstricks",
+    "summary": "Running PStricks under XeTeX"
+  },
+  {
+    "name": "texlive-xetex-tibetan",
+    "summary": "XeTeX input maps for Unicode Tibetan"
+  },
+  {
+    "name": "texlive-xetexconfig",
+    "summary": "Configuration files for XeTeX"
+  },
+  {
+    "name": "texlive-xetexfontinfo",
+    "summary": "Report font features in XeTeX"
+  },
+  {
+    "name": "texlive-xifthen",
+    "summary": "Extended conditional commands"
+  },
+  {
+    "name": "texlive-xkeyval",
+    "summary": "Extension of the keyval package"
+  },
+  {
+    "name": "texlive-xltxtra",
+    "summary": "\"Extras\" for LaTeX users of XeTeX"
+  },
+  {
+    "name": "texlive-xmltex",
+    "summary": "Support for parsing XML documents"
+  },
+  {
+    "name": "texlive-xmltexconfig",
+    "summary": "xmltexconfig package"
+  },
+  {
+    "name": "texlive-xstring",
+    "summary": "String manipulation for (La)TeX"
+  },
+  {
+    "name": "texlive-xtab",
+    "summary": "Break tables across pages"
+  },
+  {
+    "name": "texlive-xunicode",
+    "summary": "Generate Unicode characters from accented glyphs"
+  },
+  {
+    "name": "texlive-zapfchan",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-zapfding",
+    "summary": "URW \"Base 35\" font pack for LaTeX"
+  },
+  {
+    "name": "texlive-zref",
+    "summary": "A new reference scheme for LaTeX"
+  },
+  {
+    "name": "tftp",
+    "summary": "The client for the Trivial File Transfer Protocol (TFTP)"
+  },
+  {
+    "name": "tftp-server",
+    "summary": "The server for the Trivial File Transfer Protocol (TFTP)"
+  },
+  {
+    "name": "thai-scalable-fonts-common",
+    "summary": "Common files of thai-scalable-fonts"
+  },
+  {
+    "name": "thai-scalable-garuda-fonts",
+    "summary": "Thai Garuda fonts"
+  },
+  {
+    "name": "thai-scalable-kinnari-fonts",
+    "summary": "Thai Kinnari fonts"
+  },
+  {
+    "name": "thai-scalable-loma-fonts",
+    "summary": "Thai Loma fonts"
+  },
+  {
+    "name": "thai-scalable-norasi-fonts",
+    "summary": "Thai Norasi fonts"
+  },
+  {
+    "name": "thai-scalable-purisa-fonts",
+    "summary": "Thai Purisa fonts"
+  },
+  {
+    "name": "thai-scalable-sawasdee-fonts",
+    "summary": "Thai Sawasdee fonts"
+  },
+  {
+    "name": "thai-scalable-tlwgmono-fonts",
+    "summary": "Thai TlwgMono fonts"
+  },
+  {
+    "name": "thai-scalable-tlwgtypewriter-fonts",
+    "summary": "Thai TlwgTypewriter fonts"
+  },
+  {
+    "name": "thai-scalable-tlwgtypist-fonts",
+    "summary": "Thai TlwgTypist fonts"
+  },
+  {
+    "name": "thai-scalable-tlwgtypo-fonts",
+    "summary": "Thai TlwgTypo fonts"
+  },
+  {
+    "name": "thai-scalable-umpush-fonts",
+    "summary": "Thai Umpush fonts"
+  },
+  {
+    "name": "thai-scalable-waree-fonts",
+    "summary": "Thai Waree fonts"
+  },
+  {
+    "name": "theora-tools",
+    "summary": "Command line tools for Theora videos"
+  },
+  {
+    "name": "thermald",
+    "summary": "Thermal Management daemon"
+  },
+  {
+    "name": "thunderbird",
+    "summary": "Mozilla Thunderbird mail/newsgroup client"
+  },
+  {
+    "name": "tigervnc",
+    "summary": "A TigerVNC remote display system"
+  },
+  {
+    "name": "tigervnc-icons",
+    "summary": "Icons for TigerVNC viewer"
+  },
+  {
+    "name": "tigervnc-license",
+    "summary": "License of TigerVNC suite"
+  },
+  {
+    "name": "tigervnc-selinux",
+    "summary": "SELinux module for TigerVNC"
+  },
+  {
+    "name": "tigervnc-server",
+    "summary": "A TigerVNC server"
+  },
+  {
+    "name": "tigervnc-server-minimal",
+    "summary": "A minimal installation of TigerVNC server"
+  },
+  {
+    "name": "tigervnc-server-module",
+    "summary": "TigerVNC module to Xorg"
+  },
+  {
+    "name": "tinycdb",
+    "summary": "Utility and library for manipulating constant databases"
+  },
+  {
+    "name": "tk",
+    "summary": "The graphical toolkit for the Tcl scripting language"
+  },
+  {
+    "name": "tk-devel",
+    "summary": "Tk graphical toolkit development files"
+  },
+  {
+    "name": "tlog",
+    "summary": "Terminal I/O logger"
+  },
+  {
+    "name": "tmpwatch",
+    "summary": "A utility for removing files based on when they were last accessed"
+  },
+  {
+    "name": "tog-pegasus",
+    "summary": "OpenPegasus WBEM Services for Linux"
+  },
+  {
+    "name": "tog-pegasus-libs",
+    "summary": "The OpenPegasus Libraries"
+  },
+  {
+    "name": "tokyocabinet",
+    "summary": "A modern implementation of a DBM"
+  },
+  {
+    "name": "tomcat",
+    "summary": "Apache Servlet/JSP Engine, RI for Servlet 4.0/JSP 2.3 API"
+  },
+  {
+    "name": "tomcat-admin-webapps",
+    "summary": "The host-manager and manager web applications for Apache Tomcat"
+  },
+  {
+    "name": "tomcat-docs-webapp",
+    "summary": "The docs web application for Apache Tomcat"
+  },
+  {
+    "name": "tomcat-el-3.0-api",
+    "summary": "Apache Tomcat Expression Language v3.0 API Implementation Classes"
+  },
+  {
+    "name": "tomcat-jsp-2.3-api",
+    "summary": "Apache Tomcat JavaServer Pages v2.3 API Implementation Classes"
+  },
+  {
+    "name": "tomcat-lib",
+    "summary": "Libraries needed to run the Tomcat Web container"
+  },
+  {
+    "name": "tomcat-servlet-4.0-api",
+    "summary": "Apache Tomcat Java Servlet v4.0 API Implementation Classes"
+  },
+  {
+    "name": "tomcat-webapps",
+    "summary": "The ROOT web application for Apache Tomcat"
+  },
+  {
+    "name": "tomcatjss",
+    "summary": "JSS Connector for Apache Tomcat"
+  },
+  {
+    "name": "toolbox",
+    "summary": "Tool for containerized command line environments on Linux"
+  },
+  {
+    "name": "toolbox-tests",
+    "summary": "Tests for toolbox"
+  },
+  {
+    "name": "totem",
+    "summary": "Movie player for GNOME"
+  },
+  {
+    "name": "totem-pl-parser",
+    "summary": "Totem Playlist Parser library"
+  },
+  {
+    "name": "totem-video-thumbnailer",
+    "summary": "Totem video thumbnailer"
+  },
+  {
+    "name": "tpm2-abrmd",
+    "summary": "A system daemon implementing TPM2 Access Broker and Resource Manager"
+  },
+  {
+    "name": "tpm2-abrmd-selinux",
+    "summary": "SELinux policies for tpm2-abrmd"
+  },
+  {
+    "name": "tpm2-pkcs11",
+    "summary": "PKCS#11 interface for TPM 2.0 hardware"
+  },
+  {
+    "name": "tpm2-pkcs11-tools",
+    "summary": "The tools required to setup and configure TPM2 for PKCS#11"
+  },
+  {
+    "name": "tracer-common",
+    "summary": "Common files for tracer"
+  },
+  {
+    "name": "tracker",
+    "summary": "Desktop-neutral metadata database and search tool"
+  },
+  {
+    "name": "tracker-miners",
+    "summary": "Tracker miners and metadata extractors"
+  },
+  {
+    "name": "trustee-guest-components",
+    "summary": "Tools that run in confidential VMs, attest and get secrets from Trustee"
+  },
+  {
+    "name": "ttmkfdir",
+    "summary": "Utility to create fonts.scale files for truetype fonts"
+  },
+  {
+    "name": "tuned-gtk",
+    "summary": "GTK GUI for tuned"
+  },
+  {
+    "name": "tuned-ppd",
+    "summary": "PPD compatibility daemon"
+  },
+  {
+    "name": "tuned-profiles-atomic",
+    "summary": "Additional tuned profile(s) targeted to Atomic"
+  },
+  {
+    "name": "tuned-profiles-mssql",
+    "summary": "Additional tuned profile(s) for MS SQL Server"
+  },
+  {
+    "name": "tuned-profiles-oracle",
+    "summary": "Additional tuned profile(s) targeted to Oracle loads"
+  },
+  {
+    "name": "tuned-profiles-postgresql",
+    "summary": "Additional tuned profile(s) targeted to PostgreSQL server loads"
+  },
+  {
+    "name": "tuned-profiles-spectrumscale",
+    "summary": "Additional tuned profile(s) optimized for IBM Spectrum Scale"
+  },
+  {
+    "name": "tuned-utils",
+    "summary": "Various tuned utilities"
+  },
+  {
+    "name": "twolame",
+    "summary": "Optimized MPEG Audio Layer 2 encoding library based on tooLAME"
+  },
+  {
+    "name": "twolame-libs",
+    "summary": "TwoLAME is an optimized MPEG Audio Layer 2 encoding library based on tooLAME"
+  },
+  {
+    "name": "tzdata-java",
+    "summary": "Timezone data for Java"
+  },
+  {
+    "name": "ucs-miscfixed-fonts",
+    "summary": "Selected set of bitmap fonts"
+  },
+  {
+    "name": "ucx",
+    "summary": "UCX is a communication library implementing high-performance messaging"
+  },
+  {
+    "name": "ucx-cma",
+    "summary": "UCX CMA support"
+  },
+  {
+    "name": "ucx-devel",
+    "summary": "Header files required for developing with UCX"
+  },
+  {
+    "name": "ucx-ib",
+    "summary": "UCX RDMA support"
+  },
+  {
+    "name": "ucx-rdmacm",
+    "summary": "UCX RDMA connection manager support"
+  },
+  {
+    "name": "udftools",
+    "summary": "Linux UDF Filesystem userspace utilities"
+  },
+  {
+    "name": "udica",
+    "summary": "A tool for generating SELinux security policies for containers"
+  },
+  {
+    "name": "udisks2",
+    "summary": "Disk Manager"
+  },
+  {
+    "name": "udisks2-iscsi",
+    "summary": "Module for iSCSI"
+  },
+  {
+    "name": "udisks2-lsm",
+    "summary": "Module for LSM"
+  },
+  {
+    "name": "udisks2-lvm2",
+    "summary": "Module for LVM2"
+  },
+  {
+    "name": "uki-direct",
+    "summary": "Tools for virtual machine firmware volumes - test cases - manage UKI kernels."
+  },
+  {
+    "name": "unbound",
+    "summary": "Validating, recursive, and caching DNS(SEC) resolver"
+  },
+  {
+    "name": "unbound-dracut",
+    "summary": "Unbound dracut module"
+  },
+  {
+    "name": "unbound-libs",
+    "summary": "Libraries used by the unbound server and client applications"
+  },
+  {
+    "name": "unicode-ucd",
+    "summary": "Unicode Character Database"
+  },
+  {
+    "name": "univocity-parsers",
+    "summary": "Collection of parsers for Java"
+  },
+  {
+    "name": "unixODBC",
+    "summary": "A complete ODBC driver manager for Linux"
+  },
+  {
+    "name": "upower",
+    "summary": "Power Management Service"
+  },
+  {
+    "name": "uresourced",
+    "summary": "Dynamically allocate resources to the active user"
+  },
+  {
+    "name": "urlview",
+    "summary": "URL extractor/launcher"
+  },
+  {
+    "name": "urw-base35-bookman-fonts",
+    "summary": "URW Bookman font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-c059-fonts",
+    "summary": "C059 font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-d050000l-fonts",
+    "summary": "D050000L font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-fonts",
+    "summary": "Core Font Set containing 35 freely distributable fonts from (URW)++"
+  },
+  {
+    "name": "urw-base35-fonts-common",
+    "summary": "Common files of the (URW)++ Level 2 Core Font Set"
+  },
+  {
+    "name": "urw-base35-gothic-fonts",
+    "summary": "URW Gothic font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-nimbus-mono-ps-fonts",
+    "summary": "Nimbus Mono PS font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-nimbus-roman-fonts",
+    "summary": "Nimbus Roman font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-nimbus-sans-fonts",
+    "summary": "Nimbus Sans font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-p052-fonts",
+    "summary": "P052 font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-standard-symbols-ps-fonts",
+    "summary": "Standard Symbols PS font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "urw-base35-z003-fonts",
+    "summary": "Z003 font family [part of Level 2 Core Font Set]"
+  },
+  {
+    "name": "usbguard",
+    "summary": "A tool for implementing USB device usage policy"
+  },
+  {
+    "name": "usbguard-dbus",
+    "summary": "USBGuard D-Bus Service"
+  },
+  {
+    "name": "usbguard-notifier",
+    "summary": "A tool for detecting usbguard policy and device presence changes"
+  },
+  {
+    "name": "usbguard-selinux",
+    "summary": "USBGuard selinux"
+  },
+  {
+    "name": "usbguard-tools",
+    "summary": "USBGuard Tools"
+  },
+  {
+    "name": "usbredir",
+    "summary": "USB network redirection protocol libraries"
+  },
+  {
+    "name": "usbredir-server",
+    "summary": "Simple USB host TCP server"
+  },
+  {
+    "name": "usermode-gtk",
+    "summary": "Graphical tools for certain user account management tasks"
+  },
+  {
+    "name": "utf8proc",
+    "summary": "Library for processing UTF-8 encoded Unicode strings"
+  },
+  {
+    "name": "uuid",
+    "summary": "Universally Unique Identifier library"
+  },
+  {
+    "name": "uuid-c++",
+    "summary": "C++ support for Universally Unique Identifier library"
+  },
+  {
+    "name": "uuid-dce",
+    "summary": "DCE support for Universally Unique Identifier library"
+  },
+  {
+    "name": "uuidd",
+    "summary": "Helper daemon to guarantee uniqueness of time-based UUIDs"
+  },
+  {
+    "name": "valgrind",
+    "summary": "Tool for finding memory management bugs in programs"
+  },
+  {
+    "name": "valgrind-devel",
+    "summary": "Development files for valgrind aware programs"
+  },
+  {
+    "name": "varnish",
+    "summary": "High-performance HTTP accelerator"
+  },
+  {
+    "name": "varnish-docs",
+    "summary": "Documentation files for varnish"
+  },
+  {
+    "name": "varnish-modules",
+    "summary": "A collection of modules (\"vmods\") extending Varnish VCL"
+  },
+  {
+    "name": "vim-common",
+    "summary": "The common files needed by any version of the VIM editor"
+  },
+  {
+    "name": "vim-enhanced",
+    "summary": "A version of the VIM editor which includes recent enhancements"
+  },
+  {
+    "name": "vim-X11",
+    "summary": "The VIM version of the vi editor for the X Window System - GVim"
+  },
+  {
+    "name": "virt-install",
+    "summary": "Utilities for installing virtual machines"
+  },
+  {
+    "name": "virt-manager",
+    "summary": "Desktop tool for managing virtual machines via libvirt"
+  },
+  {
+    "name": "virt-manager-common",
+    "summary": "Common files used by the different Virtual Machine Manager interfaces"
+  },
+  {
+    "name": "virt-p2v",
+    "summary": "Convert a physical machine to run on KVM"
+  },
+  {
+    "name": "virt-top",
+    "summary": "Utility like top(1) for displaying virtualization stats"
+  },
+  {
+    "name": "virt-v2v",
+    "summary": "Convert a virtual machine to run on KVM"
+  },
+  {
+    "name": "virt-v2v-bash-completion",
+    "summary": "Bash tab-completion for virt-v2v"
+  },
+  {
+    "name": "virt-viewer",
+    "summary": "Virtual Machine Viewer"
+  },
+  {
+    "name": "virt-who",
+    "summary": "Agent for reporting virtual guest IDs to subscription-manager"
+  },
+  {
+    "name": "virt-win-reg",
+    "summary": "Access and modify the Windows Registry of a Windows VM"
+  },
+  {
+    "name": "virtio-win",
+    "summary": "VirtIO para-virtualized drivers for Windows(R)"
+  },
+  {
+    "name": "virtiofsd",
+    "summary": "Virtio-fs vhost-user device daemon (Rust version)"
+  },
+  {
+    "name": "voikko-fi",
+    "summary": "A description of Finnish morphology written for libvoikko"
+  },
+  {
+    "name": "volume_key",
+    "summary": "An utility for manipulating storage encryption keys and passphrases"
+  },
+  {
+    "name": "volume_key-libs",
+    "summary": "A library for manipulating storage encryption keys and passphrases"
+  },
+  {
+    "name": "vsftpd",
+    "summary": "Very Secure Ftp Daemon"
+  },
+  {
+    "name": "vte-profile",
+    "summary": "Profile script for VTE terminal emulator library"
+  },
+  {
+    "name": "vte291",
+    "summary": "Terminal emulator library"
+  },
+  {
+    "name": "vulkan-headers",
+    "summary": "Vulkan Header files and API registry"
+  },
+  {
+    "name": "vulkan-loader",
+    "summary": "Vulkan ICD desktop loader"
+  },
+  {
+    "name": "vulkan-loader-devel",
+    "summary": "Development files for vulkan-loader"
+  },
+  {
+    "name": "vulkan-tools",
+    "summary": "Vulkan tools"
+  },
+  {
+    "name": "vulkan-validation-layers",
+    "summary": "Vulkan validation layers"
+  },
+  {
+    "name": "vulkan-volk-devel",
+    "summary": "Development files for vulkan-volk"
+  },
+  {
+    "name": "WALinuxAgent",
+    "summary": "The Microsoft Azure Linux Agent"
+  },
+  {
+    "name": "WALinuxAgent-udev",
+    "summary": "Udev rules for Microsoft Azure"
+  },
+  {
+    "name": "watchdog",
+    "summary": "Software and/or Hardware watchdog daemon"
+  },
+  {
+    "name": "wavpack",
+    "summary": "A completely open audiocodec"
+  },
+  {
+    "name": "wayland-devel",
+    "summary": "Development files for wayland"
+  },
+  {
+    "name": "wayland-protocols-devel",
+    "summary": "Wayland protocols that adds functionality not available in the core protocol"
+  },
+  {
+    "name": "wayland-utils",
+    "summary": "Wayland utilities"
+  },
+  {
+    "name": "waypipe",
+    "summary": "Wayland forwarding proxy"
+  },
+  {
+    "name": "web-assets-filesystem",
+    "summary": "The basic directory layout for Web Assets"
+  },
+  {
+    "name": "webkit2gtk3",
+    "summary": "GTK Web content engine library"
+  },
+  {
+    "name": "webkit2gtk3-devel",
+    "summary": "Development files for webkit2gtk3"
+  },
+  {
+    "name": "webkit2gtk3-jsc",
+    "summary": "JavaScript engine from webkit2gtk3"
+  },
+  {
+    "name": "webkit2gtk3-jsc-devel",
+    "summary": "Development files for JavaScript engine from webkit2gtk3"
+  },
+  {
+    "name": "webrtc-audio-processing",
+    "summary": "Library for echo cancellation"
+  },
+  {
+    "name": "weldr-client",
+    "summary": "Command line utility to control osbuild-composer"
+  },
+  {
+    "name": "wget",
+    "summary": "A utility for retrieving files using the HTTP or FTP protocols"
+  },
+  {
+    "name": "whois",
+    "summary": "Improved WHOIS client"
+  },
+  {
+    "name": "whois-nls",
+    "summary": "Gettext catalogs for whois tools"
+  },
+  {
+    "name": "wireguard-tools",
+    "summary": "Fast, modern, secure VPN tunnel"
+  },
+  {
+    "name": "wireplumber",
+    "summary": "A modular session/policy manager for PipeWire"
+  },
+  {
+    "name": "wireplumber-libs",
+    "summary": "Libraries for WirePlumber clients"
+  },
+  {
+    "name": "wireshark",
+    "summary": "Network traffic analyzer"
+  },
+  {
+    "name": "wireshark-cli",
+    "summary": "Network traffic analyzer"
+  },
+  {
+    "name": "woff2",
+    "summary": "Web Open Font Format 2.0 library"
+  },
+  {
+    "name": "wpebackend-fdo",
+    "summary": "A WPE backend designed for Linux desktop systems"
+  },
+  {
+    "name": "wsmancli",
+    "summary": "WS-Management-Command line Interface"
+  },
+  {
+    "name": "x3270-x11",
+    "summary": "IBM 3278/3279 terminal emulator for the X Window System"
+  },
+  {
+    "name": "xalan-j2",
+    "summary": "Java XSLT processor"
+  },
+  {
+    "name": "xapian-core",
+    "summary": "The Xapian Probabilistic Information Retrieval Library"
+  },
+  {
+    "name": "xapian-core-libs",
+    "summary": "Xapian search engine libraries"
+  },
+  {
+    "name": "Xaw3d",
+    "summary": "A version of the MIT Athena widget set for X"
+  },
+  {
+    "name": "xcb-util",
+    "summary": "Convenience libraries sitting on top of libxcb"
+  },
+  {
+    "name": "xcb-util-cursor",
+    "summary": "Cursor library on top of libxcb"
+  },
+  {
+    "name": "xcb-util-cursor-devel",
+    "summary": "Development and header files for xcb-util-cursos"
+  },
+  {
+    "name": "xcb-util-image",
+    "summary": "Port of Xlib's XImage and XShmImage functions on top of libxcb"
+  },
+  {
+    "name": "xcb-util-image-devel",
+    "summary": "Development and header files for xcb-util-image"
+  },
+  {
+    "name": "xcb-util-keysyms",
+    "summary": "Standard X key constants and keycodes conversion on top of libxcb"
+  },
+  {
+    "name": "xcb-util-renderutil",
+    "summary": "Convenience functions for the Render extension"
+  },
+  {
+    "name": "xcb-util-renderutil-devel",
+    "summary": "Development and header files for xcb-util-renderutil"
+  },
+  {
+    "name": "xcb-util-wm",
+    "summary": "Client and window-manager helper library on top of libxcb"
+  },
+  {
+    "name": "xdg-dbus-proxy",
+    "summary": "Filtering proxy for D-Bus connections"
+  },
+  {
+    "name": "xdg-desktop-portal",
+    "summary": "Portal frontend service to flatpak"
+  },
+  {
+    "name": "xdg-desktop-portal-gnome",
+    "summary": "Backend implementation for xdg-desktop-portal using GNOME"
+  },
+  {
+    "name": "xdg-desktop-portal-gtk",
+    "summary": "Backend implementation for xdg-desktop-portal using GTK+"
+  },
+  {
+    "name": "xdg-user-dirs",
+    "summary": "Handles user special directories"
+  },
+  {
+    "name": "xdg-user-dirs-gtk",
+    "summary": "Gnome integration of special directories"
+  },
+  {
+    "name": "xdg-utils",
+    "summary": "Basic desktop integration functions"
+  },
+  {
+    "name": "xdp-tools",
+    "summary": "Utilities and example programs for use with XDP"
+  },
+  {
+    "name": "xerces-j2",
+    "summary": "Java XML parser"
+  },
+  {
+    "name": "xfsprogs-devel",
+    "summary": "XFS filesystem-specific headers"
+  },
+  {
+    "name": "xfsprogs-xfs_scrub",
+    "summary": "XFS filesystem online scrubbing utilities"
+  },
+  {
+    "name": "xhtml1-dtds",
+    "summary": "XHTML 1.0 document type definitions"
+  },
+  {
+    "name": "xhtml2fo-style-xsl",
+    "summary": "Antenna House, Inc. XHTML to XSL:FO stylesheets"
+  },
+  {
+    "name": "xkbcomp",
+    "summary": "XKB keymap compiler"
+  },
+  {
+    "name": "xkeyboard-config",
+    "summary": "X Keyboard Extension configuration data"
+  },
+  {
+    "name": "xkeyboard-config-devel",
+    "summary": "Development files for xkeyboard-config"
+  },
+  {
+    "name": "xml-common",
+    "summary": "Common XML catalog and DTD files"
+  },
+  {
+    "name": "xml-commons-apis",
+    "summary": "APIs for DOM, SAX, and JAXP"
+  },
+  {
+    "name": "xml-commons-resolver",
+    "summary": "Resolver subproject of xml-commons"
+  },
+  {
+    "name": "xmlrpc-c",
+    "summary": "Lightweight RPC library based on XML and HTTP"
+  },
+  {
+    "name": "xmlrpc-c-client",
+    "summary": "C client libraries for xmlrpc-c"
+  },
+  {
+    "name": "xmlsec1",
+    "summary": "Library providing support for \"XML Signature\" and \"XML Encryption\" standards"
+  },
+  {
+    "name": "xmlsec1-nss",
+    "summary": "NSS crypto plugin for XML Security Library"
+  },
+  {
+    "name": "xmlsec1-openssl",
+    "summary": "OpenSSL crypto plugin for XML Security Library"
+  },
+  {
+    "name": "xmlstarlet",
+    "summary": "Command Line XML Toolkit"
+  },
+  {
+    "name": "xmlto",
+    "summary": "A tool for converting XML files to various formats"
+  },
+  {
+    "name": "xmlto-tex",
+    "summary": "A set of xmlto backends with TeX requirements"
+  },
+  {
+    "name": "xmlto-xhtml",
+    "summary": "A set of xmlto backends for xhtml1 source format"
+  },
+  {
+    "name": "xorg-x11-drivers",
+    "summary": "X.Org X11 driver installation package"
+  },
+  {
+    "name": "xorg-x11-drv-dummy",
+    "summary": "Xorg X11 dummy video driver"
+  },
+  {
+    "name": "xorg-x11-drv-evdev",
+    "summary": "Xorg X11 evdev input driver"
+  },
+  {
+    "name": "xorg-x11-drv-fbdev",
+    "summary": "Xorg X11 fbdev video driver"
+  },
+  {
+    "name": "xorg-x11-drv-libinput",
+    "summary": "Xorg X11 libinput input driver"
+  },
+  {
+    "name": "xorg-x11-drv-v4l",
+    "summary": "Xorg X11 v4l video driver"
+  },
+  {
+    "name": "xorg-x11-drv-vmware",
+    "summary": "Xorg X11 vmware video driver"
+  },
+  {
+    "name": "xorg-x11-drv-wacom",
+    "summary": "Xorg X11 wacom input driver"
+  },
+  {
+    "name": "xorg-x11-drv-wacom-serial-support",
+    "summary": "Files for enabling the wacom_w8001 kernel driver"
+  },
+  {
+    "name": "xorg-x11-fonts-100dpi",
+    "summary": "A set of 100dpi resolution fonts for the X Window System"
+  },
+  {
+    "name": "xorg-x11-fonts-75dpi",
+    "summary": "A set of 75dpi resolution fonts for the X Window System"
+  },
+  {
+    "name": "xorg-x11-fonts-cyrillic",
+    "summary": "Cyrillic fonts for X"
+  },
+  {
+    "name": "xorg-x11-fonts-ethiopic",
+    "summary": "Ethiopic fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-1-100dpi",
+    "summary": "A set of 100dpi ISO-8859-1 fonts for X"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-1-75dpi",
+    "summary": "A set of 75dpi ISO-8859-1 fonts for X"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-14-100dpi",
+    "summary": "ISO8859-14-100dpi fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-14-75dpi",
+    "summary": "ISO8859-14-75dpi fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-15-100dpi",
+    "summary": "ISO8859-15-100dpi fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-15-75dpi",
+    "summary": "ISO8859-15-75dpi fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-2-100dpi",
+    "summary": "A set of 100dpi Central European language fonts for X"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-2-75dpi",
+    "summary": "A set of 75dpi Central European language fonts for X"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-9-100dpi",
+    "summary": "ISO8859-9-100dpi fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-ISO8859-9-75dpi",
+    "summary": "ISO8859-9-75dpi fonts"
+  },
+  {
+    "name": "xorg-x11-fonts-misc",
+    "summary": "misc bitmap fonts for the X Window System"
+  },
+  {
+    "name": "xorg-x11-fonts-Type1",
+    "summary": "Type1 fonts provided by the X Window System"
+  },
+  {
+    "name": "xorg-x11-proto-devel",
+    "summary": "X.Org X11 Protocol headers"
+  },
+  {
+    "name": "xorg-x11-server-common",
+    "summary": "Xorg server common files"
+  },
+  {
+    "name": "xorg-x11-server-utils",
+    "summary": "X.Org X11 X server utilities"
+  },
+  {
+    "name": "xorg-x11-server-Xdmx",
+    "summary": "Distributed Multihead X Server and utilities"
+  },
+  {
+    "name": "xorg-x11-server-Xephyr",
+    "summary": "A nested server"
+  },
+  {
+    "name": "xorg-x11-server-Xnest",
+    "summary": "A nested server"
+  },
+  {
+    "name": "xorg-x11-server-Xorg",
+    "summary": "Xorg X server"
+  },
+  {
+    "name": "xorg-x11-server-Xvfb",
+    "summary": "A X Windows System virtual framebuffer X server"
+  },
+  {
+    "name": "xorg-x11-server-Xwayland",
+    "summary": "Xwayland"
+  },
+  {
+    "name": "xorg-x11-utils",
+    "summary": "X.Org X11 X client utilities"
+  },
+  {
+    "name": "xorg-x11-xauth",
+    "summary": "X.Org X11 X authority utilities"
+  },
+  {
+    "name": "xorg-x11-xbitmaps",
+    "summary": "X.Org X11 application bitmaps"
+  },
+  {
+    "name": "xorg-x11-xinit",
+    "summary": "X.Org X11 X Window System xinit startup scripts"
+  },
+  {
+    "name": "xorg-x11-xinit-session",
+    "summary": "Display manager support for ~/.xsession and ~/.Xclients"
+  },
+  {
+    "name": "xorriso",
+    "summary": "ISO-9660 and Rock Ridge image manipulation tool"
+  },
+  {
+    "name": "xrestop",
+    "summary": "X Resource Monitor"
+  },
+  {
+    "name": "xsane",
+    "summary": "X Window System front-end for the SANE scanner interface"
+  },
+  {
+    "name": "xsane-common",
+    "summary": "Common files for xsane packages"
+  },
+  {
+    "name": "xterm",
+    "summary": "Terminal emulator for the X Window System"
+  },
+  {
+    "name": "xterm-resize",
+    "summary": "Set environment and terminal settings to current window size"
+  },
+  {
+    "name": "xxhash",
+    "summary": "Extremely fast hash algorithm"
+  },
+  {
+    "name": "xxhash-libs",
+    "summary": "Extremely fast hash algorithm - library"
+  },
+  {
+    "name": "xz-devel",
+    "summary": "Devel libraries & headers for liblzma"
+  },
+  {
+    "name": "xz-java",
+    "summary": "Java implementation of XZ data compression"
+  },
+  {
+    "name": "xz-lzma-compat",
+    "summary": "Older LZMA format compatibility binaries"
+  },
+  {
+    "name": "yajl",
+    "summary": "Yet Another JSON Library (YAJL)"
+  },
+  {
+    "name": "yara",
+    "summary": "Pattern matching Swiss knife for malware researchers"
+  },
+  {
+    "name": "yelp",
+    "summary": "Help browser for the GNOME desktop"
+  },
+  {
+    "name": "yelp-libs",
+    "summary": "Libraries for yelp"
+  },
+  {
+    "name": "yelp-tools",
+    "summary": "Create, manage, and publish documentation for Yelp"
+  },
+  {
+    "name": "yelp-xsl",
+    "summary": "XSL stylesheets for the yelp help browser"
+  },
+  {
+    "name": "zenity",
+    "summary": "Display dialog boxes from shell scripts"
+  },
+  {
+    "name": "zlib-devel",
+    "summary": "Header files and libraries for Zlib development"
+  },
+  {
+    "name": "zram-generator",
+    "summary": "Systemd unit generator for zram swap devices"
+  },
+  {
+    "name": "zziplib",
+    "summary": "Lightweight library to easily extract data from zip files"
+  },
+  {
+    "name": "zziplib-utils",
+    "summary": "Utilities for the zziplib library"
+  }
+]

--- a/distributions/rhel-9.6/rhel-9.6-x86_64-baseos-packages.json
+++ b/distributions/rhel-9.6/rhel-9.6-x86_64-baseos-packages.json
@@ -1,0 +1,3802 @@
+[
+  {
+    "name": "accel-config",
+    "summary": "Configure accelerator subsystem devices"
+  },
+  {
+    "name": "accel-config-libs",
+    "summary": "Configuration library for accelerator subsystem devices"
+  },
+  {
+    "name": "acl",
+    "summary": "Access control list utilities"
+  },
+  {
+    "name": "acpica-tools",
+    "summary": "ACPICA tools for the development and debug of ACPI tables"
+  },
+  {
+    "name": "adcli",
+    "summary": "Active Directory enrollment"
+  },
+  {
+    "name": "adobe-source-code-pro-fonts",
+    "summary": "A set of mono-spaced OpenType fonts designed for coding environments"
+  },
+  {
+    "name": "alternatives",
+    "summary": "A tool to maintain symbolic links determining default commands"
+  },
+  {
+    "name": "at",
+    "summary": "Job spooling tools"
+  },
+  {
+    "name": "atlas",
+    "summary": "Automatically Tuned Linear Algebra Software"
+  },
+  {
+    "name": "attr",
+    "summary": "Utilities for managing filesystem extended attributes"
+  },
+  {
+    "name": "audispd-plugins",
+    "summary": "Plugins for the audit event dispatcher"
+  },
+  {
+    "name": "audispd-plugins-zos",
+    "summary": "z/OS plugin for the audit event dispatcher"
+  },
+  {
+    "name": "audit",
+    "summary": "User space tools for kernel auditing"
+  },
+  {
+    "name": "audit-libs",
+    "summary": "Dynamic library for libaudit"
+  },
+  {
+    "name": "authselect",
+    "summary": "Configures authentication and identity sources from supported profiles"
+  },
+  {
+    "name": "authselect-libs",
+    "summary": "Utility library used by the authselect tool"
+  },
+  {
+    "name": "autofs",
+    "summary": "A tool for automatically mounting and unmounting filesystems"
+  },
+  {
+    "name": "avahi",
+    "summary": "Local network service discovery"
+  },
+  {
+    "name": "avahi-libs",
+    "summary": "Libraries for avahi run-time use"
+  },
+  {
+    "name": "basesystem",
+    "summary": "The skeleton package which defines a simple Red Hat Enterprise Linux system"
+  },
+  {
+    "name": "bash",
+    "summary": "The GNU Bourne Again shell"
+  },
+  {
+    "name": "bash-completion",
+    "summary": "Programmable completion for Bash"
+  },
+  {
+    "name": "bc",
+    "summary": "GNU's bc (a numeric processing language) and dc (a calculator)"
+  },
+  {
+    "name": "binutils",
+    "summary": "A GNU collection of binary utilities"
+  },
+  {
+    "name": "binutils-gold",
+    "summary": "The GOLD linker, a faster alternative to the BFD linker"
+  },
+  {
+    "name": "biosdevname",
+    "summary": "Udev helper for naming devices per BIOS names"
+  },
+  {
+    "name": "bluez",
+    "summary": "Bluetooth utilities"
+  },
+  {
+    "name": "bluez-libs",
+    "summary": "Libraries for use in Bluetooth applications"
+  },
+  {
+    "name": "bolt",
+    "summary": "Thunderbolt device manager"
+  },
+  {
+    "name": "bpftool",
+    "summary": "Inspection and simple manipulation of eBPF programs and maps"
+  },
+  {
+    "name": "bubblewrap",
+    "summary": "Core execution tool for unprivileged containers"
+  },
+  {
+    "name": "bzip2",
+    "summary": "A file compression utility"
+  },
+  {
+    "name": "bzip2-libs",
+    "summary": "Libraries for applications using bzip2"
+  },
+  {
+    "name": "c-ares",
+    "summary": "A library that performs asynchronous DNS operations"
+  },
+  {
+    "name": "ca-certificates",
+    "summary": "The Mozilla CA root certificate bundle"
+  },
+  {
+    "name": "cachefilesd",
+    "summary": "CacheFiles user-space management daemon"
+  },
+  {
+    "name": "chkconfig",
+    "summary": "A system tool for maintaining the /etc/rc*.d hierarchy"
+  },
+  {
+    "name": "chrony",
+    "summary": "An NTP client/server"
+  },
+  {
+    "name": "chrpath",
+    "summary": "Modify rpath of compiled programs"
+  },
+  {
+    "name": "cifs-utils",
+    "summary": "Utilities for mounting and managing CIFS mounts"
+  },
+  {
+    "name": "cockpit",
+    "summary": "Web Console for Linux servers"
+  },
+  {
+    "name": "cockpit-bridge",
+    "summary": "Cockpit bridge server-side component"
+  },
+  {
+    "name": "cockpit-doc",
+    "summary": "Cockpit deployment and developer guide"
+  },
+  {
+    "name": "cockpit-system",
+    "summary": "Cockpit admin interface package for configuring and troubleshooting a system"
+  },
+  {
+    "name": "cockpit-ws",
+    "summary": "Cockpit Web Service"
+  },
+  {
+    "name": "coreutils",
+    "summary": "A set of basic GNU tools commonly used in shell scripts"
+  },
+  {
+    "name": "coreutils-common",
+    "summary": "coreutils common optional components"
+  },
+  {
+    "name": "coreutils-single",
+    "summary": "coreutils multicall binary"
+  },
+  {
+    "name": "cpio",
+    "summary": "A GNU archiving program"
+  },
+  {
+    "name": "cracklib",
+    "summary": "A password-checking library"
+  },
+  {
+    "name": "cracklib-dicts",
+    "summary": "The standard CrackLib dictionaries"
+  },
+  {
+    "name": "cronie",
+    "summary": "Cron daemon for executing programs at set times"
+  },
+  {
+    "name": "cronie-anacron",
+    "summary": "Utility for running regular jobs"
+  },
+  {
+    "name": "cronie-noanacron",
+    "summary": "Utility for running simple regular jobs in old cron style"
+  },
+  {
+    "name": "crontabs",
+    "summary": "Root crontab files used to schedule the execution of programs"
+  },
+  {
+    "name": "crypto-policies",
+    "summary": "System-wide crypto policies"
+  },
+  {
+    "name": "crypto-policies-scripts",
+    "summary": "Tool to switch between crypto policies"
+  },
+  {
+    "name": "cryptsetup",
+    "summary": "Utility for setting up encrypted disks"
+  },
+  {
+    "name": "cryptsetup-libs",
+    "summary": "Cryptsetup shared library"
+  },
+  {
+    "name": "cups-libs",
+    "summary": "CUPS printing system - libraries"
+  },
+  {
+    "name": "curl",
+    "summary": "A utility for getting files from remote servers (FTP, HTTP, and others)"
+  },
+  {
+    "name": "curl-minimal",
+    "summary": "Conservatively configured build of curl for minimal installations"
+  },
+  {
+    "name": "cxl-libs",
+    "summary": "Management library for CXL devices"
+  },
+  {
+    "name": "cyrus-sasl",
+    "summary": "The Cyrus SASL library"
+  },
+  {
+    "name": "cyrus-sasl-gssapi",
+    "summary": "GSSAPI authentication support for Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-lib",
+    "summary": "Shared libraries needed by applications which use Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-plain",
+    "summary": "PLAIN and LOGIN authentication support for Cyrus SASL"
+  },
+  {
+    "name": "cyrus-sasl-scram",
+    "summary": "SCRAM auxprop support for Cyrus SASL"
+  },
+  {
+    "name": "daxctl-libs",
+    "summary": "Management library for \"Device DAX\" devices"
+  },
+  {
+    "name": "dbus",
+    "summary": "D-BUS message bus"
+  },
+  {
+    "name": "dbus-broker",
+    "summary": "Linux D-Bus Message Broker"
+  },
+  {
+    "name": "dbus-common",
+    "summary": "D-BUS message bus configuration"
+  },
+  {
+    "name": "dbus-libs",
+    "summary": "Libraries for accessing D-BUS"
+  },
+  {
+    "name": "dbus-tools",
+    "summary": "D-BUS Tools and Utilities"
+  },
+  {
+    "name": "dejavu-sans-fonts",
+    "summary": "DejaVu Sans, a variable-width sans-serif font family"
+  },
+  {
+    "name": "dejavu-sans-mono-fonts",
+    "summary": "DejaVu Sans Mono, a mono-space sans-serif font family"
+  },
+  {
+    "name": "dejavu-serif-fonts",
+    "summary": "DejaVu Serif, a variable-width serif font family"
+  },
+  {
+    "name": "device-mapper",
+    "summary": "Device mapper utility"
+  },
+  {
+    "name": "device-mapper-event",
+    "summary": "Device-mapper event daemon"
+  },
+  {
+    "name": "device-mapper-event-libs",
+    "summary": "Device-mapper event daemon shared library"
+  },
+  {
+    "name": "device-mapper-libs",
+    "summary": "Device-mapper shared library"
+  },
+  {
+    "name": "device-mapper-multipath",
+    "summary": "Tools to manage multipath devices using device-mapper"
+  },
+  {
+    "name": "device-mapper-multipath-libs",
+    "summary": "The device-mapper-multipath modules and shared library"
+  },
+  {
+    "name": "device-mapper-persistent-data",
+    "summary": "Device-mapper Persistent Data Tools"
+  },
+  {
+    "name": "dhcp-client",
+    "summary": "Provides the ISC DHCP client daemon and dhclient-script"
+  },
+  {
+    "name": "dhcp-common",
+    "summary": "Common files used by ISC dhcp client, server and relay agent"
+  },
+  {
+    "name": "dhcp-relay",
+    "summary": "Provides the ISC DHCP relay agent"
+  },
+  {
+    "name": "dhcp-server",
+    "summary": "Provides the ISC DHCP server"
+  },
+  {
+    "name": "diffutils",
+    "summary": "GNU collection of diff utilities"
+  },
+  {
+    "name": "dmidecode",
+    "summary": "Tool to analyse BIOS DMI data"
+  },
+  {
+    "name": "dnf",
+    "summary": "Package manager"
+  },
+  {
+    "name": "dnf-automatic",
+    "summary": "Package manager - automated upgrades"
+  },
+  {
+    "name": "dnf-data",
+    "summary": "Common data and configuration files for DNF"
+  },
+  {
+    "name": "dnf-plugins-core",
+    "summary": "Core Plugins for DNF"
+  },
+  {
+    "name": "dos2unix",
+    "summary": "Text file format converters"
+  },
+  {
+    "name": "dosfstools",
+    "summary": "Utilities for making and checking MS-DOS FAT filesystems on Linux"
+  },
+  {
+    "name": "dracut",
+    "summary": "Initramfs generator using udev"
+  },
+  {
+    "name": "dracut-config-generic",
+    "summary": "dracut configuration to turn off hostonly image generation"
+  },
+  {
+    "name": "dracut-config-rescue",
+    "summary": "dracut configuration to turn on rescue image generation"
+  },
+  {
+    "name": "dracut-network",
+    "summary": "dracut modules to build a dracut initramfs with network support"
+  },
+  {
+    "name": "dracut-squash",
+    "summary": "dracut module to build an initramfs with most files in a squashfs image"
+  },
+  {
+    "name": "dracut-tools",
+    "summary": "dracut tools to build the local initramfs"
+  },
+  {
+    "name": "e2fsprogs",
+    "summary": "Utilities for managing ext2, ext3, and ext4 file systems"
+  },
+  {
+    "name": "e2fsprogs-libs",
+    "summary": "Ext2/3/4 file system specific shared libraries"
+  },
+  {
+    "name": "ed",
+    "summary": "The GNU line editor"
+  },
+  {
+    "name": "efi-filesystem",
+    "summary": "The basic directory layout for EFI machines"
+  },
+  {
+    "name": "efibootmgr",
+    "summary": "EFI Boot Manager"
+  },
+  {
+    "name": "efivar-libs",
+    "summary": "Library to manage UEFI variables"
+  },
+  {
+    "name": "elfutils",
+    "summary": "A collection of utilities and DSOs to handle ELF files and DWARF data"
+  },
+  {
+    "name": "elfutils-debuginfod-client",
+    "summary": "Library and command line client for build-id HTTP ELF/DWARF server"
+  },
+  {
+    "name": "elfutils-default-yama-scope",
+    "summary": "Default yama attach scope sysctl setting"
+  },
+  {
+    "name": "elfutils-libelf",
+    "summary": "Library to read and write ELF files"
+  },
+  {
+    "name": "elfutils-libs",
+    "summary": "Libraries to handle compiled objects"
+  },
+  {
+    "name": "environment-modules",
+    "summary": "Provides dynamic modification of a user's environment"
+  },
+  {
+    "name": "ethtool",
+    "summary": "Settings tool for Ethernet NICs"
+  },
+  {
+    "name": "exfatprogs",
+    "summary": "Userspace utilities for exFAT filesystems"
+  },
+  {
+    "name": "expat",
+    "summary": "An XML parser library"
+  },
+  {
+    "name": "fcoe-utils",
+    "summary": "Fibre Channel over Ethernet utilities"
+  },
+  {
+    "name": "file",
+    "summary": "Utility for determining file types"
+  },
+  {
+    "name": "file-libs",
+    "summary": "Libraries for applications using libmagic"
+  },
+  {
+    "name": "filesystem",
+    "summary": "The basic directory layout for a Linux system"
+  },
+  {
+    "name": "findutils",
+    "summary": "The GNU versions of find utilities (find and xargs)"
+  },
+  {
+    "name": "firewalld",
+    "summary": "A firewall daemon with D-Bus interface providing a dynamic firewall"
+  },
+  {
+    "name": "firewalld-filesystem",
+    "summary": "Firewalld directory layout and rpm macros"
+  },
+  {
+    "name": "fonts-filesystem",
+    "summary": "Directories used by font packages"
+  },
+  {
+    "name": "freetype",
+    "summary": "A free and portable font rendering engine"
+  },
+  {
+    "name": "fuse",
+    "summary": "File System in Userspace (FUSE) v2 utilities"
+  },
+  {
+    "name": "fuse-common",
+    "summary": "Common files for File System in Userspace (FUSE) v2 and v3"
+  },
+  {
+    "name": "fuse-libs",
+    "summary": "File System in Userspace (FUSE) v2 libraries"
+  },
+  {
+    "name": "fwupd",
+    "summary": "Firmware update daemon"
+  },
+  {
+    "name": "gawk",
+    "summary": "The GNU version of the AWK text processing utility"
+  },
+  {
+    "name": "gdbm-libs",
+    "summary": "Libraries files for gdbm"
+  },
+  {
+    "name": "gettext",
+    "summary": "GNU libraries and utilities for producing multi-lingual messages"
+  },
+  {
+    "name": "gettext-libs",
+    "summary": "Libraries for gettext"
+  },
+  {
+    "name": "glib-networking",
+    "summary": "Networking support for GLib"
+  },
+  {
+    "name": "glib2",
+    "summary": "A library of handy utility functions"
+  },
+  {
+    "name": "glibc",
+    "summary": "The GNU libc libraries"
+  },
+  {
+    "name": "glibc-all-langpacks",
+    "summary": "All language packs for glibc."
+  },
+  {
+    "name": "glibc-common",
+    "summary": "Common binaries and locale data for glibc"
+  },
+  {
+    "name": "glibc-gconv-extra",
+    "summary": "All iconv converter modules for glibc."
+  },
+  {
+    "name": "glibc-langpack-aa",
+    "summary": "Locale data for Afar"
+  },
+  {
+    "name": "glibc-langpack-af",
+    "summary": "Locale data for Afrikaans"
+  },
+  {
+    "name": "glibc-langpack-agr",
+    "summary": "Locale data for Aguaruna"
+  },
+  {
+    "name": "glibc-langpack-ak",
+    "summary": "Locale data for Akan"
+  },
+  {
+    "name": "glibc-langpack-am",
+    "summary": "Locale data for Amharic"
+  },
+  {
+    "name": "glibc-langpack-an",
+    "summary": "Locale data for Aragonese"
+  },
+  {
+    "name": "glibc-langpack-anp",
+    "summary": "Locale data for Angika"
+  },
+  {
+    "name": "glibc-langpack-ar",
+    "summary": "Locale data for Arabic"
+  },
+  {
+    "name": "glibc-langpack-as",
+    "summary": "Locale data for Assamese"
+  },
+  {
+    "name": "glibc-langpack-ast",
+    "summary": "Locale data for Asturian"
+  },
+  {
+    "name": "glibc-langpack-ayc",
+    "summary": "Locale data for Southern Aymara"
+  },
+  {
+    "name": "glibc-langpack-az",
+    "summary": "Locale data for Azerbaijani"
+  },
+  {
+    "name": "glibc-langpack-be",
+    "summary": "Locale data for Belarusian"
+  },
+  {
+    "name": "glibc-langpack-bem",
+    "summary": "Locale data for Bemba"
+  },
+  {
+    "name": "glibc-langpack-ber",
+    "summary": "Locale data for Berber"
+  },
+  {
+    "name": "glibc-langpack-bg",
+    "summary": "Locale data for Bulgarian"
+  },
+  {
+    "name": "glibc-langpack-bhb",
+    "summary": "Locale data for Bhili"
+  },
+  {
+    "name": "glibc-langpack-bho",
+    "summary": "Locale data for Bhojpuri"
+  },
+  {
+    "name": "glibc-langpack-bi",
+    "summary": "Locale data for Bislama"
+  },
+  {
+    "name": "glibc-langpack-bn",
+    "summary": "Locale data for Bangla"
+  },
+  {
+    "name": "glibc-langpack-bo",
+    "summary": "Locale data for Tibetan"
+  },
+  {
+    "name": "glibc-langpack-br",
+    "summary": "Locale data for Breton"
+  },
+  {
+    "name": "glibc-langpack-brx",
+    "summary": "Locale data for Bodo"
+  },
+  {
+    "name": "glibc-langpack-bs",
+    "summary": "Locale data for Bosnian"
+  },
+  {
+    "name": "glibc-langpack-byn",
+    "summary": "Locale data for Blin"
+  },
+  {
+    "name": "glibc-langpack-ca",
+    "summary": "Locale data for Catalan"
+  },
+  {
+    "name": "glibc-langpack-ce",
+    "summary": "Locale data for Chechen"
+  },
+  {
+    "name": "glibc-langpack-chr",
+    "summary": "Locale data for Cherokee"
+  },
+  {
+    "name": "glibc-langpack-ckb",
+    "summary": "Locale data for Central Kurdish"
+  },
+  {
+    "name": "glibc-langpack-cmn",
+    "summary": "Locale data for Mandarin Chinese"
+  },
+  {
+    "name": "glibc-langpack-crh",
+    "summary": "Locale data for Crimean Turkish"
+  },
+  {
+    "name": "glibc-langpack-cs",
+    "summary": "Locale data for Czech"
+  },
+  {
+    "name": "glibc-langpack-csb",
+    "summary": "Locale data for Kashubian"
+  },
+  {
+    "name": "glibc-langpack-cv",
+    "summary": "Locale data for Chuvash"
+  },
+  {
+    "name": "glibc-langpack-cy",
+    "summary": "Locale data for Welsh"
+  },
+  {
+    "name": "glibc-langpack-da",
+    "summary": "Locale data for Danish"
+  },
+  {
+    "name": "glibc-langpack-de",
+    "summary": "Locale data for German"
+  },
+  {
+    "name": "glibc-langpack-doi",
+    "summary": "Locale data for Dogri"
+  },
+  {
+    "name": "glibc-langpack-dsb",
+    "summary": "Locale data for Lower Sorbian"
+  },
+  {
+    "name": "glibc-langpack-dv",
+    "summary": "Locale data for Divehi"
+  },
+  {
+    "name": "glibc-langpack-dz",
+    "summary": "Locale data for Dzongkha"
+  },
+  {
+    "name": "glibc-langpack-el",
+    "summary": "Locale data for Greek"
+  },
+  {
+    "name": "glibc-langpack-en",
+    "summary": "Locale data for English"
+  },
+  {
+    "name": "glibc-langpack-eo",
+    "summary": "Locale data for Esperanto"
+  },
+  {
+    "name": "glibc-langpack-es",
+    "summary": "Locale data for Spanish"
+  },
+  {
+    "name": "glibc-langpack-et",
+    "summary": "Locale data for Estonian"
+  },
+  {
+    "name": "glibc-langpack-eu",
+    "summary": "Locale data for Basque"
+  },
+  {
+    "name": "glibc-langpack-fa",
+    "summary": "Locale data for Persian"
+  },
+  {
+    "name": "glibc-langpack-ff",
+    "summary": "Locale data for Fulah"
+  },
+  {
+    "name": "glibc-langpack-fi",
+    "summary": "Locale data for Finnish"
+  },
+  {
+    "name": "glibc-langpack-fil",
+    "summary": "Locale data for Filipino"
+  },
+  {
+    "name": "glibc-langpack-fo",
+    "summary": "Locale data for Faroese"
+  },
+  {
+    "name": "glibc-langpack-fr",
+    "summary": "Locale data for French"
+  },
+  {
+    "name": "glibc-langpack-fur",
+    "summary": "Locale data for Friulian"
+  },
+  {
+    "name": "glibc-langpack-fy",
+    "summary": "Locale data for Western Frisian"
+  },
+  {
+    "name": "glibc-langpack-ga",
+    "summary": "Locale data for Irish"
+  },
+  {
+    "name": "glibc-langpack-gd",
+    "summary": "Locale data for Scottish Gaelic"
+  },
+  {
+    "name": "glibc-langpack-gez",
+    "summary": "Locale data for Geez"
+  },
+  {
+    "name": "glibc-langpack-gl",
+    "summary": "Locale data for Galician"
+  },
+  {
+    "name": "glibc-langpack-gu",
+    "summary": "Locale data for Gujarati"
+  },
+  {
+    "name": "glibc-langpack-gv",
+    "summary": "Locale data for Manx"
+  },
+  {
+    "name": "glibc-langpack-ha",
+    "summary": "Locale data for Hausa"
+  },
+  {
+    "name": "glibc-langpack-hak",
+    "summary": "Locale data for Hakka Chinese"
+  },
+  {
+    "name": "glibc-langpack-he",
+    "summary": "Locale data for Hebrew"
+  },
+  {
+    "name": "glibc-langpack-hi",
+    "summary": "Locale data for Hindi"
+  },
+  {
+    "name": "glibc-langpack-hif",
+    "summary": "Locale data for Fiji Hindi"
+  },
+  {
+    "name": "glibc-langpack-hne",
+    "summary": "Locale data for Chhattisgarhi"
+  },
+  {
+    "name": "glibc-langpack-hr",
+    "summary": "Locale data for Croatian"
+  },
+  {
+    "name": "glibc-langpack-hsb",
+    "summary": "Locale data for Upper Sorbian"
+  },
+  {
+    "name": "glibc-langpack-ht",
+    "summary": "Locale data for Haitian Creole"
+  },
+  {
+    "name": "glibc-langpack-hu",
+    "summary": "Locale data for Hungarian"
+  },
+  {
+    "name": "glibc-langpack-hy",
+    "summary": "Locale data for Armenian"
+  },
+  {
+    "name": "glibc-langpack-ia",
+    "summary": "Locale data for Interlingua"
+  },
+  {
+    "name": "glibc-langpack-id",
+    "summary": "Locale data for Indonesian"
+  },
+  {
+    "name": "glibc-langpack-ig",
+    "summary": "Locale data for Igbo"
+  },
+  {
+    "name": "glibc-langpack-ik",
+    "summary": "Locale data for Inupiaq"
+  },
+  {
+    "name": "glibc-langpack-is",
+    "summary": "Locale data for Icelandic"
+  },
+  {
+    "name": "glibc-langpack-it",
+    "summary": "Locale data for Italian"
+  },
+  {
+    "name": "glibc-langpack-iu",
+    "summary": "Locale data for Inuktitut"
+  },
+  {
+    "name": "glibc-langpack-ja",
+    "summary": "Locale data for Japanese"
+  },
+  {
+    "name": "glibc-langpack-ka",
+    "summary": "Locale data for Georgian"
+  },
+  {
+    "name": "glibc-langpack-kab",
+    "summary": "Locale data for Kabyle"
+  },
+  {
+    "name": "glibc-langpack-kk",
+    "summary": "Locale data for Kazakh"
+  },
+  {
+    "name": "glibc-langpack-kl",
+    "summary": "Locale data for Kalaallisut"
+  },
+  {
+    "name": "glibc-langpack-km",
+    "summary": "Locale data for Khmer"
+  },
+  {
+    "name": "glibc-langpack-kn",
+    "summary": "Locale data for Kannada"
+  },
+  {
+    "name": "glibc-langpack-ko",
+    "summary": "Locale data for Korean"
+  },
+  {
+    "name": "glibc-langpack-kok",
+    "summary": "Locale data for Konkani"
+  },
+  {
+    "name": "glibc-langpack-ks",
+    "summary": "Locale data for Kashmiri"
+  },
+  {
+    "name": "glibc-langpack-ku",
+    "summary": "Locale data for Kurdish"
+  },
+  {
+    "name": "glibc-langpack-kw",
+    "summary": "Locale data for Cornish"
+  },
+  {
+    "name": "glibc-langpack-ky",
+    "summary": "Locale data for Kyrgyz"
+  },
+  {
+    "name": "glibc-langpack-lb",
+    "summary": "Locale data for Luxembourgish"
+  },
+  {
+    "name": "glibc-langpack-lg",
+    "summary": "Locale data for Ganda"
+  },
+  {
+    "name": "glibc-langpack-li",
+    "summary": "Locale data for Limburgish"
+  },
+  {
+    "name": "glibc-langpack-lij",
+    "summary": "Locale data for Ligurian"
+  },
+  {
+    "name": "glibc-langpack-ln",
+    "summary": "Locale data for Lingala"
+  },
+  {
+    "name": "glibc-langpack-lo",
+    "summary": "Locale data for Lao"
+  },
+  {
+    "name": "glibc-langpack-lt",
+    "summary": "Locale data for Lithuanian"
+  },
+  {
+    "name": "glibc-langpack-lv",
+    "summary": "Locale data for Latvian"
+  },
+  {
+    "name": "glibc-langpack-lzh",
+    "summary": "Locale data for Literary Chinese"
+  },
+  {
+    "name": "glibc-langpack-mag",
+    "summary": "Locale data for Magahi"
+  },
+  {
+    "name": "glibc-langpack-mai",
+    "summary": "Locale data for Maithili"
+  },
+  {
+    "name": "glibc-langpack-mfe",
+    "summary": "Locale data for Morisyen"
+  },
+  {
+    "name": "glibc-langpack-mg",
+    "summary": "Locale data for Malagasy"
+  },
+  {
+    "name": "glibc-langpack-mhr",
+    "summary": "Locale data for Meadow Mari"
+  },
+  {
+    "name": "glibc-langpack-mi",
+    "summary": "Locale data for Maori"
+  },
+  {
+    "name": "glibc-langpack-miq",
+    "summary": "Locale data for Miskito"
+  },
+  {
+    "name": "glibc-langpack-mjw",
+    "summary": "Locale data for Karbi"
+  },
+  {
+    "name": "glibc-langpack-mk",
+    "summary": "Locale data for Macedonian"
+  },
+  {
+    "name": "glibc-langpack-ml",
+    "summary": "Locale data for Malayalam"
+  },
+  {
+    "name": "glibc-langpack-mn",
+    "summary": "Locale data for Mongolian"
+  },
+  {
+    "name": "glibc-langpack-mni",
+    "summary": "Locale data for Manipuri"
+  },
+  {
+    "name": "glibc-langpack-mnw",
+    "summary": "Locale data for Mon"
+  },
+  {
+    "name": "glibc-langpack-mr",
+    "summary": "Locale data for Marathi"
+  },
+  {
+    "name": "glibc-langpack-ms",
+    "summary": "Locale data for Malay"
+  },
+  {
+    "name": "glibc-langpack-mt",
+    "summary": "Locale data for Maltese"
+  },
+  {
+    "name": "glibc-langpack-my",
+    "summary": "Locale data for Burmese"
+  },
+  {
+    "name": "glibc-langpack-nan",
+    "summary": "Locale data for Min Nan Chinese"
+  },
+  {
+    "name": "glibc-langpack-nb",
+    "summary": "Locale data for Norwegian Bokm\u00e5l"
+  },
+  {
+    "name": "glibc-langpack-nds",
+    "summary": "Locale data for Low German"
+  },
+  {
+    "name": "glibc-langpack-ne",
+    "summary": "Locale data for Nepali"
+  },
+  {
+    "name": "glibc-langpack-nhn",
+    "summary": "Locale data for Tlaxcala-Puebla Nahuatl"
+  },
+  {
+    "name": "glibc-langpack-niu",
+    "summary": "Locale data for Niuean"
+  },
+  {
+    "name": "glibc-langpack-nl",
+    "summary": "Locale data for Dutch"
+  },
+  {
+    "name": "glibc-langpack-nn",
+    "summary": "Locale data for Norwegian Nynorsk"
+  },
+  {
+    "name": "glibc-langpack-nr",
+    "summary": "Locale data for South Ndebele"
+  },
+  {
+    "name": "glibc-langpack-nso",
+    "summary": "Locale data for Northern Sotho"
+  },
+  {
+    "name": "glibc-langpack-oc",
+    "summary": "Locale data for Occitan"
+  },
+  {
+    "name": "glibc-langpack-om",
+    "summary": "Locale data for Oromo"
+  },
+  {
+    "name": "glibc-langpack-or",
+    "summary": "Locale data for Odia"
+  },
+  {
+    "name": "glibc-langpack-os",
+    "summary": "Locale data for Ossetic"
+  },
+  {
+    "name": "glibc-langpack-pa",
+    "summary": "Locale data for Punjabi"
+  },
+  {
+    "name": "glibc-langpack-pap",
+    "summary": "Locale data for Papiamento"
+  },
+  {
+    "name": "glibc-langpack-pl",
+    "summary": "Locale data for Polish"
+  },
+  {
+    "name": "glibc-langpack-ps",
+    "summary": "Locale data for Pashto"
+  },
+  {
+    "name": "glibc-langpack-pt",
+    "summary": "Locale data for Portuguese"
+  },
+  {
+    "name": "glibc-langpack-quz",
+    "summary": "Locale data for Cusco Quechua"
+  },
+  {
+    "name": "glibc-langpack-raj",
+    "summary": "Locale data for Rajasthani"
+  },
+  {
+    "name": "glibc-langpack-ro",
+    "summary": "Locale data for Romanian"
+  },
+  {
+    "name": "glibc-langpack-ru",
+    "summary": "Locale data for Russian"
+  },
+  {
+    "name": "glibc-langpack-rw",
+    "summary": "Locale data for Kinyarwanda"
+  },
+  {
+    "name": "glibc-langpack-sa",
+    "summary": "Locale data for Sanskrit"
+  },
+  {
+    "name": "glibc-langpack-sah",
+    "summary": "Locale data for Sakha"
+  },
+  {
+    "name": "glibc-langpack-sat",
+    "summary": "Locale data for Santali"
+  },
+  {
+    "name": "glibc-langpack-sc",
+    "summary": "Locale data for Sardinian"
+  },
+  {
+    "name": "glibc-langpack-sd",
+    "summary": "Locale data for Sindhi"
+  },
+  {
+    "name": "glibc-langpack-se",
+    "summary": "Locale data for Northern Sami"
+  },
+  {
+    "name": "glibc-langpack-sgs",
+    "summary": "Locale data for Samogitian"
+  },
+  {
+    "name": "glibc-langpack-shn",
+    "summary": "Locale data for Shan"
+  },
+  {
+    "name": "glibc-langpack-shs",
+    "summary": "Locale data for Shuswap"
+  },
+  {
+    "name": "glibc-langpack-si",
+    "summary": "Locale data for Sinhala"
+  },
+  {
+    "name": "glibc-langpack-sid",
+    "summary": "Locale data for Sidamo"
+  },
+  {
+    "name": "glibc-langpack-sk",
+    "summary": "Locale data for Slovak"
+  },
+  {
+    "name": "glibc-langpack-sl",
+    "summary": "Locale data for Slovenian"
+  },
+  {
+    "name": "glibc-langpack-sm",
+    "summary": "Locale data for Samoan"
+  },
+  {
+    "name": "glibc-langpack-so",
+    "summary": "Locale data for Somali"
+  },
+  {
+    "name": "glibc-langpack-sq",
+    "summary": "Locale data for Albanian"
+  },
+  {
+    "name": "glibc-langpack-sr",
+    "summary": "Locale data for Serbian"
+  },
+  {
+    "name": "glibc-langpack-ss",
+    "summary": "Locale data for Swati"
+  },
+  {
+    "name": "glibc-langpack-st",
+    "summary": "Locale data for Southern Sotho"
+  },
+  {
+    "name": "glibc-langpack-sv",
+    "summary": "Locale data for Swedish"
+  },
+  {
+    "name": "glibc-langpack-sw",
+    "summary": "Locale data for Swahili"
+  },
+  {
+    "name": "glibc-langpack-szl",
+    "summary": "Locale data for Silesian"
+  },
+  {
+    "name": "glibc-langpack-ta",
+    "summary": "Locale data for Tamil"
+  },
+  {
+    "name": "glibc-langpack-tcy",
+    "summary": "Locale data for Tulu"
+  },
+  {
+    "name": "glibc-langpack-te",
+    "summary": "Locale data for Telugu"
+  },
+  {
+    "name": "glibc-langpack-tg",
+    "summary": "Locale data for Tajik"
+  },
+  {
+    "name": "glibc-langpack-th",
+    "summary": "Locale data for Thai"
+  },
+  {
+    "name": "glibc-langpack-the",
+    "summary": "Locale data for Chitwania Tharu"
+  },
+  {
+    "name": "glibc-langpack-ti",
+    "summary": "Locale data for Tigrinya"
+  },
+  {
+    "name": "glibc-langpack-tig",
+    "summary": "Locale data for Tigre"
+  },
+  {
+    "name": "glibc-langpack-tk",
+    "summary": "Locale data for Turkmen"
+  },
+  {
+    "name": "glibc-langpack-tl",
+    "summary": "Locale data for Tagalog"
+  },
+  {
+    "name": "glibc-langpack-tn",
+    "summary": "Locale data for Tswana"
+  },
+  {
+    "name": "glibc-langpack-to",
+    "summary": "Locale data for Tongan"
+  },
+  {
+    "name": "glibc-langpack-tpi",
+    "summary": "Locale data for Tok Pisin"
+  },
+  {
+    "name": "glibc-langpack-tr",
+    "summary": "Locale data for Turkish"
+  },
+  {
+    "name": "glibc-langpack-ts",
+    "summary": "Locale data for Tsonga"
+  },
+  {
+    "name": "glibc-langpack-tt",
+    "summary": "Locale data for Tatar"
+  },
+  {
+    "name": "glibc-langpack-ug",
+    "summary": "Locale data for Uyghur"
+  },
+  {
+    "name": "glibc-langpack-uk",
+    "summary": "Locale data for Ukrainian"
+  },
+  {
+    "name": "glibc-langpack-unm",
+    "summary": "Locale data for Unami language"
+  },
+  {
+    "name": "glibc-langpack-ur",
+    "summary": "Locale data for Urdu"
+  },
+  {
+    "name": "glibc-langpack-uz",
+    "summary": "Locale data for Uzbek"
+  },
+  {
+    "name": "glibc-langpack-ve",
+    "summary": "Locale data for Venda"
+  },
+  {
+    "name": "glibc-langpack-vi",
+    "summary": "Locale data for Vietnamese"
+  },
+  {
+    "name": "glibc-langpack-wa",
+    "summary": "Locale data for Walloon"
+  },
+  {
+    "name": "glibc-langpack-wae",
+    "summary": "Locale data for Walser"
+  },
+  {
+    "name": "glibc-langpack-wal",
+    "summary": "Locale data for Wolaytta"
+  },
+  {
+    "name": "glibc-langpack-wo",
+    "summary": "Locale data for Wolof"
+  },
+  {
+    "name": "glibc-langpack-xh",
+    "summary": "Locale data for Xhosa"
+  },
+  {
+    "name": "glibc-langpack-yi",
+    "summary": "Locale data for Yiddish"
+  },
+  {
+    "name": "glibc-langpack-yo",
+    "summary": "Locale data for Yoruba"
+  },
+  {
+    "name": "glibc-langpack-yue",
+    "summary": "Locale data for Cantonese"
+  },
+  {
+    "name": "glibc-langpack-yuw",
+    "summary": "Locale data for Yau"
+  },
+  {
+    "name": "glibc-langpack-zh",
+    "summary": "Locale data for Mandarin Chinese"
+  },
+  {
+    "name": "glibc-langpack-zu",
+    "summary": "Locale data for Zulu"
+  },
+  {
+    "name": "glibc-minimal-langpack",
+    "summary": "Minimal language packs for glibc."
+  },
+  {
+    "name": "gmp",
+    "summary": "A GNU arbitrary precision library"
+  },
+  {
+    "name": "gnupg2",
+    "summary": "Utility for secure communication and data storage"
+  },
+  {
+    "name": "gnutls",
+    "summary": "A TLS protocol implementation"
+  },
+  {
+    "name": "gobject-introspection",
+    "summary": "Introspection system for GObject-based libraries"
+  },
+  {
+    "name": "gpgme",
+    "summary": "GnuPG Made Easy - high level crypto API"
+  },
+  {
+    "name": "graphite2",
+    "summary": "Font rendering capabilities for complex non-Roman writing systems"
+  },
+  {
+    "name": "grep",
+    "summary": "Pattern matching utilities"
+  },
+  {
+    "name": "groff-base",
+    "summary": "Parts of the groff formatting system required to display manual pages"
+  },
+  {
+    "name": "grub2-common",
+    "summary": "grub2 common layout"
+  },
+  {
+    "name": "grub2-efi-aa64-modules",
+    "summary": "Modules used to build custom grub.efi images"
+  },
+  {
+    "name": "grub2-efi-x64",
+    "summary": "GRUB for EFI systems."
+  },
+  {
+    "name": "grub2-efi-x64-cdboot",
+    "summary": "Files used to boot removeable media with EFI"
+  },
+  {
+    "name": "grub2-efi-x64-modules",
+    "summary": "Modules used to build custom grub.efi images"
+  },
+  {
+    "name": "grub2-pc",
+    "summary": "Bootloader with support for Linux, Multiboot, and more"
+  },
+  {
+    "name": "grub2-pc-modules",
+    "summary": "Modules used to build custom grub images"
+  },
+  {
+    "name": "grub2-tools",
+    "summary": "Support tools for GRUB."
+  },
+  {
+    "name": "grub2-tools-efi",
+    "summary": "Support tools for GRUB."
+  },
+  {
+    "name": "grub2-tools-extra",
+    "summary": "Support tools for GRUB."
+  },
+  {
+    "name": "grub2-tools-minimal",
+    "summary": "Support tools for GRUB."
+  },
+  {
+    "name": "grubby",
+    "summary": "Command line tool for updating bootloader configs"
+  },
+  {
+    "name": "gsettings-desktop-schemas",
+    "summary": "A collection of GSettings schemas"
+  },
+  {
+    "name": "gssproxy",
+    "summary": "GSSAPI Proxy"
+  },
+  {
+    "name": "gzip",
+    "summary": "The GNU data compression program"
+  },
+  {
+    "name": "harfbuzz",
+    "summary": "Text shaping library"
+  },
+  {
+    "name": "hdparm",
+    "summary": "A utility for displaying and/or setting hard disk parameters"
+  },
+  {
+    "name": "hostname",
+    "summary": "Utility to set/show the host name or domain name"
+  },
+  {
+    "name": "hwdata",
+    "summary": "Hardware identification and configuration data"
+  },
+  {
+    "name": "hwloc",
+    "summary": "Portable Hardware Locality - portable abstraction of hierarchical architectures"
+  },
+  {
+    "name": "hwloc-libs",
+    "summary": "Run time libraries for the hwloc"
+  },
+  {
+    "name": "ibacm",
+    "summary": "InfiniBand Communication Manager Assistant"
+  },
+  {
+    "name": "ima-evm-utils",
+    "summary": "IMA/EVM support utilities"
+  },
+  {
+    "name": "info",
+    "summary": "A stand-alone TTY-based reader for GNU texinfo documentation"
+  },
+  {
+    "name": "inih",
+    "summary": "Simple INI file parser library"
+  },
+  {
+    "name": "initscripts",
+    "summary": "Basic support for legacy System V init scripts"
+  },
+  {
+    "name": "initscripts-rename-device",
+    "summary": "Udev helper utility that provides network interface naming"
+  },
+  {
+    "name": "initscripts-service",
+    "summary": "Support for service command"
+  },
+  {
+    "name": "integritysetup",
+    "summary": "A utility for setting up dm-integrity volumes"
+  },
+  {
+    "name": "intel-cmt-cat",
+    "summary": "Provides command line interface to CMT, MBM, CAT, CDP and MBA technologies"
+  },
+  {
+    "name": "iotop",
+    "summary": "Top like utility for I/O"
+  },
+  {
+    "name": "ipcalc",
+    "summary": "IP network address calculator"
+  },
+  {
+    "name": "iproute",
+    "summary": "Advanced IP routing and network device configuration tools"
+  },
+  {
+    "name": "iproute-tc",
+    "summary": "Linux Traffic Control utility"
+  },
+  {
+    "name": "iprutils",
+    "summary": "Utilities for the IBM Power Linux RAID adapters"
+  },
+  {
+    "name": "ipset",
+    "summary": "Manage Linux IP sets"
+  },
+  {
+    "name": "ipset-libs",
+    "summary": "Shared library providing the IP sets functionality"
+  },
+  {
+    "name": "iptables-libs",
+    "summary": "libxtables and iptables extensions userspace support"
+  },
+  {
+    "name": "iptables-nft",
+    "summary": "nftables compatibility for iptables, arptables and ebtables"
+  },
+  {
+    "name": "iptables-utils",
+    "summary": "iptables and ip6tables misc utilities"
+  },
+  {
+    "name": "iptraf-ng",
+    "summary": "A console-based network monitoring utility"
+  },
+  {
+    "name": "iputils",
+    "summary": "Network monitoring tools including ping"
+  },
+  {
+    "name": "irqbalance",
+    "summary": "IRQ balancing daemon"
+  },
+  {
+    "name": "iscsi-initiator-utils",
+    "summary": "iSCSI daemon and utility programs"
+  },
+  {
+    "name": "iscsi-initiator-utils-iscsiuio",
+    "summary": "Userspace configuration daemon required for some iSCSI hardware"
+  },
+  {
+    "name": "isns-utils",
+    "summary": "The iSNS daemon and utility programs"
+  },
+  {
+    "name": "isns-utils-libs",
+    "summary": "Shared library files for iSNS"
+  },
+  {
+    "name": "iw",
+    "summary": "A nl80211 based wireless configuration tool"
+  },
+  {
+    "name": "iwl100-firmware",
+    "summary": "Firmware for Intel(R) Wireless WiFi Link 100 Series Adapters"
+  },
+  {
+    "name": "iwl1000-firmware",
+    "summary": "Firmware for Intel\u00ae PRO/Wireless 1000 B/G/N network adaptors"
+  },
+  {
+    "name": "iwl105-firmware",
+    "summary": "Firmware for Intel(R) Centrino Wireless-N 105 Series Adapters"
+  },
+  {
+    "name": "iwl135-firmware",
+    "summary": "Firmware for Intel(R) Centrino Wireless-N 135 Series Adapters"
+  },
+  {
+    "name": "iwl2000-firmware",
+    "summary": "Firmware for Intel(R) Centrino Wireless-N 2000 Series Adapters"
+  },
+  {
+    "name": "iwl2030-firmware",
+    "summary": "Firmware for Intel(R) Centrino Wireless-N 2030 Series Adapters"
+  },
+  {
+    "name": "iwl3160-firmware",
+    "summary": "Firmware for Intel(R) Wireless WiFi Link 3160 Series Adapters"
+  },
+  {
+    "name": "iwl5000-firmware",
+    "summary": "Firmware for Intel\u00ae PRO/Wireless 5000 A/G/N network adaptors"
+  },
+  {
+    "name": "iwl5150-firmware",
+    "summary": "Firmware for Intel\u00ae PRO/Wireless 5150 A/G/N network adaptors"
+  },
+  {
+    "name": "iwl6000g2a-firmware",
+    "summary": "Firmware for Intel(R) Wireless WiFi Link 6005 Series Adapters"
+  },
+  {
+    "name": "iwl6000g2b-firmware",
+    "summary": "Firmware for Intel(R) Wireless WiFi Link 6030 Series Adapters"
+  },
+  {
+    "name": "iwl6050-firmware",
+    "summary": "Firmware for Intel(R) Wireless WiFi Link 6050 Series Adapters"
+  },
+  {
+    "name": "iwl7260-firmware",
+    "summary": "Firmware for Intel(R) Wireless WiFi Link 726x/8000/9000/AX200/AX201 Series Adapters"
+  },
+  {
+    "name": "iwpmd",
+    "summary": "iWarp Port Mapper userspace daemon"
+  },
+  {
+    "name": "jansson",
+    "summary": "C library for encoding, decoding and manipulating JSON data"
+  },
+  {
+    "name": "jitterentropy",
+    "summary": "Library implementing the jitter entropy source"
+  },
+  {
+    "name": "jq",
+    "summary": "Command-line JSON processor"
+  },
+  {
+    "name": "json-c",
+    "summary": "JSON implementation in C"
+  },
+  {
+    "name": "json-glib",
+    "summary": "Library for JavaScript Object Notation format"
+  },
+  {
+    "name": "kbd",
+    "summary": "Tools for configuring the console (keyboard, virtual terminals, etc.)"
+  },
+  {
+    "name": "kbd-legacy",
+    "summary": "Legacy data for kbd package"
+  },
+  {
+    "name": "kbd-misc",
+    "summary": "Data for kbd package"
+  },
+  {
+    "name": "kernel",
+    "summary": "The Linux kernel"
+  },
+  {
+    "name": "kernel-abi-stablelists",
+    "summary": "The Red Hat Enterprise Linux kernel ABI symbol stablelists"
+  },
+  {
+    "name": "kernel-core",
+    "summary": "The Linux kernel"
+  },
+  {
+    "name": "kernel-debug",
+    "summary": "kernel meta-package for the debug kernel"
+  },
+  {
+    "name": "kernel-debug-core",
+    "summary": "The Linux kernel compiled with extra debugging enabled"
+  },
+  {
+    "name": "kernel-debug-modules",
+    "summary": "kernel modules to match the core kernel"
+  },
+  {
+    "name": "kernel-debug-modules-core",
+    "summary": "Core kernel modules to match the core kernel"
+  },
+  {
+    "name": "kernel-debug-modules-extra",
+    "summary": "Extra kernel modules to match the kernel"
+  },
+  {
+    "name": "kernel-debug-uki-virt",
+    "summary": "%{variant_summary} unified kernel image for virtual machines"
+  },
+  {
+    "name": "kernel-modules",
+    "summary": "kernel modules to match the core kernel"
+  },
+  {
+    "name": "kernel-modules-core",
+    "summary": "Core kernel modules to match the core kernel"
+  },
+  {
+    "name": "kernel-modules-extra",
+    "summary": "Extra kernel modules to match the kernel"
+  },
+  {
+    "name": "kernel-tools",
+    "summary": "Assortment of tools for the Linux kernel"
+  },
+  {
+    "name": "kernel-tools-libs",
+    "summary": "Libraries for the kernels-tools"
+  },
+  {
+    "name": "kernel-uki-virt",
+    "summary": "The Linux kernel unified kernel image for virtual machines"
+  },
+  {
+    "name": "kernel-uki-virt-addons",
+    "summary": "The Linux kernel unified kernel image addons for virtual machines"
+  },
+  {
+    "name": "kexec-tools",
+    "summary": "The kexec/kdump userspace component"
+  },
+  {
+    "name": "keyutils",
+    "summary": "Linux Key Management Utilities"
+  },
+  {
+    "name": "keyutils-libs",
+    "summary": "Key utilities library"
+  },
+  {
+    "name": "kmod",
+    "summary": "Linux kernel module management utilities"
+  },
+  {
+    "name": "kmod-kvdo",
+    "summary": "Kernel Modules for Virtual Data Optimizer"
+  },
+  {
+    "name": "kmod-libs",
+    "summary": "Libraries to handle kernel module loading and unloading"
+  },
+  {
+    "name": "kmod-redhat-arc4",
+    "summary": "arc4 kernel module for Driver Update Program"
+  },
+  {
+    "name": "kmod-redhat-arc4-devel",
+    "summary": "arc4 development files for Driver Update Program"
+  },
+  {
+    "name": "kmod-redhat-cfg80211",
+    "summary": "cfg80211 kernel module for Driver Update Program"
+  },
+  {
+    "name": "kmod-redhat-cfg80211-devel",
+    "summary": "cfg80211 development files for Driver Update Program"
+  },
+  {
+    "name": "kmod-redhat-mac80211",
+    "summary": "mac80211 kernel module for Driver Update Program"
+  },
+  {
+    "name": "kmod-redhat-mac80211-devel",
+    "summary": "mac80211 development files for Driver Update Program"
+  },
+  {
+    "name": "kmod-redhat-rtw89",
+    "summary": "rtw89 kernel module for Driver Update Program"
+  },
+  {
+    "name": "kmod-redhat-rtw89-devel",
+    "summary": "rtw89 development files for Driver Update Program"
+  },
+  {
+    "name": "kpartx",
+    "summary": "Partition device manager for device-mapper devices"
+  },
+  {
+    "name": "kpatch",
+    "summary": "Dynamic kernel patch manager"
+  },
+  {
+    "name": "kpatch-dnf",
+    "summary": "kpatch-patch manager plugin for DNF"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-162_12_1",
+    "summary": "Live kernel patching module for kernel-5.14.0-162.12.1.el9_1.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-162_18_1",
+    "summary": "Initial empty kpatch-patch for kernel-5.14.0-162.18.1.el9_1.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-162_22_2",
+    "summary": "Initial empty kpatch-patch for kernel-5.14.0-162.22.2.el9_1.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-162_23_1",
+    "summary": "Initial empty kpatch-patch for kernel-5.14.0-162.23.1.el9_1.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-162_6_1",
+    "summary": "Live kernel patching module for kernel-5.14.0-162.6.1.el9_1.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-284_11_1",
+    "summary": "Live kernel patching module for kernel-5.14.0-284.11.1.el9_2.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-284_18_1",
+    "summary": "Live kernel patching module for kernel-5.14.0-284.18.1.el9_2.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-284_25_1",
+    "summary": "Live kernel patching module for kernel-5.14.0-284.25.1.el9_2.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-284_30_1",
+    "summary": "Initial empty kpatch-patch for kernel-5.14.0-284.30.1.el9_2.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-362_13_1",
+    "summary": "Initial empty kpatch-patch for kernel-5.14.0-362.13.1.el9_3.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-362_18_1",
+    "summary": "Live kernel patching module for kernel-5.14.0-362.18.1.el9_3.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-362_8_1",
+    "summary": "Live kernel patching module for kernel-5.14.0-362.8.1.el9_3.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-427_13_1",
+    "summary": "Live kernel patching module for kernel-5.14.0-427.13.1.el9_4.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-427_31_1",
+    "summary": "Initial empty kpatch-patch for kernel-5.14.0-427.31.1.el9_4.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-503_15_1",
+    "summary": "Initial empty kpatch-patch for kernel-5.14.0-503.15.1.el9_5.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-503_26_1",
+    "summary": "Live kernel patching module for kernel-5.14.0-503.26.1.el9_5.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-570_17_1",
+    "summary": "Initial empty kpatch-patch for kernel-5.14.0-570.17.1.el9_6.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-70_13_1",
+    "summary": "Live kernel patching module for kernel-5.14.0-70.13.1.el9_0.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-70_17_1",
+    "summary": "Live kernel patching module for kernel-5.14.0-70.17.1.el9_0.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-70_22_1",
+    "summary": "Live kernel patching module for kernel-5.14.0-70.22.1.el9_0.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-70_26_1",
+    "summary": "Live kernel patching module for kernel-5.14.0-70.26.1.el9_0.x86_64"
+  },
+  {
+    "name": "kpatch-patch-5_14_0-70_30_1",
+    "summary": "Initial empty kpatch-patch for kernel-5.14.0-70.30.1.el9_0.x86_64"
+  },
+  {
+    "name": "krb5-libs",
+    "summary": "The non-admin shared libraries used by Kerberos 5"
+  },
+  {
+    "name": "krb5-pkinit",
+    "summary": "The PKINIT module for Kerberos 5"
+  },
+  {
+    "name": "krb5-server",
+    "summary": "The KDC and related programs for Kerberos 5"
+  },
+  {
+    "name": "krb5-server-ldap",
+    "summary": "The LDAP storage plugin for the Kerberos 5 KDC"
+  },
+  {
+    "name": "krb5-workstation",
+    "summary": "Kerberos 5 programs for use on workstations"
+  },
+  {
+    "name": "ktls-utils",
+    "summary": "TLS handshake agent for kernel sockets"
+  },
+  {
+    "name": "ldb-tools",
+    "summary": "Tools to manage LDB files"
+  },
+  {
+    "name": "ledmon",
+    "summary": "Enclosure LED Utilities"
+  },
+  {
+    "name": "ledmon-libs",
+    "summary": "Runtime library files for ledmon"
+  },
+  {
+    "name": "less",
+    "summary": "A text file browser similar to more, but better"
+  },
+  {
+    "name": "libacl",
+    "summary": "Dynamic library for access control list support"
+  },
+  {
+    "name": "libaio",
+    "summary": "Linux-native asynchronous I/O access library"
+  },
+  {
+    "name": "libarchive",
+    "summary": "A library for handling streaming archive formats"
+  },
+  {
+    "name": "libassuan",
+    "summary": "GnuPG IPC library"
+  },
+  {
+    "name": "libatomic",
+    "summary": "The GNU Atomic library"
+  },
+  {
+    "name": "libattr",
+    "summary": "Dynamic library for extended attribute support"
+  },
+  {
+    "name": "libbasicobjects",
+    "summary": "Basic object types for C"
+  },
+  {
+    "name": "libblkid",
+    "summary": "Block device ID library"
+  },
+  {
+    "name": "libbpf",
+    "summary": "Libbpf library"
+  },
+  {
+    "name": "libbrotli",
+    "summary": "Library for brotli lossless compression algorithm"
+  },
+  {
+    "name": "libcap",
+    "summary": "Library for getting and setting POSIX.1e capabilities"
+  },
+  {
+    "name": "libcap-ng",
+    "summary": "Alternate posix capabilities library"
+  },
+  {
+    "name": "libcap-ng-utils",
+    "summary": "Utilities for analyzing and setting file capabilities"
+  },
+  {
+    "name": "libcbor",
+    "summary": "A CBOR parsing library"
+  },
+  {
+    "name": "libcollection",
+    "summary": "Collection data-type for C"
+  },
+  {
+    "name": "libcom_err",
+    "summary": "Common error description library"
+  },
+  {
+    "name": "libcomps",
+    "summary": "Comps XML file manipulation library"
+  },
+  {
+    "name": "libconfig",
+    "summary": "C/C++ configuration file library"
+  },
+  {
+    "name": "libcurl",
+    "summary": "A library for getting files from web servers"
+  },
+  {
+    "name": "libcurl-minimal",
+    "summary": "Conservatively configured build of libcurl for minimal installations"
+  },
+  {
+    "name": "libdaemon",
+    "summary": "Library for writing UNIX daemons"
+  },
+  {
+    "name": "libdb",
+    "summary": "The Berkeley DB database library for C"
+  },
+  {
+    "name": "libdhash",
+    "summary": "Dynamic hash table"
+  },
+  {
+    "name": "libdnf",
+    "summary": "Library providing simplified C and Python API to libsolv"
+  },
+  {
+    "name": "libdnf-plugin-subscription-manager",
+    "summary": "Subscription Manager plugin for libdnf"
+  },
+  {
+    "name": "libeconf",
+    "summary": "Enhanced config file parser library"
+  },
+  {
+    "name": "libedit",
+    "summary": "The NetBSD Editline library"
+  },
+  {
+    "name": "libertas-sd8787-firmware",
+    "summary": "Firmware for Marvell Libertas SD 8787 Network Adapter"
+  },
+  {
+    "name": "libev",
+    "summary": "High-performance event loop/event model with lots of features"
+  },
+  {
+    "name": "libevent",
+    "summary": "Abstract asynchronous event notification library"
+  },
+  {
+    "name": "libfdisk",
+    "summary": "Partitioning library for fdisk-like programs."
+  },
+  {
+    "name": "libffi",
+    "summary": "A portable foreign function interface library"
+  },
+  {
+    "name": "libfido2",
+    "summary": "FIDO2 library"
+  },
+  {
+    "name": "libgcab1",
+    "summary": "Library to create Cabinet archives"
+  },
+  {
+    "name": "libgcc",
+    "summary": "GCC version 11 shared support library"
+  },
+  {
+    "name": "libgcrypt",
+    "summary": "A general-purpose cryptography library"
+  },
+  {
+    "name": "libgfortran",
+    "summary": "Fortran runtime"
+  },
+  {
+    "name": "libgomp",
+    "summary": "GCC OpenMP v4.5 shared support library"
+  },
+  {
+    "name": "libgpg-error",
+    "summary": "Library for error values used by GnuPG components"
+  },
+  {
+    "name": "libgudev",
+    "summary": "GObject-based wrapper library for libudev"
+  },
+  {
+    "name": "libgusb",
+    "summary": "GLib wrapper around libusb1"
+  },
+  {
+    "name": "libibumad",
+    "summary": "OpenFabrics Alliance InfiniBand umad (userspace management datagram) library"
+  },
+  {
+    "name": "libibverbs",
+    "summary": "A library and drivers for direct userspace use of RDMA (InfiniBand/iWARP/RoCE) hardware"
+  },
+  {
+    "name": "libibverbs-utils",
+    "summary": "Examples for the libibverbs library"
+  },
+  {
+    "name": "libicu",
+    "summary": "International Components for Unicode - libraries"
+  },
+  {
+    "name": "libidn2",
+    "summary": "Library to support IDNA2008 internationalized domain names"
+  },
+  {
+    "name": "libini_config",
+    "summary": "INI file parser for C"
+  },
+  {
+    "name": "libipa_hbac",
+    "summary": "FreeIPA HBAC Evaluator library"
+  },
+  {
+    "name": "libjcat",
+    "summary": "Library for reading Jcat files"
+  },
+  {
+    "name": "libkadm5",
+    "summary": "Kerberos 5 Administrative libraries"
+  },
+  {
+    "name": "libkcapi",
+    "summary": "User space interface to the Linux Kernel Crypto API"
+  },
+  {
+    "name": "libkcapi-hmaccalc",
+    "summary": "Drop-in replacements for hmaccalc provided by the libkcapi package"
+  },
+  {
+    "name": "libksba",
+    "summary": "CMS and X.509 library"
+  },
+  {
+    "name": "libldb",
+    "summary": "A schema-less, ldap like, API and database"
+  },
+  {
+    "name": "liblockfile",
+    "summary": "This implements a number of functions found in -lmail on SysV systems"
+  },
+  {
+    "name": "libmbim",
+    "summary": "Support library for the Mobile Broadband Interface Model protocol"
+  },
+  {
+    "name": "libmbim-utils",
+    "summary": "Utilities to use the MBIM protocol from the command line"
+  },
+  {
+    "name": "libmnl",
+    "summary": "A minimalistic Netlink library"
+  },
+  {
+    "name": "libmodulemd",
+    "summary": "Module metadata manipulation library"
+  },
+  {
+    "name": "libmount",
+    "summary": "Device mounting library"
+  },
+  {
+    "name": "libndp",
+    "summary": "Library for Neighbor Discovery Protocol"
+  },
+  {
+    "name": "libnetapi",
+    "summary": "The NETAPI library"
+  },
+  {
+    "name": "libnetfilter_conntrack",
+    "summary": "Netfilter conntrack userspace library"
+  },
+  {
+    "name": "libnfnetlink",
+    "summary": "Netfilter netlink userspace library"
+  },
+  {
+    "name": "libnfsidmap",
+    "summary": "NFSv4 User and Group ID Mapping Library"
+  },
+  {
+    "name": "libnftnl",
+    "summary": "Library for low-level interaction with nftables Netlink's API over libmnl"
+  },
+  {
+    "name": "libnghttp2",
+    "summary": "A library implementing the HTTP/2 protocol"
+  },
+  {
+    "name": "libnl3",
+    "summary": "Convenience library for kernel netlink sockets"
+  },
+  {
+    "name": "libnl3-cli",
+    "summary": "Command line interface utils for libnl3"
+  },
+  {
+    "name": "libnsl",
+    "summary": "Legacy support library for NIS"
+  },
+  {
+    "name": "libnvme",
+    "summary": "Linux-native nvme device management library"
+  },
+  {
+    "name": "libpath_utils",
+    "summary": "Filesystem Path Utilities"
+  },
+  {
+    "name": "libpcap",
+    "summary": "A system-independent interface for user-level packet capture"
+  },
+  {
+    "name": "libpciaccess",
+    "summary": "PCI access library"
+  },
+  {
+    "name": "libpeas",
+    "summary": "Plug-ins implementation convenience library"
+  },
+  {
+    "name": "libpipeline",
+    "summary": "A pipeline manipulation library"
+  },
+  {
+    "name": "libpkgconf",
+    "summary": "Backend library for pkgconf"
+  },
+  {
+    "name": "libpng",
+    "summary": "A library of functions for manipulating PNG image format files"
+  },
+  {
+    "name": "libproxy",
+    "summary": "A library handling all the details of proxy configuration"
+  },
+  {
+    "name": "libpsl",
+    "summary": "C library for the Publix Suffix List"
+  },
+  {
+    "name": "libpwquality",
+    "summary": "A library for password generation and password quality checking"
+  },
+  {
+    "name": "libqmi",
+    "summary": "Support library to use the Qualcomm MSM Interface (QMI) protocol"
+  },
+  {
+    "name": "libqmi-utils",
+    "summary": "Utilities to use the QMI protocol from the command line"
+  },
+  {
+    "name": "libqrtr-glib",
+    "summary": "Support library to use and manage the QRTR (Qualcomm IPC Router) bus."
+  },
+  {
+    "name": "libquadmath",
+    "summary": "GCC __float128 shared support library"
+  },
+  {
+    "name": "librdmacm",
+    "summary": "Userspace RDMA Connection Manager"
+  },
+  {
+    "name": "librdmacm-utils",
+    "summary": "Examples for the librdmacm library"
+  },
+  {
+    "name": "libref_array",
+    "summary": "A refcounted array for C"
+  },
+  {
+    "name": "librepo",
+    "summary": "Repodata downloading library"
+  },
+  {
+    "name": "libreport-filesystem",
+    "summary": "Filesystem layout for libreport"
+  },
+  {
+    "name": "librhsm",
+    "summary": "Red Hat Subscription Manager library"
+  },
+  {
+    "name": "libseccomp",
+    "summary": "Enhanced seccomp library"
+  },
+  {
+    "name": "libselinux",
+    "summary": "SELinux library and simple utilities"
+  },
+  {
+    "name": "libselinux-utils",
+    "summary": "SELinux libselinux utilities"
+  },
+  {
+    "name": "libsemanage",
+    "summary": "SELinux binary policy manipulation library"
+  },
+  {
+    "name": "libsepol",
+    "summary": "SELinux binary policy manipulation library"
+  },
+  {
+    "name": "libsigsegv",
+    "summary": "Library for handling page faults in user mode"
+  },
+  {
+    "name": "libsmartcols",
+    "summary": "Formatting library for ls-like programs."
+  },
+  {
+    "name": "libsmbclient",
+    "summary": "The SMB client library"
+  },
+  {
+    "name": "libsmbios",
+    "summary": "Libsmbios C/C++ shared libraries"
+  },
+  {
+    "name": "libsolv",
+    "summary": "Package dependency solver"
+  },
+  {
+    "name": "libss",
+    "summary": "Command line interface parsing library"
+  },
+  {
+    "name": "libssh",
+    "summary": "A library implementing the SSH protocol"
+  },
+  {
+    "name": "libssh-config",
+    "summary": "Configuration files for libssh"
+  },
+  {
+    "name": "libsss_autofs",
+    "summary": "A library to allow communication between Autofs and SSSD"
+  },
+  {
+    "name": "libsss_certmap",
+    "summary": "SSSD Certificate Mapping Library"
+  },
+  {
+    "name": "libsss_idmap",
+    "summary": "FreeIPA Idmap library"
+  },
+  {
+    "name": "libsss_nss_idmap",
+    "summary": "Library for SID and certificate based lookups"
+  },
+  {
+    "name": "libsss_simpleifp",
+    "summary": "The SSSD D-Bus responder helper library"
+  },
+  {
+    "name": "libsss_sudo",
+    "summary": "A library to allow communication between SUDO and SSSD"
+  },
+  {
+    "name": "libstdc++",
+    "summary": "GNU Standard C++ Library"
+  },
+  {
+    "name": "libsysfs",
+    "summary": "Shared library for interfacing with sysfs"
+  },
+  {
+    "name": "libtalloc",
+    "summary": "The talloc library"
+  },
+  {
+    "name": "libtasn1",
+    "summary": "The ASN.1 library used in GNUTLS"
+  },
+  {
+    "name": "libtdb",
+    "summary": "The tdb library"
+  },
+  {
+    "name": "libteam",
+    "summary": "Library for controlling team network device"
+  },
+  {
+    "name": "libtevent",
+    "summary": "The tevent library"
+  },
+  {
+    "name": "libtirpc",
+    "summary": "Transport Independent RPC Library"
+  },
+  {
+    "name": "libtool-ltdl",
+    "summary": "Runtime libraries for GNU Libtool Dynamic Module Loader"
+  },
+  {
+    "name": "libtracecmd",
+    "summary": "Libraries of trace-cmd"
+  },
+  {
+    "name": "libtraceevent",
+    "summary": "Library to parse raw trace event formats"
+  },
+  {
+    "name": "libtracefs",
+    "summary": "Library for access kernel tracefs"
+  },
+  {
+    "name": "libunistring",
+    "summary": "GNU Unicode string library"
+  },
+  {
+    "name": "libusbx",
+    "summary": "Library for accessing USB devices"
+  },
+  {
+    "name": "libuser",
+    "summary": "A user and group account administration library"
+  },
+  {
+    "name": "libutempter",
+    "summary": "A privileged helper for utmp/wtmp updates"
+  },
+  {
+    "name": "libuuid",
+    "summary": "Universally unique ID library"
+  },
+  {
+    "name": "libverto",
+    "summary": "Main loop abstraction library"
+  },
+  {
+    "name": "libverto-libev",
+    "summary": "libev module for libverto"
+  },
+  {
+    "name": "libwbclient",
+    "summary": "The winbind client library"
+  },
+  {
+    "name": "libxcrypt",
+    "summary": "Extended crypt library for descrypt, md5crypt, bcrypt, and others"
+  },
+  {
+    "name": "libxml2",
+    "summary": "Library providing XML and HTML support"
+  },
+  {
+    "name": "libxmlb",
+    "summary": "Library for querying compressed XML metadata"
+  },
+  {
+    "name": "libyaml",
+    "summary": "YAML 1.1 parser and emitter written in C"
+  },
+  {
+    "name": "libzstd",
+    "summary": "Zstd shared library"
+  },
+  {
+    "name": "linux-firmware",
+    "summary": "Firmware files used by the Linux kernel"
+  },
+  {
+    "name": "linux-firmware-whence",
+    "summary": "WHENCE License file"
+  },
+  {
+    "name": "lksctp-tools",
+    "summary": "User-space access to Linux Kernel SCTP"
+  },
+  {
+    "name": "lldpad",
+    "summary": "Intel LLDP Agent"
+  },
+  {
+    "name": "lmdb-libs",
+    "summary": "Shared libraries for lmdb"
+  },
+  {
+    "name": "lockdev",
+    "summary": "A library for locking devices"
+  },
+  {
+    "name": "logrotate",
+    "summary": "Rotates, compresses, removes and mails system log files"
+  },
+  {
+    "name": "lrzsz",
+    "summary": "The lrz and lsz modem communications programs"
+  },
+  {
+    "name": "lshw",
+    "summary": "Hardware lister"
+  },
+  {
+    "name": "lsof",
+    "summary": "A utility which lists open files on a Linux/UNIX system"
+  },
+  {
+    "name": "lsscsi",
+    "summary": "List SCSI devices (or hosts) and associated information"
+  },
+  {
+    "name": "lua-libs",
+    "summary": "Libraries for lua"
+  },
+  {
+    "name": "lvm2",
+    "summary": "Userland logical volume management tools"
+  },
+  {
+    "name": "lvm2-libs",
+    "summary": "Shared libraries for lvm2"
+  },
+  {
+    "name": "lz4",
+    "summary": "Extremely fast compression algorithm"
+  },
+  {
+    "name": "lz4-libs",
+    "summary": "Libaries for lz4"
+  },
+  {
+    "name": "lzo",
+    "summary": "Data compression library with very fast (de)compression"
+  },
+  {
+    "name": "lzop",
+    "summary": "Real-time file compressor"
+  },
+  {
+    "name": "mailcap",
+    "summary": "Helper application and MIME type associations for file types"
+  },
+  {
+    "name": "make",
+    "summary": "A GNU tool which simplifies the build process for users"
+  },
+  {
+    "name": "man-db",
+    "summary": "Tools for searching and reading man pages"
+  },
+  {
+    "name": "man-pages",
+    "summary": "Linux kernel and C library user-space interface documentation"
+  },
+  {
+    "name": "mcelog",
+    "summary": "Tool to translate x86-64 CPU Machine Check Exception data"
+  },
+  {
+    "name": "mcstrans",
+    "summary": "SELinux Translation Daemon"
+  },
+  {
+    "name": "mdadm",
+    "summary": "The mdadm program controls Linux md devices (software RAID arrays)"
+  },
+  {
+    "name": "microcode_ctl",
+    "summary": "CPU microcode updates for Intel x86 processors"
+  },
+  {
+    "name": "microdnf",
+    "summary": "Lightweight implementation of DNF in C"
+  },
+  {
+    "name": "minicom",
+    "summary": "A text-based modem control and terminal emulation program"
+  },
+  {
+    "name": "mksh",
+    "summary": "MirBSD enhanced version of the Korn Shell"
+  },
+  {
+    "name": "mlocate",
+    "summary": "An utility for finding files by name"
+  },
+  {
+    "name": "ModemManager",
+    "summary": "Mobile broadband modem management service"
+  },
+  {
+    "name": "ModemManager-glib",
+    "summary": "Libraries for adding ModemManager support to applications that use glib."
+  },
+  {
+    "name": "mokutil",
+    "summary": "Tool to manage UEFI Secure Boot MoK Keys"
+  },
+  {
+    "name": "mpfr",
+    "summary": "C library for multiple-precision floating-point computations"
+  },
+  {
+    "name": "mtools",
+    "summary": "Programs for accessing MS-DOS disks without mounting the disks"
+  },
+  {
+    "name": "mtr",
+    "summary": "Network diagnostic tool combining 'traceroute' and 'ping'"
+  },
+  {
+    "name": "nano",
+    "summary": "A small text editor"
+  },
+  {
+    "name": "ncurses",
+    "summary": "Ncurses support utilities"
+  },
+  {
+    "name": "ncurses-base",
+    "summary": "Descriptions of common terminals"
+  },
+  {
+    "name": "ncurses-libs",
+    "summary": "Ncurses libraries"
+  },
+  {
+    "name": "ndctl",
+    "summary": "Manage \"libnvdimm\" subsystem devices (Non-volatile Memory)"
+  },
+  {
+    "name": "ndctl-libs",
+    "summary": "Management library for \"libnvdimm\" subsystem devices (Non-volatile Memory)"
+  },
+  {
+    "name": "net-tools",
+    "summary": "Basic networking tools"
+  },
+  {
+    "name": "netconsole-service",
+    "summary": "Service for initializing of network console logging"
+  },
+  {
+    "name": "netlabel_tools",
+    "summary": "Tools to manage the Linux NetLabel subsystem"
+  },
+  {
+    "name": "netronome-firmware",
+    "summary": "Firmware for Netronome Smart NICs"
+  },
+  {
+    "name": "nettle",
+    "summary": "A low-level cryptographic library"
+  },
+  {
+    "name": "NetworkManager",
+    "summary": "Network connection manager and user applications"
+  },
+  {
+    "name": "NetworkManager-adsl",
+    "summary": "ADSL device plugin for NetworkManager"
+  },
+  {
+    "name": "NetworkManager-bluetooth",
+    "summary": "Bluetooth device plugin for NetworkManager"
+  },
+  {
+    "name": "NetworkManager-config-server",
+    "summary": "NetworkManager config file for \"server-like\" defaults"
+  },
+  {
+    "name": "NetworkManager-initscripts-updown",
+    "summary": "Legacy ifup/ifdown scripts for NetworkManager that replace initscripts (network-scripts)"
+  },
+  {
+    "name": "NetworkManager-libnm",
+    "summary": "Libraries for adding NetworkManager support to applications."
+  },
+  {
+    "name": "NetworkManager-team",
+    "summary": "Team device plugin for NetworkManager"
+  },
+  {
+    "name": "NetworkManager-tui",
+    "summary": "NetworkManager curses-based UI"
+  },
+  {
+    "name": "NetworkManager-wifi",
+    "summary": "Wifi plugin for NetworkManager"
+  },
+  {
+    "name": "NetworkManager-wwan",
+    "summary": "Mobile broadband device plugin for NetworkManager"
+  },
+  {
+    "name": "newt",
+    "summary": "A library for text mode user interfaces"
+  },
+  {
+    "name": "nfs-utils",
+    "summary": "NFS utilities and supporting clients and daemons for the kernel NFS server"
+  },
+  {
+    "name": "nfs4-acl-tools",
+    "summary": "The nfs4 ACL tools"
+  },
+  {
+    "name": "nftables",
+    "summary": "Netfilter Tables userspace utillites"
+  },
+  {
+    "name": "npth",
+    "summary": "The New GNU Portable Threads library"
+  },
+  {
+    "name": "nscd",
+    "summary": "A Name Service Caching Daemon (nscd)."
+  },
+  {
+    "name": "numactl",
+    "summary": "Library for tuning for Non Uniform Memory Access machines"
+  },
+  {
+    "name": "numactl-libs",
+    "summary": "libnuma libraries"
+  },
+  {
+    "name": "numad",
+    "summary": "NUMA user daemon"
+  },
+  {
+    "name": "numatop",
+    "summary": "Memory access locality characterization and analysis"
+  },
+  {
+    "name": "nvme-cli",
+    "summary": "NVMe management command line interface"
+  },
+  {
+    "name": "nvmetcli",
+    "summary": "An adminstration shell for NVMe storage targets"
+  },
+  {
+    "name": "oniguruma",
+    "summary": "Regular expressions library"
+  },
+  {
+    "name": "opencryptoki",
+    "summary": "Implementation of the PKCS#11 (Cryptoki) specification v3.0"
+  },
+  {
+    "name": "opencryptoki-ccatok",
+    "summary": "CCA cryptographic devices (secure-key) support for opencryptoki"
+  },
+  {
+    "name": "opencryptoki-icsftok",
+    "summary": "ICSF token support for opencryptoki"
+  },
+  {
+    "name": "opencryptoki-libs",
+    "summary": "The run-time libraries for opencryptoki package"
+  },
+  {
+    "name": "opencryptoki-swtok",
+    "summary": "The software token implementation for opencryptoki"
+  },
+  {
+    "name": "openldap",
+    "summary": "LDAP support libraries"
+  },
+  {
+    "name": "openldap-clients",
+    "summary": "LDAP client utilities"
+  },
+  {
+    "name": "openldap-compat",
+    "summary": "Package providing legacy non-threded libldap"
+  },
+  {
+    "name": "opensc",
+    "summary": "Smart card library and applications"
+  },
+  {
+    "name": "opensm",
+    "summary": "OpenIB InfiniBand Subnet Manager and management utilities"
+  },
+  {
+    "name": "opensm-libs",
+    "summary": "Libraries used by opensm and included utilities"
+  },
+  {
+    "name": "openssh",
+    "summary": "An open source implementation of SSH protocol version 2"
+  },
+  {
+    "name": "openssh-clients",
+    "summary": "An open source SSH client applications"
+  },
+  {
+    "name": "openssh-keycat",
+    "summary": "A mls keycat backend for openssh"
+  },
+  {
+    "name": "openssh-server",
+    "summary": "An open source SSH server daemon"
+  },
+  {
+    "name": "openssl",
+    "summary": "Utilities from the general purpose cryptography library with TLS implementation"
+  },
+  {
+    "name": "openssl-fips-provider",
+    "summary": "FIPS module for OpenSSL"
+  },
+  {
+    "name": "openssl-fips-provider-so",
+    "summary": "FIPS module for OpenSSL"
+  },
+  {
+    "name": "openssl-libs",
+    "summary": "A general purpose cryptography library with TLS implementation"
+  },
+  {
+    "name": "openssl-pkcs11",
+    "summary": "A PKCS#11 engine for use with OpenSSL"
+  },
+  {
+    "name": "os-prober",
+    "summary": "Probes disks on the system for installed operating systems"
+  },
+  {
+    "name": "p11-kit",
+    "summary": "Library for loading and sharing PKCS#11 modules"
+  },
+  {
+    "name": "p11-kit-trust",
+    "summary": "System trust module from p11-kit"
+  },
+  {
+    "name": "pam",
+    "summary": "An extensible library which provides authentication for applications"
+  },
+  {
+    "name": "parted",
+    "summary": "The GNU disk partition manipulation program"
+  },
+  {
+    "name": "passwd",
+    "summary": "An utility for setting or changing passwords using PAM"
+  },
+  {
+    "name": "pciutils",
+    "summary": "PCI bus related utilities"
+  },
+  {
+    "name": "pciutils-libs",
+    "summary": "Linux PCI library"
+  },
+  {
+    "name": "pcre",
+    "summary": "Perl-compatible regular expression library"
+  },
+  {
+    "name": "pcre2",
+    "summary": "Perl-compatible regular expression library"
+  },
+  {
+    "name": "pcre2-syntax",
+    "summary": "Documentation for PCRE2 regular expressions"
+  },
+  {
+    "name": "pcsc-lite",
+    "summary": "PC/SC Lite smart card framework and applications"
+  },
+  {
+    "name": "pcsc-lite-ccid",
+    "summary": "Generic USB CCID smart card reader driver"
+  },
+  {
+    "name": "pcsc-lite-libs",
+    "summary": "PC/SC Lite libraries"
+  },
+  {
+    "name": "perftest",
+    "summary": "IB Performance Tests"
+  },
+  {
+    "name": "pigz",
+    "summary": "Parallel implementation of gzip"
+  },
+  {
+    "name": "pkgconf",
+    "summary": "Package compiler and linker metadata toolkit"
+  },
+  {
+    "name": "pkgconf-m4",
+    "summary": "m4 macros for pkgconf"
+  },
+  {
+    "name": "pkgconf-pkg-config",
+    "summary": "pkgconf shim to provide /usr/bin/pkg-config"
+  },
+  {
+    "name": "policycoreutils",
+    "summary": "SELinux policy core utilities"
+  },
+  {
+    "name": "policycoreutils-newrole",
+    "summary": "The newrole application for RBAC/MLS"
+  },
+  {
+    "name": "policycoreutils-restorecond",
+    "summary": "SELinux restorecond utilities"
+  },
+  {
+    "name": "polkit",
+    "summary": "An authorization framework"
+  },
+  {
+    "name": "polkit-libs",
+    "summary": "Libraries for polkit"
+  },
+  {
+    "name": "polkit-pkla-compat",
+    "summary": "Rules for polkit to add compatibility with pklocalauthority"
+  },
+  {
+    "name": "popt",
+    "summary": "C library for parsing command line parameters"
+  },
+  {
+    "name": "ppp",
+    "summary": "The Point-to-Point Protocol daemon"
+  },
+  {
+    "name": "prefixdevname",
+    "summary": "Udev helper utility that provides network interface naming using user defined prefix"
+  },
+  {
+    "name": "procps-ng",
+    "summary": "System and process monitoring utilities"
+  },
+  {
+    "name": "procps-ng-i18n",
+    "summary": "Internationalization pack for procps-ng"
+  },
+  {
+    "name": "protobuf-c",
+    "summary": "C bindings for Google's Protocol Buffers"
+  },
+  {
+    "name": "psacct",
+    "summary": "Utilities for monitoring process activities"
+  },
+  {
+    "name": "psmisc",
+    "summary": "Utilities for managing processes on your system"
+  },
+  {
+    "name": "publicsuffix-list-dafsa",
+    "summary": "Cross-vendor public domain suffix database in DAFSA form"
+  },
+  {
+    "name": "python3",
+    "summary": "Python 3.9 interpreter"
+  },
+  {
+    "name": "python3-cffi",
+    "summary": "Foreign Function Interface for Python 3 to call C code"
+  },
+  {
+    "name": "python3-chardet",
+    "summary": "Character encoding auto-detection in Python"
+  },
+  {
+    "name": "python3-cloud-what",
+    "summary": "Python package for detection of public cloud provider"
+  },
+  {
+    "name": "python3-configshell",
+    "summary": "A framework to implement simple but nice CLIs"
+  },
+  {
+    "name": "python3-cryptography",
+    "summary": "PyCA's cryptography library"
+  },
+  {
+    "name": "python3-dateutil",
+    "summary": "Powerful extensions to the standard datetime module"
+  },
+  {
+    "name": "python3-dbus",
+    "summary": "D-Bus bindings for python3"
+  },
+  {
+    "name": "python3-decorator",
+    "summary": "Module to simplify usage of decorators in python3"
+  },
+  {
+    "name": "python3-dmidecode",
+    "summary": "Python 3 module to access DMI data"
+  },
+  {
+    "name": "python3-dnf",
+    "summary": "Python 3 interface to DNF"
+  },
+  {
+    "name": "python3-dnf-plugin-post-transaction-actions",
+    "summary": "Post transaction actions Plugin for DNF"
+  },
+  {
+    "name": "python3-dnf-plugin-versionlock",
+    "summary": "Version Lock Plugin for DNF"
+  },
+  {
+    "name": "python3-dnf-plugins-core",
+    "summary": "Core Plugins for DNF"
+  },
+  {
+    "name": "python3-dns",
+    "summary": "DNS toolkit for Python"
+  },
+  {
+    "name": "python3-ethtool",
+    "summary": "Python module to interface with ethtool"
+  },
+  {
+    "name": "python3-firewall",
+    "summary": "Python3 bindings for firewalld"
+  },
+  {
+    "name": "python3-gobject-base",
+    "summary": "Python 3 bindings for GObject Introspection base package"
+  },
+  {
+    "name": "python3-gobject-base-noarch",
+    "summary": "Python 3 bindings for GObject Introspection base (not architecture dependent)"
+  },
+  {
+    "name": "python3-gpg",
+    "summary": "gpgme bindings for Python 3"
+  },
+  {
+    "name": "python3-hawkey",
+    "summary": "Python 3 bindings for the hawkey library"
+  },
+  {
+    "name": "python3-idna",
+    "summary": "Internationalized Domain Names in Applications (IDNA)"
+  },
+  {
+    "name": "python3-iniparse",
+    "summary": "Python Module for Accessing and Modifying Configuration Data in INI files"
+  },
+  {
+    "name": "python3-inotify",
+    "summary": "Monitor filesystem events with Python under Linux"
+  },
+  {
+    "name": "python3-kmod",
+    "summary": "Python module to work with kernel modules"
+  },
+  {
+    "name": "python3-ldb",
+    "summary": "Python bindings for the LDB library"
+  },
+  {
+    "name": "python3-libcomps",
+    "summary": "Python 3 bindings for libcomps library"
+  },
+  {
+    "name": "python3-libdnf",
+    "summary": "Python 3 bindings for the libdnf library."
+  },
+  {
+    "name": "python3-libipa_hbac",
+    "summary": "Python3 bindings for the FreeIPA HBAC Evaluator library"
+  },
+  {
+    "name": "python3-librepo",
+    "summary": "Python 3 bindings for the librepo library"
+  },
+  {
+    "name": "python3-libs",
+    "summary": "Python runtime libraries"
+  },
+  {
+    "name": "python3-libsss_nss_idmap",
+    "summary": "Python3 bindings for libsss_nss_idmap"
+  },
+  {
+    "name": "python3-libxml2",
+    "summary": "Python 3 bindings for the libxml2 library"
+  },
+  {
+    "name": "python3-linux-procfs",
+    "summary": "Linux /proc abstraction classes"
+  },
+  {
+    "name": "python3-markdown",
+    "summary": "Markdown implementation in Python"
+  },
+  {
+    "name": "python3-nftables",
+    "summary": "Python module providing an interface to libnftables"
+  },
+  {
+    "name": "python3-perf",
+    "summary": "Python bindings for apps which will manipulate perf events"
+  },
+  {
+    "name": "python3-pexpect",
+    "summary": "Unicode-aware Pure Python Expect-like module"
+  },
+  {
+    "name": "python3-pip-wheel",
+    "summary": "The pip wheel"
+  },
+  {
+    "name": "python3-ply",
+    "summary": "Python Lex-Yacc"
+  },
+  {
+    "name": "python3-ptyprocess",
+    "summary": "Run a subprocess in a pseudo terminal"
+  },
+  {
+    "name": "python3-pycparser",
+    "summary": "C parser and AST generator written in Python"
+  },
+  {
+    "name": "python3-pyparsing",
+    "summary": "Python package with an object-oriented approach to text processing"
+  },
+  {
+    "name": "python3-pysocks",
+    "summary": "A Python SOCKS client module"
+  },
+  {
+    "name": "python3-pyudev",
+    "summary": "A libudev binding"
+  },
+  {
+    "name": "python3-pyyaml",
+    "summary": "YAML parser and emitter for Python"
+  },
+  {
+    "name": "python3-requests",
+    "summary": "HTTP library, written in Python, for human beings"
+  },
+  {
+    "name": "python3-rpm",
+    "summary": "Python 3 bindings for apps which will manipulate RPM packages"
+  },
+  {
+    "name": "python3-samba",
+    "summary": "Samba Python3 libraries"
+  },
+  {
+    "name": "python3-samba-dc",
+    "summary": "Samba Python libraries for Samba AD"
+  },
+  {
+    "name": "python3-setools",
+    "summary": "Policy analysis tools for SELinux"
+  },
+  {
+    "name": "python3-setuptools",
+    "summary": "Easily build and distribute Python 3 packages"
+  },
+  {
+    "name": "python3-setuptools-wheel",
+    "summary": "The setuptools wheel"
+  },
+  {
+    "name": "python3-six",
+    "summary": "Python 2 and 3 compatibility utilities"
+  },
+  {
+    "name": "python3-sss",
+    "summary": "Python3 bindings for sssd"
+  },
+  {
+    "name": "python3-sss-murmur",
+    "summary": "Python3 bindings for murmur hash function"
+  },
+  {
+    "name": "python3-sssdconfig",
+    "summary": "SSSD and IPA configuration file manipulation classes and functions"
+  },
+  {
+    "name": "python3-subscription-manager-rhsm",
+    "summary": "A Python library to communicate with a Red Hat Unified Entitlement Platform"
+  },
+  {
+    "name": "python3-systemd",
+    "summary": "Python module wrapping systemd functionality"
+  },
+  {
+    "name": "python3-talloc",
+    "summary": "Python bindings for the Talloc library"
+  },
+  {
+    "name": "python3-tdb",
+    "summary": "Python3 bindings for the Tdb library"
+  },
+  {
+    "name": "python3-tevent",
+    "summary": "Python 3 bindings for the Tevent library"
+  },
+  {
+    "name": "python3-urllib3",
+    "summary": "Python3 HTTP library with thread-safe connection pooling and file post"
+  },
+  {
+    "name": "python3-urwid",
+    "summary": "Console user interface library"
+  },
+  {
+    "name": "quota",
+    "summary": "System administration tools for monitoring users' disk usage"
+  },
+  {
+    "name": "quota-nls",
+    "summary": "Gettext catalogs for disk quota tools"
+  },
+  {
+    "name": "rdma-core",
+    "summary": "RDMA core userspace libraries and daemons"
+  },
+  {
+    "name": "readline",
+    "summary": "A library for editing typed command lines"
+  },
+  {
+    "name": "readonly-root",
+    "summary": "Service for configuring read-only root support"
+  },
+  {
+    "name": "realmd",
+    "summary": "Kerberos realm enrollment service"
+  },
+  {
+    "name": "redhat-release",
+    "summary": "Red Hat Enterprise Linux release file"
+  },
+  {
+    "name": "redhat-release-eula",
+    "summary": "Red Hat Enterprise Linux EULA file"
+  },
+  {
+    "name": "restore",
+    "summary": "Program for restoring ext2/ext3 filesystems"
+  },
+  {
+    "name": "rhel-net-naming-sysattrs",
+    "summary": "RHEL-specific network naming sysattrs"
+  },
+  {
+    "name": "rhsm-icons",
+    "summary": "Icons for Red Hat Subscription Management client tools"
+  },
+  {
+    "name": "rmt",
+    "summary": "Provides certain programs with access to remote tape devices"
+  },
+  {
+    "name": "rng-tools",
+    "summary": "Random number generator related utilities"
+  },
+  {
+    "name": "rootfiles",
+    "summary": "The basic required files for the root user's directory"
+  },
+  {
+    "name": "rpcbind",
+    "summary": "Universal Addresses to RPC Program Number Mapper"
+  },
+  {
+    "name": "rpm",
+    "summary": "The RPM package management system"
+  },
+  {
+    "name": "rpm-build-libs",
+    "summary": "Libraries for building RPM packages"
+  },
+  {
+    "name": "rpm-libs",
+    "summary": "Libraries for manipulating RPM packages"
+  },
+  {
+    "name": "rpm-plugin-audit",
+    "summary": "Rpm plugin for logging audit events on package operations"
+  },
+  {
+    "name": "rpm-plugin-selinux",
+    "summary": "Rpm plugin for SELinux functionality"
+  },
+  {
+    "name": "rpm-sign",
+    "summary": "Package signing support"
+  },
+  {
+    "name": "rpm-sign-libs",
+    "summary": "Libraries for signing RPM packages"
+  },
+  {
+    "name": "rsync",
+    "summary": "A program for synchronizing files over a network"
+  },
+  {
+    "name": "samba",
+    "summary": "Server and Client software to interoperate with Windows machines"
+  },
+  {
+    "name": "samba-client-libs",
+    "summary": "Samba client libraries"
+  },
+  {
+    "name": "samba-common",
+    "summary": "Files used by both Samba servers and clients"
+  },
+  {
+    "name": "samba-common-libs",
+    "summary": "Libraries used by both Samba servers and clients"
+  },
+  {
+    "name": "samba-common-tools",
+    "summary": "Tools for Samba servers and clients"
+  },
+  {
+    "name": "samba-dc-libs",
+    "summary": "Samba AD Domain Controller Libraries"
+  },
+  {
+    "name": "samba-dcerpc",
+    "summary": "DCE RPC binaries"
+  },
+  {
+    "name": "samba-ldb-ldap-modules",
+    "summary": "Samba ldap modules for ldb"
+  },
+  {
+    "name": "samba-libs",
+    "summary": "Samba libraries"
+  },
+  {
+    "name": "samba-tools",
+    "summary": "Tools for Samba servers"
+  },
+  {
+    "name": "samba-usershares",
+    "summary": "Provides support for non-root user shares"
+  },
+  {
+    "name": "samba-winbind",
+    "summary": "Samba winbind"
+  },
+  {
+    "name": "samba-winbind-modules",
+    "summary": "Samba winbind modules"
+  },
+  {
+    "name": "sed",
+    "summary": "A GNU stream text editor"
+  },
+  {
+    "name": "selinux-policy",
+    "summary": "SELinux policy configuration"
+  },
+  {
+    "name": "selinux-policy-doc",
+    "summary": "SELinux policy documentation"
+  },
+  {
+    "name": "selinux-policy-mls",
+    "summary": "SELinux MLS policy"
+  },
+  {
+    "name": "selinux-policy-sandbox",
+    "summary": "SELinux sandbox policy"
+  },
+  {
+    "name": "selinux-policy-targeted",
+    "summary": "SELinux targeted policy"
+  },
+  {
+    "name": "setools-console",
+    "summary": "Policy analysis command-line tools for SELinux"
+  },
+  {
+    "name": "setserial",
+    "summary": "A utility for configuring serial ports"
+  },
+  {
+    "name": "setup",
+    "summary": "A set of system configuration and setup files"
+  },
+  {
+    "name": "sg3_utils",
+    "summary": "Utilities for devices that use SCSI command sets"
+  },
+  {
+    "name": "sg3_utils-libs",
+    "summary": "Shared library for sg3_utils"
+  },
+  {
+    "name": "shadow-utils",
+    "summary": "Utilities for managing accounts and shadow password files"
+  },
+  {
+    "name": "shadow-utils-subid",
+    "summary": "A library to manage subordinate uid and gid ranges"
+  },
+  {
+    "name": "shared-mime-info",
+    "summary": "Shared MIME information database"
+  },
+  {
+    "name": "shim-x64",
+    "summary": "First-stage UEFI bootloader"
+  },
+  {
+    "name": "slang",
+    "summary": "Shared library for the S-Lang extension language"
+  },
+  {
+    "name": "smartmontools",
+    "summary": "Tools for monitoring SMART capable hard disks"
+  },
+  {
+    "name": "snappy",
+    "summary": "Fast compression and decompression library"
+  },
+  {
+    "name": "sos",
+    "summary": "A set of tools to gather troubleshooting information from a system"
+  },
+  {
+    "name": "sos-audit",
+    "summary": "Audit use of some commands for support purposes"
+  },
+  {
+    "name": "sqlite-libs",
+    "summary": "Shared library for the sqlite3 embeddable SQL database engine."
+  },
+  {
+    "name": "squashfs-tools",
+    "summary": "Utility for the creation of squashfs filesystems"
+  },
+  {
+    "name": "srp_daemon",
+    "summary": "Tools for using the InfiniBand SRP protocol devices"
+  },
+  {
+    "name": "sssd",
+    "summary": "System Security Services Daemon"
+  },
+  {
+    "name": "sssd-ad",
+    "summary": "The AD back end of the SSSD"
+  },
+  {
+    "name": "sssd-client",
+    "summary": "SSSD Client libraries for NSS and PAM"
+  },
+  {
+    "name": "sssd-common",
+    "summary": "Common files for the SSSD"
+  },
+  {
+    "name": "sssd-common-pac",
+    "summary": "Common files needed for supporting PAC processing"
+  },
+  {
+    "name": "sssd-dbus",
+    "summary": "The D-Bus responder of the SSSD"
+  },
+  {
+    "name": "sssd-ipa",
+    "summary": "The IPA back end of the SSSD"
+  },
+  {
+    "name": "sssd-kcm",
+    "summary": "An implementation of a Kerberos KCM server"
+  },
+  {
+    "name": "sssd-krb5",
+    "summary": "The Kerberos authentication back end for the SSSD"
+  },
+  {
+    "name": "sssd-krb5-common",
+    "summary": "SSSD helpers needed for Kerberos and GSSAPI authentication"
+  },
+  {
+    "name": "sssd-ldap",
+    "summary": "The LDAP back end of the SSSD"
+  },
+  {
+    "name": "sssd-nfs-idmap",
+    "summary": "SSSD plug-in for NFSv4 rpc.idmapd"
+  },
+  {
+    "name": "sssd-passkey",
+    "summary": "SSSD helpers and plugins needed for authentication with passkey token"
+  },
+  {
+    "name": "sssd-polkit-rules",
+    "summary": "Rules for polkit integration for SSSD"
+  },
+  {
+    "name": "sssd-proxy",
+    "summary": "The proxy back end of the SSSD"
+  },
+  {
+    "name": "sssd-tools",
+    "summary": "Userspace tools for use with the SSSD"
+  },
+  {
+    "name": "sssd-winbind-idmap",
+    "summary": "SSSD's idmap_sss Backend for Winbind"
+  },
+  {
+    "name": "strace",
+    "summary": "Tracks and displays system calls associated with a running process"
+  },
+  {
+    "name": "stunnel",
+    "summary": "A TLS-encrypting socket wrapper"
+  },
+  {
+    "name": "subscription-manager",
+    "summary": "Tools and libraries for subscription and repository management"
+  },
+  {
+    "name": "subscription-manager-cockpit",
+    "summary": "Subscription Manager Cockpit UI"
+  },
+  {
+    "name": "subscription-manager-plugin-ostree",
+    "summary": "A plugin for handling OSTree content."
+  },
+  {
+    "name": "subscription-manager-rhsm-certificates",
+    "summary": "Certificates required to communicate with a Red Hat Unified Entitlement Platform"
+  },
+  {
+    "name": "sudo",
+    "summary": "Allows restricted root access for specified users"
+  },
+  {
+    "name": "symlinks",
+    "summary": "A utility which maintains a system's symbolic links"
+  },
+  {
+    "name": "syslinux",
+    "summary": "Simple kernel loader which boots from a FAT filesystem"
+  },
+  {
+    "name": "syslinux-extlinux",
+    "summary": "The EXTLINUX bootloader, for booting the local system."
+  },
+  {
+    "name": "syslinux-extlinux-nonlinux",
+    "summary": "The parts of the EXTLINUX bootloader which aren't run from linux."
+  },
+  {
+    "name": "syslinux-nonlinux",
+    "summary": "SYSLINUX modules which aren't run from linux."
+  },
+  {
+    "name": "systemd",
+    "summary": "System and Service Manager"
+  },
+  {
+    "name": "systemd-container",
+    "summary": "Tools for containers and VMs"
+  },
+  {
+    "name": "systemd-libs",
+    "summary": "systemd libraries"
+  },
+  {
+    "name": "systemd-oomd",
+    "summary": "A userspace out-of-memory (OOM) killer"
+  },
+  {
+    "name": "systemd-pam",
+    "summary": "systemd PAM module"
+  },
+  {
+    "name": "systemd-resolved",
+    "summary": "System daemon that provides network name resolution to local applications"
+  },
+  {
+    "name": "systemd-rpm-macros",
+    "summary": "Macros that define paths and scriptlets related to systemd"
+  },
+  {
+    "name": "systemd-udev",
+    "summary": "Rule-based device node and kernel event manager"
+  },
+  {
+    "name": "tar",
+    "summary": "GNU file archiving program"
+  },
+  {
+    "name": "tboot",
+    "summary": "Performs a verified launch using Intel TXT"
+  },
+  {
+    "name": "tcl",
+    "summary": "Tool Command Language, pronounced tickle"
+  },
+  {
+    "name": "tdb-tools",
+    "summary": "Developer tools for the Tdb library"
+  },
+  {
+    "name": "teamd",
+    "summary": "Team network device control daemon"
+  },
+  {
+    "name": "time",
+    "summary": "A GNU utility for monitoring a program's use of system resources"
+  },
+  {
+    "name": "tmux",
+    "summary": "A terminal multiplexer"
+  },
+  {
+    "name": "tpm2-tools",
+    "summary": "A bunch of TPM testing toolS build upon tpm2-tss"
+  },
+  {
+    "name": "tpm2-tss",
+    "summary": "TPM2.0 Software Stack"
+  },
+  {
+    "name": "trace-cmd",
+    "summary": "A user interface to Ftrace"
+  },
+  {
+    "name": "traceroute",
+    "summary": "Traces the route taken by packets over an IPv4/IPv6 network"
+  },
+  {
+    "name": "tree",
+    "summary": "File system tree viewer"
+  },
+  {
+    "name": "tss2",
+    "summary": "IBM's TCG Software Stack (TSS) for TPM 2.0 and related utilities"
+  },
+  {
+    "name": "tuna",
+    "summary": "Application tuning GUI & command line utility"
+  },
+  {
+    "name": "tuned",
+    "summary": "A dynamic adaptive system tuning daemon"
+  },
+  {
+    "name": "tuned-profiles-cpu-partitioning",
+    "summary": "Additional tuned profile(s) optimized for CPU partitioning"
+  },
+  {
+    "name": "tzdata",
+    "summary": "Timezone data"
+  },
+  {
+    "name": "units",
+    "summary": "A utility for converting amounts from one unit to another"
+  },
+  {
+    "name": "unzip",
+    "summary": "A utility for unpacking zip files"
+  },
+  {
+    "name": "usb_modeswitch",
+    "summary": "USB Modeswitch gets mobile broadband cards in operational mode"
+  },
+  {
+    "name": "usb_modeswitch-data",
+    "summary": "USB Modeswitch gets mobile broadband cards in operational mode"
+  },
+  {
+    "name": "usbutils",
+    "summary": "Linux USB utilities"
+  },
+  {
+    "name": "usermode",
+    "summary": "Tools for certain user account management tasks"
+  },
+  {
+    "name": "userspace-rcu",
+    "summary": "RCU (read-copy-update) implementation in user-space"
+  },
+  {
+    "name": "util-linux",
+    "summary": "A collection of basic system utilities"
+  },
+  {
+    "name": "util-linux-core",
+    "summary": "The most essential utilities from the util-linux suite."
+  },
+  {
+    "name": "util-linux-user",
+    "summary": "libuser based util-linux utilities"
+  },
+  {
+    "name": "vdo",
+    "summary": "Management tools for Virtual Data Optimizer"
+  },
+  {
+    "name": "vdo-support",
+    "summary": "Support tools for Virtual Data Optimizer"
+  },
+  {
+    "name": "veritysetup",
+    "summary": "A utility for setting up dm-verity volumes"
+  },
+  {
+    "name": "vim-filesystem",
+    "summary": "VIM filesystem layout"
+  },
+  {
+    "name": "vim-minimal",
+    "summary": "A minimal version of the VIM editor"
+  },
+  {
+    "name": "virt-what",
+    "summary": "Detect if we are running in a virtual machine"
+  },
+  {
+    "name": "which",
+    "summary": "Displays where a particular program in your path is located"
+  },
+  {
+    "name": "wireless-regdb",
+    "summary": "Regulatory database for 802.11 wireless networking"
+  },
+  {
+    "name": "words",
+    "summary": "A dictionary of English words for the /usr/share/dict directory"
+  },
+  {
+    "name": "wpa_supplicant",
+    "summary": "WPA/WPA2/IEEE 802.1X Supplicant"
+  },
+  {
+    "name": "x3270",
+    "summary": "An X Window System based IBM 3278/3279 terminal emulator"
+  },
+  {
+    "name": "x3270-text",
+    "summary": "IBM 3278/3279 terminal emulator for text mode"
+  },
+  {
+    "name": "xfsdump",
+    "summary": "Backup and restore utilities for the XFS filesystem"
+  },
+  {
+    "name": "xfsprogs",
+    "summary": "Utilities for managing the XFS filesystem"
+  },
+  {
+    "name": "xz",
+    "summary": "LZMA compression utilities"
+  },
+  {
+    "name": "xz-libs",
+    "summary": "Libraries for decoding LZMA compression"
+  },
+  {
+    "name": "yum",
+    "summary": "Package manager"
+  },
+  {
+    "name": "yum-utils",
+    "summary": "Yum-utils CLI compatibility layer"
+  },
+  {
+    "name": "zip",
+    "summary": "A file compression and packaging utility compatible with PKZIP"
+  },
+  {
+    "name": "zlib",
+    "summary": "Compression and decompression library"
+  },
+  {
+    "name": "zsh",
+    "summary": "Powerful interactive shell"
+  },
+  {
+    "name": "zstd",
+    "summary": "Zstd compression library"
+  }
+]

--- a/distributions/rhel-9.6/rhel-9.6-x86_64-google-cloud-sdk-packages.json
+++ b/distributions/rhel-9.6/rhel-9.6-x86_64-google-cloud-sdk-packages.json
@@ -1,0 +1,298 @@
+[
+  {
+    "name": "google-cloud-cli",
+    "summary": "Google Cloud CLI"
+  },
+  {
+    "name": "google-cloud-cli-anthos-auth",
+    "summary": "Google Cloud CLI Anthos Auth"
+  },
+  {
+    "name": "google-cloud-cli-anthoscli",
+    "summary": "Google Cloud CLI Anthos Auth"
+  },
+  {
+    "name": "google-cloud-cli-app-engine-go",
+    "summary": "Google Cloud CLI App Engine Go"
+  },
+  {
+    "name": "google-cloud-cli-app-engine-grpc",
+    "summary": "Google Cloud CLI App Engine gRPC"
+  },
+  {
+    "name": "google-cloud-cli-app-engine-java",
+    "summary": "Google Cloud CLI App Engine Java"
+  },
+  {
+    "name": "google-cloud-cli-app-engine-python",
+    "summary": "Google Cloud CLI App Engine Python"
+  },
+  {
+    "name": "google-cloud-cli-app-engine-python-extras",
+    "summary": "Google Cloud CLI App Engine Python extra libraries"
+  },
+  {
+    "name": "google-cloud-cli-bigtable-emulator",
+    "summary": "Google Cloud CLI Bigtable Emulator"
+  },
+  {
+    "name": "google-cloud-cli-cbt",
+    "summary": "Google Cloud CLI Cloud Bigtable"
+  },
+  {
+    "name": "google-cloud-cli-cloud-build-local",
+    "summary": "Google Cloud CLI Cloud Build Local Builder"
+  },
+  {
+    "name": "google-cloud-cli-cloud-run-proxy",
+    "summary": "Google Cloud CLI Cloud Run Proxy"
+  },
+  {
+    "name": "google-cloud-cli-config-connector",
+    "summary": "Google Cloud CLI Config Connector"
+  },
+  {
+    "name": "google-cloud-cli-datalab",
+    "summary": "Google Cloud CLI Datalab"
+  },
+  {
+    "name": "google-cloud-cli-datastore-emulator",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-cli-docker-credential-gcr",
+    "summary": "Google Cloud CLI Docker Credential GCR"
+  },
+  {
+    "name": "google-cloud-cli-enterprise-certificate-proxy",
+    "summary": "Google Cloud CLI enterprise-certificate-proxy"
+  },
+  {
+    "name": "google-cloud-cli-firestore-emulator",
+    "summary": "Google Cloud CLI Firestore Emulator"
+  },
+  {
+    "name": "google-cloud-cli-gke-gcloud-auth-plugin",
+    "summary": "Google Cloud CLI GKE Auth Plugin"
+  },
+  {
+    "name": "google-cloud-cli-harbourbridge",
+    "summary": "Google Cloud CLI Harbourbridge"
+  },
+  {
+    "name": "google-cloud-cli-istioctl",
+    "summary": "Google Cloud CLI istioctl"
+  },
+  {
+    "name": "google-cloud-cli-kpt",
+    "summary": "Google Cloud CLI kpt"
+  },
+  {
+    "name": "google-cloud-cli-kubectl-oidc",
+    "summary": "Google Cloud CLI Kubectl OIDC"
+  },
+  {
+    "name": "google-cloud-cli-local-extract",
+    "summary": "Google Cloud CLI Local Extract"
+  },
+  {
+    "name": "google-cloud-cli-log-streaming",
+    "summary": "Google Cloud CLI Cloud Run Proxy"
+  },
+  {
+    "name": "google-cloud-cli-managed-flink-client",
+    "summary": "Google Cloud CLI Managed Flink Client"
+  },
+  {
+    "name": "google-cloud-cli-minikube",
+    "summary": "Google Cloud CLI Minikube"
+  },
+  {
+    "name": "google-cloud-cli-nomos",
+    "summary": "Google Cloud CLI Nomos"
+  },
+  {
+    "name": "google-cloud-cli-package-go-module",
+    "summary": "Google Cloud CLI Package Go Module"
+  },
+  {
+    "name": "google-cloud-cli-pubsub-emulator",
+    "summary": "Google Cloud CLI PubSub Emulator"
+  },
+  {
+    "name": "google-cloud-cli-run-compose",
+    "summary": "Google Cloud CLI Run Compose"
+  },
+  {
+    "name": "google-cloud-cli-skaffold",
+    "summary": "Google Cloud CLI Skaffold"
+  },
+  {
+    "name": "google-cloud-cli-spanner-cli",
+    "summary": "Google Cloud CLI Spanner Cli"
+  },
+  {
+    "name": "google-cloud-cli-spanner-emulator",
+    "summary": "Google Cloud CLI Spanner Emulator"
+  },
+  {
+    "name": "google-cloud-cli-spanner-migration-tool",
+    "summary": "Google Cloud CLI Spanner migration tool"
+  },
+  {
+    "name": "google-cloud-cli-terraform-tools",
+    "summary": "Google Cloud CLI Terraform Tools"
+  },
+  {
+    "name": "google-cloud-cli-terraform-validator",
+    "summary": "Google Cloud CLI Terraform Validator"
+  },
+  {
+    "name": "google-cloud-cli-tests",
+    "summary": "Google Cloud CLI Tests"
+  },
+  {
+    "name": "google-cloud-sdk",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-anthos-auth",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-app-engine-go",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-app-engine-grpc",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-app-engine-java",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-app-engine-python",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-app-engine-python-extras",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-bigtable-emulator",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-bundled-python3",
+    "summary": "Python3 interpreter for Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-cbt",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-cloud-build-local",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-cloud-run-proxy",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-config-connector",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-datalab",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-datastore-emulator",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-docker-credential-gcr",
+    "summary": "Google Cloud CLI Docker Credential GCR"
+  },
+  {
+    "name": "google-cloud-sdk-enterprise-certificate-proxy",
+    "summary": "Google Cloud CLI enterprise-certificate-proxy"
+  },
+  {
+    "name": "google-cloud-sdk-firestore-emulator",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-gke-gcloud-auth-plugin",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-harbourbridge",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-istioctl",
+    "summary": "Google Cloud CLI istioctl"
+  },
+  {
+    "name": "google-cloud-sdk-kpt",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-kubectl-oidc",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-local-extract",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-log-streaming",
+    "summary": "Google Cloud CLI Cloud Run Proxy"
+  },
+  {
+    "name": "google-cloud-sdk-minikube",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-nomos",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-package-go-module",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-pubsub-emulator",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-skaffold",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-spanner-emulator",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-spanner-migration-tool",
+    "summary": "Google Cloud CLI Spanner migration tool"
+  },
+  {
+    "name": "google-cloud-sdk-terraform-tools",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-terraform-validator",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "google-cloud-sdk-tests",
+    "summary": "Google Cloud SDK"
+  },
+  {
+    "name": "kubectl",
+    "summary": "Command-line utility for interacting with a Kubernetes cluster"
+  }
+]

--- a/distributions/rhel-9.6/rhel-9.6-x86_64-google-compute-engine-packages.json
+++ b/distributions/rhel-9.6/rhel-9.6-x86_64-google-compute-engine-packages.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "dnf-plugin-artifact-registry",
+    "summary": "dnf plugin for Artifact Registry"
+  },
+  {
+    "name": "gce-disk-expand",
+    "summary": "Google Compute Engine root disk expansion module"
+  },
+  {
+    "name": "google-compute-engine",
+    "summary": "Google Compute Engine guest environment."
+  },
+  {
+    "name": "google-compute-engine-oslogin",
+    "summary": "OS Login Functionality for Google Compute Engine"
+  },
+  {
+    "name": "google-guest-agent",
+    "summary": "Google Compute Engine guest agent."
+  },
+  {
+    "name": "google-osconfig-agent",
+    "summary": "Google Compute Engine guest environment."
+  },
+  {
+    "name": "google-rhui-client-rhel9",
+    "summary": "RHUI config for GCE"
+  },
+  {
+    "name": "google-rhui-client-rhel9-eus",
+    "summary": "RHUI config for GCE"
+  },
+  {
+    "name": "google-rhui-client-rhel9-ha",
+    "summary": "RHUI config for GCE (HA repo)"
+  },
+  {
+    "name": "google-rhui-client-rhel9-sap",
+    "summary": "RHUI config for GCE"
+  }
+]

--- a/distributions/rhel-9.6/rhel-9.6.json
+++ b/distributions/rhel-9.6/rhel-9.6.json
@@ -4,8 +4,7 @@
   "distribution": {
     "name": "rhel-9.6",
     "composer_name": "rhel-9.6",
-    "description": "Red Hat Enterprise Linux (RHEL) 9",
-    "no_package_list": true
+    "description": "Red Hat Enterprise Linux (RHEL) 9"
   },
   "x86_64": {
     "image_types": [ "aws", "gcp", "azure", "rhel-edge-commit", "rhel-edge-installer", "edge-commit", "edge-installer", "guest-image", "image-installer", "oci", "vsphere", "vsphere-ova", "wsl" ],


### PR DESCRIPTION
895479b0066d5c3fe43a8f83c7e1bdf2624dfe8c mentioned that the package lists are not needed because the frontend is now fully switched to use the content service but we missed a piece: the edge service still uses the package search provided by us.

This commit thus generates the package lists for 9.6 to fix the edge-mgmt service. I ran the following command:

./tools/generate-package-lists \
  --distro distributions/rhel-9.6/rhel-9.6.json \
  --key /etc/pki/entitlement/ID-key.pem \
  --cert /etc/pki/entitlement/ID.pem

Note that generating the package list for RHEL 10.0 isn't necessary because edge-mgmt doesn't supprot RHEL 10