### PR TITLE
main: add missing trace_id extractor middleware

### DIFF
--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -175,6 +175,7 @@ func Attach(conf *ServerConfig) (*Server, error) {
 	middlewares := []echo.MiddlewareFunc{
 		prometheus.StatusMiddleware,
 		extractIdentityMiddleware,
+		strc.EchoTraceExtractor(),
 		strc.EchoRequestLogger(slog.Default(), strc.MiddlewareConfig{}),
 		strc.EchoContextSetLogger(slog.Default()),
 		recoverMiddleware,


### PR DESCRIPTION
After the logging middleware refactoring, I forgot to add the trace_id extractor middleware to the server setup. This caused the trace_id to be missing from the logs, making it difficult to correlate logs with traces.

---

A quick followup for https://github.com/osbuild/image-builder-crc/pull/1700 logging works fine but every single log line is supposed to have `trace_id` field in the root but without the extractor, only trace (debug) logs have it. It is important to have this field in every single log for easy correlation.

Before:

```
time=2025-10-02T16:53:56.823+02:00 level=DEBUG msg="Getting blueprint list of 0 items" build_id=076ead5 echo=true org_id=000000 user=user
time=2025-10-02T16:53:56.823+02:00 level=INFO msg="200: OK" build_id=076ead5 time=2025-10-02T14:53:56.815Z latency=8.043489ms request.method=GET request.host=localhost:8086 request.path=/api/image-builder/v1/blueprints request.user-agent=vscode-restclient request.ip=127.0.0.1:48896 request.length=0 response.length=215 response.status=200 org_id=000000 user=user
```

After:

```
time=2025-10-02T16:54:36.024+02:00 level=DEBUG msg="Getting blueprint list of 0 items" build_id=076ead5 echo=true trace_id=ZnxSltAPlgRYpIc org_id=000000 user=user
time=2025-10-02T16:54:36.024+02:00 level=INFO msg="200: OK" build_id=076ead5 time=2025-10-02T14:54:36.015Z latency=9.130482ms request.method=GET request.host=localhost:8086 request.path=/api/image-builder/v1/blueprints request.user-agent=vscode-restclient request.ip=127.0.0.1:48292 request.length=0 trace_id=ZnxSltAPlgRYpIc response.length=215 response.status=200 trace_id=ZnxSltAPlgRYpIc org_id=000000 user=user
```

Note the `trace_id=ZnxSltAPlgRYpIc` after the patch is applied (this is a text output, the same behavior is for JSON).