### PR TITLE
distributions: enable centos 10

### DIFF
--- a/distributions/centos-10/centos-10.json
+++ b/distributions/centos-10/centos-10.json
@@ -4,8 +4,7 @@
   "distribution": {
     "name": "centos-10",
     "description": "CentOS Stream 10",
-    "no_package_list": true,
-    "restricted_access": true
+    "no_package_list": true
   },
   "x86_64": {
     "image_types": [ "ami", "aws", "azure", "gcp", "guest-image", "image-installer", "oci", "openstack", "vsphere", "vsphere-ova", "wsl"],

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -905,6 +905,7 @@ func TestGetDistributions(t *testing.T) {
 				"rhel-10.1-nightly",
 				"rhel-10.0",
 				"centos-9",
+				"centos-10",
 			},
 			distros)
 	})


### PR DESCRIPTION
CentOS 10 is released and thus should
be available and represented in the API.