### PR TITLE
distributions: add Fedora 43 (branched) and 44 (rawhide)

### DIFF
--- a/distributions/fedora-43/fedora-43.json
+++ b/distributions/fedora-43/fedora-43.json
@@ -1,0 +1,51 @@
+{
+  "module_platform_id": "platform:f43",
+  "oscap_name": "fedora",
+  "distribution": {
+    "name": "fedora-43",
+    "description": "Fedora Linux 43",
+    "no_package_list": true,
+    "restricted_access": true
+  },
+  "x86_64": {
+    "image_types": [
+      "aws",
+      "azure",
+      "guest-image",
+      "oci",
+      "vsphere",
+      "vsphere-ova",
+      "iot-commit"
+    ],
+    "repositories": [
+      {
+        "id": "fedora",
+        "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-43&arch=x86_64",
+        "rhsm": false
+      },
+      {
+        "id": "updates",
+        "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f43&arch=x86_64",
+        "rhsm": false
+      }
+    ]
+  },
+  "aarch64": {
+    "image_types": [
+      "aws",
+      "guest-image"
+    ],
+    "repositories": [
+      {
+        "id": "fedora",
+        "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-43&arch=aarch64",
+        "rhsm": false
+      },
+      {
+        "id": "updates",
+        "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f43&arch=aarch64",
+        "rhsm": false
+      }
+    ]
+  }
+}

--- a/distributions/fedora-44/fedora-44.json
+++ b/distributions/fedora-44/fedora-44.json
@@ -1,0 +1,51 @@
+{
+  "module_platform_id": "platform:f44",
+  "oscap_name": "fedora",
+  "distribution": {
+    "name": "fedora-44",
+    "description": "Fedora Linux 44",
+    "no_package_list": true,
+    "restricted_access": true
+  },
+  "x86_64": {
+    "image_types": [
+      "aws",
+      "azure",
+      "guest-image",
+      "oci",
+      "vsphere",
+      "vsphere-ova",
+      "iot-commit"
+    ],
+    "repositories": [
+      {
+        "id": "fedora",
+        "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=x86_64",
+        "rhsm": false
+      },
+      {
+        "id": "updates",
+        "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&arch=x86_64",
+        "rhsm": false
+      }
+    ]
+  },
+  "aarch64": {
+    "image_types": [
+      "aws",
+      "guest-image"
+    ],
+    "repositories": [
+      {
+        "id": "fedora",
+        "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=aarch64",
+        "rhsm": false
+      },
+      {
+        "id": "updates",
+        "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&arch=aarch64",
+        "rhsm": false
+      }
+    ]
+  }
+}

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -76,6 +76,8 @@ const (
 	Fedora40       Distributions = "fedora-40"
 	Fedora41       Distributions = "fedora-41"
 	Fedora42       Distributions = "fedora-42"
+	Fedora43       Distributions = "fedora-43"
+	Fedora44       Distributions = "fedora-44"
 	Rhel10         Distributions = "rhel-10"
 	Rhel100        Distributions = "rhel-10.0"
 	Rhel100Nightly Distributions = "rhel-10.0-nightly"

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1214,6 +1214,8 @@ components:
         - fedora-40
         - fedora-41
         - fedora-42
+        - fedora-43
+        - fedora-44
     ImageRequest:
       type: object
       additionalProperties: false

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -861,6 +861,8 @@ func TestGetDistributions(t *testing.T) {
 				"fedora-40",
 				"fedora-41",
 				"fedora-42",
+				"fedora-43",
+				"fedora-44",
 			},
 			distros)
 	})


### PR DESCRIPTION
We need these to build the runners to start building and testing osbuild RPMs.