### PR TITLE
internal/v1: do not secretly enable rhcd service (HMS-8756)

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -1168,21 +1168,6 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 		}
 	}
 
-	// we need to explicitly add 'rhcd' to the enabled services
-	// if openscap and subscription customizations are set, otherwise
-	// the insights-client doesn't register properly
-	if cust.Subscription != nil && cust.Subscription.Insights && cust.Openscap != nil {
-		if res.Services == nil {
-			res.Services = &composer.Services{}
-		}
-		if res.Services.Enabled == nil {
-			res.Services.Enabled = &[]string{}
-		}
-		if !slices.Contains(*res.Services.Enabled, "rhcd") {
-			*res.Services.Enabled = append(*res.Services.Enabled, "rhcd")
-		}
-	}
-
 	if cust.Firewall != nil {
 		res.Firewall = &composer.FirewallCustomization{
 			Ports: cust.Firewall.Ports,


### PR DESCRIPTION
The service rhcd is no longer in RHEL 10 and enabling it causes RHEL 10 builds with a security profile selected to fail.

I considered adding a conditional to only enable it for RHEL < 10, but instead landed on removing this behavior entirely.

It feels like an anti-pattern to have image-builder-crc "inject" an enabled service into a compose request to me.

Things on my mind that led me to this conclusion:
What if a user explicitly disables or masks `rhcd`? Do we also enable `rhcd` for requests that cockpit-image-builder makes? Shouldn't this kind of knowledge live in osbuild/images so there is only one source of truth?

After this, we will need to determine why RHEL 8 and 9 images don't register via rhc when using some (all?) security profiles.