### PR TITLE
clowdapp: Deafult to Konflux image

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -261,7 +261,7 @@ objects:
 
 parameters:
   - name: IMAGE
-    value: quay.io/cloudservices/image-builder
+    value: quay.io/redhat-services-prod/insights-management-tenant/insights-image-builder/image-builder-backend
     required: true
   - name: IMAGE_TAG
     required: true


### PR DESCRIPTION
Use the konflux built container by default.