### PR TITLE
internal/v1: remove azure source id (HMS-9185)

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -241,18 +241,12 @@ type AzureUploadRequestOptions struct {
 	// ResourceGroup Name of the resource group where the image should be uploaded.
 	ResourceGroup string `json:"resource_group"`
 
-	// SourceId ID of the source that will be used to resolve the tenant and subscription IDs.
-	// Do not provide a tenant_id or subscription_id when providing a source_id.
-	SourceId *string `json:"source_id,omitempty"`
-
 	// SubscriptionId ID of subscription where the image should be uploaded.
-	// When providing a subscription_id, also be sure to provide a tenant_id and do not include a source_id.
 	SubscriptionId *string `json:"subscription_id,omitempty"`
 
 	// TenantId ID of the tenant where the image should be uploaded. This link explains how
 	// to find it in the Azure Portal:
 	// https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-how-to-find-tenant
-	// When providing a tenant_id, also be sure to provide a subscription_id and do not include a source_id.
 	TenantId *string `json:"tenant_id,omitempty"`
 }
 

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1402,12 +1402,6 @@ components:
       required:
         - resource_group
       properties:
-        source_id:
-          type: string
-          example: '12345'
-          description: |
-            ID of the source that will be used to resolve the tenant and subscription IDs.
-            Do not provide a tenant_id or subscription_id when providing a source_id.
         tenant_id:
           type: string
           example: '5c7ef5b6-1c3f-4da0-a622-0b060239d7d7'
@@ -1415,13 +1409,11 @@ components:
             ID of the tenant where the image should be uploaded. This link explains how
             to find it in the Azure Portal:
             https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-how-to-find-tenant
-            When providing a tenant_id, also be sure to provide a subscription_id and do not include a source_id.
         subscription_id:
           type: string
           example: '4e5d8b2c-ab24-4413-90c5-612306e809e2'
           description: |
             ID of subscription where the image should be uploaded.
-            When providing a subscription_id, also be sure to provide a tenant_id and do not include a source_id.
         resource_group:
           type: string
           example: 'ToucanResourceGroup'


### PR DESCRIPTION
Deleting things after Launch EOF. :100: TIL that the only use of the Sources integration we had was to resolve the tenant id and subscription id. That means nothing else needs to be done, we do not have this anywhere in db.

After decommissioning of Launch, Sources will only support AWS integration with Image Builder. Therefore, we have no use of the azure source id on the backend side.