### PR TITLE
content_sources: improve HTTP error message

### DIFF
--- a/internal/clients/content_sources/client.go
+++ b/internal/clients/content_sources/client.go
@@ -85,10 +85,10 @@ func (csc *ContentSourcesClient) fetchRepositories(ctx context.Context, repoURLs
 		if resp.StatusCode != http.StatusUnauthorized {
 			body, err := io.ReadAll(resp.Body)
 			if err != nil {
-				return nil, fmt.Errorf("unable to fetch repositories, got %v response, body: %s", resp.StatusCode, body)
+				return nil, fmt.Errorf("unable to fetch repositories from %s, got %v response, body: %s", csReposURL.String(), resp.StatusCode, body)
 			}
 		}
-		return nil, fmt.Errorf("unable to fetch repositories, got %v response", resp.StatusCode)
+		return nil, fmt.Errorf("unable to fetch repositories from %s, got %v response", csReposURL.String(), resp.StatusCode)
 	}
 
 	var repos *ApiRepositoryCollectionResponse


### PR DESCRIPTION
content_sources: improve HTTP error message

The error is quite confusing and it was not sure which URL was failing.
The reporter were investigating EPEL repository while the service was
unable to reach out to snapshost of the EPEL repository.

This patch makes it clear where the error is coming from.

---

@schuellerf 