### PR TITLE
v1: forward error message and details on compose failure (HMS-9448)

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -173,6 +173,7 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 			if err := json.Unmarshal(body, &serviceStat); err != nil {
 				return ComposeResponse{}, httpError
 			}
+			httpError.Message = fmt.Sprintf("Failed posting compose request to osbuild-composer. %s: %s", serviceStat.Reason, serviceStat.Details)
 			if serviceStat.Id == "10" {
 				httpError.Message = "Error resolving OSTree repo"
 				httpError.Code = http.StatusBadRequest

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -426,8 +426,14 @@ func TestComposeImageErrorsWhenStatusCodeIsNotStatusCreated(t *testing.T) {
 		require.Equal(t, "Bearer accesstoken", r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusTeapot)
-		s := "deliberately returning !201 during tests"
-		err := json.NewEncoder(w).Encode(s)
+
+		serviceError := composer.Error{
+			Code:    "50000",
+			Id:      "50000",
+			Reason:  "deliberately returning !201 during tests",
+			Details: "details!",
+		}
+		err := json.NewEncoder(w).Encode(serviceError)
 		require.NoError(t, err)
 	}))
 	defer apiSrv.Close()
@@ -455,7 +461,7 @@ func TestComposeImageErrorsWhenStatusCodeIsNotStatusCreated(t *testing.T) {
 	}
 	respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 	require.Equal(t, http.StatusInternalServerError, respStatusCode)
-	require.Contains(t, body, "Failed posting compose request to osbuild-composer")
+	require.Contains(t, body, "Failed posting compose request to osbuild-composer. deliberately returning !201 during tests: details")
 }
 
 func TestComposeImageErrorResolvingOSTree(t *testing.T) {


### PR DESCRIPTION
Show a more detailed message if composer fails to enqueue the build. This can be due to manifest generation failure, where the extra information is very useful to at least work around the problem.