### PR TITLE
db: only match on org id when deleting blueprints (HMS-9329)

### DIFF
--- a/cmd/image-builder-db-test/main_test.go
+++ b/cmd/image-builder-db-test/main_test.go
@@ -444,7 +444,7 @@ func testBlueprints(ctx context.Context, t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, count)
 
-	err = d.DeleteBlueprint(ctx, id, ORGID1, ANR1)
+	err = d.DeleteBlueprint(ctx, id, ORGID1)
 	require.NoError(t, err)
 
 	_, count, err = d.GetComposes(ctx, ORGID1, (time.Hour * 24 * 14), 100, 0, nil)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -83,7 +83,7 @@ type DB interface {
 	GetBlueprints(ctx context.Context, orgID string, limit, offset int) ([]BlueprintWithNoBody, int, error)
 	FindBlueprints(ctx context.Context, orgID, search string, limit, offset int) ([]BlueprintWithNoBody, int, error)
 	FindBlueprintByName(ctx context.Context, orgID, nameQuery string) (*BlueprintWithNoBody, error)
-	DeleteBlueprint(ctx context.Context, id uuid.UUID, orgID, accountNumber string) error
+	DeleteBlueprint(ctx context.Context, id uuid.UUID, orgID string) error
 }
 
 const (

--- a/internal/db/db_blueprints.go
+++ b/internal/db/db_blueprints.go
@@ -95,7 +95,7 @@ const (
 		WHERE composes.blueprint_version_id = blueprint_versions.id
 		AND composes.org_id=$1 AND blueprint_versions.blueprint_id=$2`
 
-	sqlDeleteBlueprint = `UPDATE blueprints SET deleted = TRUE, name = id WHERE deleted = FALSE AND id = $1 AND org_id = $2 AND account_number = $3`
+	sqlDeleteBlueprint = `UPDATE blueprints SET deleted = TRUE, name = id WHERE deleted = FALSE AND id = $1 AND org_id = $2`
 
 	sqlGetBlueprints = `
 		SELECT blueprints.id, blueprints.name, blueprints.description, MAX(blueprint_versions.version) as version, MAX(blueprint_versions.created_at) as last_modified_at
@@ -294,7 +294,7 @@ func (db *dB) UpdateBlueprint(ctx context.Context, id uuid.UUID, blueprintId uui
 	return err
 }
 
-func (db *dB) DeleteBlueprint(ctx context.Context, id uuid.UUID, orgID, accountNumber string) error {
+func (db *dB) DeleteBlueprint(ctx context.Context, id uuid.UUID, orgID string) error {
 	conn, err := db.Pool.Acquire(ctx)
 	if err != nil {
 		return err
@@ -306,7 +306,7 @@ func (db *dB) DeleteBlueprint(ctx context.Context, id uuid.UUID, orgID, accountN
 		return fmt.Errorf("marking blueprint(%s) composes as deleted failed: %w", id, err)
 	}
 
-	tag, err := conn.Exec(ctx, sqlDeleteBlueprint, id, orgID, accountNumber)
+	tag, err := conn.Exec(ctx, sqlDeleteBlueprint, id, orgID)
 	if err != nil {
 		return err
 	}

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -728,7 +728,7 @@ func (h *Handlers) DeleteBlueprint(ctx echo.Context, blueprintId openapi_types.U
 		return err
 	}
 
-	err = h.server.db.DeleteBlueprint(ctx.Request().Context(), blueprintId, userID.OrgID(), userID.AccountNumber())
+	err = h.server.db.DeleteBlueprint(ctx.Request().Context(), blueprintId, userID.OrgID())
 	if err != nil {
 		if errors.Is(err, db.ErrBlueprintNotFound) {
 			return echo.NewHTTPError(http.StatusNotFound)

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -47,6 +47,7 @@ func makeTestServer(t *testing.T, apiSrv *string) (dbase db.DB, srvURL string, s
 		DistributionsDir: "../../distributions",
 		CSReposURL:       "https://content-sources.org",
 	})
+
 	return srv.DB, srv.URL, func(t *testing.T) {
 		srv.Shutdown(t)
 	}
@@ -1621,7 +1622,7 @@ func TestLintBlueprint(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(body), &result))
 		require.ElementsMatch(t, c.lintErrors, result.Lint.Errors)
 
-		require.NoError(t, srv.DB.DeleteBlueprint(context.Background(), bpID, "000000", "000000"))
+		require.NoError(t, srv.DB.DeleteBlueprint(context.Background(), bpID, "000000"))
 	}
 }
 
@@ -1693,6 +1694,6 @@ func TestFixupBlueprint(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(body), &result))
 		require.Empty(t, result.Lint.Errors)
 
-		require.NoError(t, srv.DB.DeleteBlueprint(context.Background(), bpID, "000000", "000000"))
+		require.NoError(t, srv.DB.DeleteBlueprint(context.Background(), bpID, "000000"))
 	}
 }


### PR DESCRIPTION
There are certain scenarios where the account number isn't set in the identity header. For instance when using service accounts and working via the api, the account number will be empty. Deleting the same blueprint via the UI will fail because there the account number will be set.