### PR TITLE
ci: enable changelog for gobump

### DIFF
--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -20,3 +20,4 @@ jobs:
           go_version: "1.23.9"
           token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
           exec_pr: ./tools/prepare-source.sh
+          changelog: true


### PR DESCRIPTION
I added a new feature to gobump - every update will now come with a changelog. Due to size, these will be links to gists for each PR. Example: https://gist.github.com/lzap/b46a70514be80685d9e1b9a041dfdb5c