### PR TITLE
oscap: fix policy without changes returns empty response body (HMS-9351)

### DIFF
--- a/internal/clients/compliance/client.go
+++ b/internal/clients/compliance/client.go
@@ -126,6 +126,10 @@ func (cc *ComplianceClient) PolicyDataForMinorVersion(ctx context.Context, major
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		// if the policy had no customizations, the json endpoint returns empty body (unlike toml endpoint)
+		// but we need to return empty json object for osbuild autotailoring
+		tailoringData, _ = json.Marshal("{}")
 	}
 
 	return &PolicyData{


### PR DESCRIPTION
The JSON endpoint for getting a tailoring file returns a empty body when the policy was not customized, but autotailoring in osbuild expects valid JSON object. Fix with on status code 204 we assume "{}".