### PR TITLE
gha: pin shellcheck to 0.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,7 @@ jobs:
         uses: ludeeus/action-shellcheck@2.0.0
         with:
           ignore: vendor # We don't want to fix the code in vendored dependencies
+          version: "v0.10.0"
         env:
         # don't check /etc/os-release sourcing and allow useless cats to live inside our codebase
         # allow seemingly unreachable commands


### PR DESCRIPTION
This fixes broken CI:

```
./test/cases/api.sh:29:1: note: This function is never invoked. Check usage (or ignored if invoked indirectly). [SC2329]
./test/cases/api.sh:48:1: note: This function is never invoked. Check usage (or ignored if invoked indirectly). [SC2329]
```

Created an issue to unpin it or upgrade it: https://github.com/osbuild/image-builder-crc/issues/1666
