### PR TITLE
Update logging & native middleware & context improvements

### DIFF
--- a/internal/v1/server_identity_test.go
+++ b/internal/v1/server_identity_test.go
@@ -18,8 +18,8 @@ func TestRedHatIdentity(t *testing.T) {
 
 	t.Run("VerifyIdentityHeaderMissing", func(t *testing.T) {
 		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", nil)
-		require.Equal(t, http.StatusBadRequest, respStatusCode)
-		require.Contains(t, body, "missing x-rh-identity header")
+		require.Equal(t, http.StatusUnauthorized, respStatusCode)
+		require.Contains(t, body, "missing identity header")
 	})
 
 	t.Run("Valid authstring", func(t *testing.T) {


### PR DESCRIPTION
main: use echo middleware with context

New function NewEchoV4MiddlewareWithConfig is utilized to use native
echo middleware which prevents incorrect error logging.

New function NewProxyWithContextFor allows for setting request-based
context-aware logger for echo logger. This will include all correlation
fields to be inluded in all echo log records.

Middleware was moved from main.go to server.go and identity extraction
was put as the first middleware to be done as soon as possible so all
logs will include the relevant context.

Logging configuration was updated with ContextCallback that puts
organization id (and fedora user) in all log/slog lines automatically.

---

The first commit updates the `logging` library to v0.0.5 which requires the necessary features.

The second commit contains several small updates as described. I did not break it into individual commits unfortunately, these hunks are quite close each other and I was experimenting while working on this. Can do interactive hunk rebase if needed tho I guess git will not work well as I edited the same place many times.

This makes several improvements:

* Request INFO log now does correctly catch errors returned from echo handlers and sets status correctly
* Request INFO log also does not display body length (or body itself when configured) when echo handler returns an error (because it cannot do this thanks to the design of echo framework)
* All log records now contains `org_id=000000 user=user` information or just `user=user` in case of fedora instance
* Log records created via echo (`c.Logger().Info(...)`) now also contains the above including `trace_id` and `build_id`

Example:

```
time=2025-08-21T18:46:39.868+02:00 level=INFO msg="400: Bad Request" build_id=f4c4e51 request.time=2025-08-21T16:46:39.868Z request.method=GET request.host=localhost:8086 request.path=/api/image-builder/v1/blueprints request.ip=127.0.0.1:43318 request.length=0 response.time=2025-08-21T16:46:39.868Z response.latency=171.149µs response.status=400 trace_id=FBOifBBhgCDGXFv org_id=000000 user=user

time=2025-08-21T18:46:39.868+02:00 level=WARN msg="HTTP error: code=400, message=parameter \"search\" in query has an error: empty value is not allowed" build_id=f4c4e51 echo=true org_id=000000 user=user
```

HMS-9093