### PR TITLE
floorplan: Dump clones table (HMS-9078)

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -234,6 +234,12 @@ objects:
         from
           blueprint_versions v
           left outer join blueprints b ON v.blueprint_id = b.id
+    - prefix: ${FLOORIST_QUERY_PREFIX}/clones
+      query: >-
+        select
+          compose_id, created_at
+        from
+          clones
 
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION
In order to assess how much the `AWS clone to region` feature is used, let's take a look at the numbers.
(This feature was a pre-requisite for the - now decommissioned - 'Launch in AWS' feature. It's not useless now, but also just a convenience function.)