### PR TITLE
clowdapp: Use correct Konflux image

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -261,7 +261,7 @@ objects:
 
 parameters:
   - name: IMAGE
-    value: quay.io/redhat-services-prod/insights-management-tenant/insights-image-builder/image-builder-backend
+    value: quay.io/redhat-services-prod/insights-management-tenant/insights-image-builder/image-builder
     required: true
   - name: IMAGE_TAG
     required: true


### PR DESCRIPTION
in 5433c6b we've used incorrect (old) repo. We have switched to a new repo in the meantime.


Ugh, someone made an oopsie in #1699