### PR TITLE
github: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
+* @osbuild/ib-service-reviewers


### PR DESCRIPTION
Add the ib-service-reviewers team as code owners for automatic review assignment.

@osbuild/ib-service-reviewers, please take a look.