### PR TITLE
v1/oscap: extract OpenSCAP logic from lintBlueprint

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -289,10 +289,11 @@ type BlueprintItem struct {
 	Version        int                `json:"version"`
 }
 
-// BlueprintLint Linting errors in the current blueprint, these might need to be resolved before the
-// blueprint can be used to build images again.
+// BlueprintLint Linting errors and warnings in the current blueprint. Errors might need to be resolved before the
+// blueprint can be used to build images again. Warnings provide information about policy changes.
 type BlueprintLint struct {
-	Errors []BlueprintLintItem `json:"errors"`
+	Errors   []BlueprintLintItem `json:"errors"`
+	Warnings []BlueprintLintItem `json:"warnings"`
 }
 
 // BlueprintLintItem defines model for BlueprintLintItem.
@@ -323,8 +324,8 @@ type BlueprintResponse struct {
 	// ImageRequests Array of image requests. Having more image requests in a single blueprint is currently not supported.
 	ImageRequests []ImageRequest `json:"image_requests"`
 
-	// Lint Linting errors in the current blueprint, these might need to be resolved before the
-	// blueprint can be used to build images again.
+	// Lint Linting errors and warnings in the current blueprint. Errors might need to be resolved before the
+	// blueprint can be used to build images again. Warnings provide information about policy changes.
 	Lint BlueprintLint `json:"lint"`
 	Name string        `json:"name"`
 }

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1151,11 +1151,16 @@ components:
     BlueprintLint:
       required:
         - errors
+        - warnings
       description: |
-        Linting errors in the current blueprint, these might need to be resolved before the
-        blueprint can be used to build images again.
+        Linting errors and warnings in the current blueprint. Errors might need to be resolved before the
+        blueprint can be used to build images again. Warnings provide information about policy changes.
       properties:
         errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/BlueprintLintItem'
+        warnings:
           type: array
           items:
             $ref: '#/components/schemas/BlueprintLintItem'

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -19,7 +19,6 @@ import (
 	"github.com/labstack/echo/v4"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
-	"github.com/osbuild/image-builder-crc/internal/clients/compliance"
 	"github.com/osbuild/image-builder-crc/internal/clients/content_sources"
 	"github.com/osbuild/image-builder-crc/internal/common"
 	"github.com/osbuild/image-builder-crc/internal/db"
@@ -162,7 +161,7 @@ func (h *Handlers) buildServiceSnapshots(ctx echo.Context, customizations *Custo
 	}
 
 	var cust Customizations
-	_, err = h.lintOpenscap(ctx, &cust, true, distribution, compl.PolicyId.String())
+	_, err = h.lintOpenscap(ctx, &cust, true, distribution)
 	if err != nil {
 		slog.ErrorContext(ctx.Request().Context(), "error getting policy customizations via lintOpenscap",
 			"error", err.Error(), "distribution", distribution, "policy_id", compl.PolicyId.String())
@@ -407,22 +406,11 @@ func (h *Handlers) GetBlueprint(ctx echo.Context, id openapi_types.UUID, params 
 
 func (h *Handlers) lintBlueprint(ctx echo.Context, blueprint *BlueprintBody, fixup bool) ([]BlueprintLintItem, error) {
 	lintErrors := []BlueprintLintItem{}
-	if blueprint.Customizations.Openscap != nil {
-		var compl OpenSCAPCompliance
-		var err error
-		if compl, err = blueprint.Customizations.Openscap.AsOpenSCAPCompliance(); err == nil && compl.PolicyId != uuid.Nil {
-			errs, err := h.lintOpenscap(ctx, &blueprint.Customizations, fixup, blueprint.Distribution, compl.PolicyId.String())
-			if err == compliance.ErrorTailoringNotFound {
-				lintErrors = append(lintErrors, BlueprintLintItem{
-					Name:        "Compliance",
-					Description: "Compliance policy does not have a definition for the latest minor version",
-				})
-			} else if err != nil {
-				return nil, err
-			} else {
-				lintErrors = append(lintErrors, errs...)
-			}
-		}
+
+	if errors, err := h.lintOpenscap(ctx, &blueprint.Customizations, fixup, blueprint.Distribution); err != nil {
+		return nil, err
+	} else {
+		lintErrors = append(lintErrors, errors...)
 	}
 	return lintErrors, nil
 }

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -859,7 +859,9 @@ func (h *Handlers) FixupBlueprint(ctx echo.Context, id openapi_types.UUID) error
 		return err
 	}
 
-	_, _, err = h.lintBlueprint(ctx, blueprintEntry, true)
+	// Apply fixup by calling lintOpenscap directly and capturing the modified customizations
+	snapshotCustomizations := extractSnapshotCustomizations(blueprintEntry)
+	_, _, err = h.lintOpenscap(ctx, &blueprint.Customizations, true, blueprint.Distribution, snapshotCustomizations)
 	if err != nil {
 		return err
 	}

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -150,17 +150,15 @@ func (h *Handlers) buildServiceSnapshots(ctx echo.Context, customizations *Custo
 		return nil, nil
 	}
 
-	var compl OpenSCAPCompliance
 	compl, err := customizations.Openscap.AsOpenSCAPCompliance()
 	if err != nil {
 		slog.ErrorContext(ctx.Request().Context(), "error in AsOpenSCAPCompliance", "error", err.Error())
 		return nil, err
 	}
-	if compl.PolicyId == uuid.Nil {
-		return nil, nil
-	}
 
 	var cust Customizations
+	cust.Openscap = customizations.Openscap
+
 	_, err = h.lintOpenscap(ctx, &cust, true, distribution)
 	if err != nil {
 		slog.ErrorContext(ctx.Request().Context(), "error getting policy customizations via lintOpenscap",

--- a/internal/v1/handler_oscap.go
+++ b/internal/v1/handler_oscap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 
+	"github.com/osbuild/blueprint/pkg/blueprint"
 	"github.com/osbuild/image-builder-crc/internal/clients/compliance"
 	"github.com/osbuild/image-builder-crc/internal/common"
 	"github.com/osbuild/image-builder-crc/internal/distribution"
@@ -190,7 +191,7 @@ func (h *Handlers) GetOscapCustomizationsForPolicy(ctx echo.Context, policy uuid
 		return err
 	}
 	cust.Openscap = &openscap
-	_, err = h.lintOpenscap(ctx, &cust, true, distro)
+	_, _, err = h.lintOpenscap(ctx, &cust, true, distro, nil)
 	if err != nil {
 		switch err {
 		case distribution.ErrMajorMinor:
@@ -207,164 +208,338 @@ func (h *Handlers) GetOscapCustomizationsForPolicy(ctx echo.Context, policy uuid
 	return ctx.JSON(http.StatusOK, cust)
 }
 
-func (h *Handlers) lintOpenscap(ctx echo.Context, cust *Customizations, fixup bool, distro Distributions) ([]BlueprintLintItem, error) {
-	var lintErrors []BlueprintLintItem
+func (h *Handlers) lintOpenscap(ctx echo.Context, bpBody *Customizations, fixup bool, distro Distributions, snapshotCust *Customizations) ([]BlueprintLintItem, []BlueprintLintItem, error) {
 	var err error
 
-	if cust.Openscap == nil {
-		return []BlueprintLintItem{}, nil
+	if bpBody.Openscap == nil {
+		return []BlueprintLintItem{}, []BlueprintLintItem{}, nil
 	}
 
-	compl, err := cust.Openscap.AsOpenSCAPCompliance()
+	compl, err := bpBody.Openscap.AsOpenSCAPCompliance()
 	if err != nil || compl.PolicyId == uuid.Nil {
-		return []BlueprintLintItem{}, nil
+		return []BlueprintLintItem{}, []BlueprintLintItem{}, nil
 	}
 
 	d, err := h.server.getDistro(ctx, distro)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	major, minor, err := d.RHELMajorMinor()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Validate policy major version matches distribution before fetching TOML customizations.
 	// This makes failures deterministic regardless of which minor "rhel-9" symlinks to.
 	if _, err := h.server.complianceClient.PolicyDataForMinorVersion(ctx.Request().Context(), major, minor, compl.PolicyId.String()); err != nil {
 		if err == compliance.ErrorMajorVersion {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	bp, err := h.server.complianceClient.PolicyCustomizations(ctx.Request().Context(), major, minor, compl.PolicyId.String())
+	policyBP, err := h.server.complianceClient.PolicyCustomizations(ctx.Request().Context(), major, minor, compl.PolicyId.String())
 	if err == compliance.ErrorTailoringNotFound {
 		if fixup {
 			//typically 500 or endpoint-specific handling
-			return nil, err
+			return nil, nil, err
 		}
 		return []BlueprintLintItem{{
 			Name:        "Compliance",
 			Description: "Compliance policy does not have a definition for the latest minor version",
-		}}, nil
+		}}, nil, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	// make sure all packages are present, all partitions, all enabled/disabled services, all kernel args
-	for _, pkg := range bp.GetPackagesEx(false) {
-		if cust.Packages == nil || !slices.Contains(*cust.Packages, pkg) {
-			lintErrors = append(lintErrors, BlueprintLintItem{
+	var allErrors []BlueprintLintItem
+	var allWarnings []BlueprintLintItem
+
+	// Collect errors and warnings from all lint functions (they now return instead of mutating)
+	errs, warns := lintPackages(policyBP, snapshotCust, bpBody, fixup)
+	allErrors = append(allErrors, errs...)
+	allWarnings = append(allWarnings, warns...)
+	errs, warns = lintFilesystems(policyBP, snapshotCust, bpBody, fixup)
+	allErrors = append(allErrors, errs...)
+	allWarnings = append(allWarnings, warns...)
+	errs, warns = lintServices(policyBP, snapshotCust, bpBody, fixup)
+	allErrors = append(allErrors, errs...)
+	allWarnings = append(allWarnings, warns...)
+	errs, warns = lintKernel(policyBP, snapshotCust, bpBody, fixup)
+	allErrors = append(allErrors, errs...)
+	allWarnings = append(allWarnings, warns...)
+	errs, warns = lintFIPS(policyBP, snapshotCust, bpBody, fixup)
+	allErrors = append(allErrors, errs...)
+	allWarnings = append(allWarnings, warns...)
+
+	return allErrors, allWarnings, nil
+}
+
+// lintPackages validates package compliance by performing two comparisons:
+// 1. ERRORS: Packages required by current policy but missing from current blueprint
+// 2. WARNINGS: Packages that were required by policy in snapshot but no longer required
+func lintPackages(policyBP *blueprint.Blueprint, snapshotCust, currentCust *Customizations, fixup bool) ([]BlueprintLintItem, []BlueprintLintItem) {
+	var errs []BlueprintLintItem
+	var warns []BlueprintLintItem
+
+	for _, pkg := range policyBP.GetPackagesEx(false) {
+		if currentCust.Packages == nil || !slices.Contains(*currentCust.Packages, pkg) {
+			errs = append(errs, BlueprintLintItem{
 				Name:        "Compliance",
 				Description: fmt.Sprintf("package %s required by policy is not present", pkg),
 			})
 			if fixup {
-				cust.Packages = common.ToPtr(append(common.FromPtr(cust.Packages), pkg))
+				currentCust.Packages = common.ToPtr(append(common.FromPtr(currentCust.Packages), pkg))
 			}
 		}
 	}
 
-	// some policies (ansi minimal) only require some extra packages
-	if bp.Customizations == nil {
-		return lintErrors, nil
-	}
-
-	for _, fsc := range bp.Customizations.GetFilesystems() {
-		if cust.Filesystem == nil || !slices.ContainsFunc(*cust.Filesystem, func(fs Filesystem) bool {
-			return fs.Mountpoint == fsc.Mountpoint
-		}) {
-			lintErrors = append(lintErrors, BlueprintLintItem{
-				Name:        "Compliance",
-				Description: fmt.Sprintf("mountpoint %s required by policy is not present", fsc.Mountpoint),
-			})
-			if fixup {
-				cust.Filesystem = common.ToPtr(append(common.FromPtr(cust.Filesystem), Filesystem{
-					Mountpoint: fsc.Mountpoint,
-					MinSize:    fsc.MinSize,
-				}))
+	// Warnings: packages from saved policy no longer required
+	if snapshotCust != nil {
+		for _, pkg := range common.FromPtr(snapshotCust.Packages) {
+			if !slices.Contains(policyBP.GetPackagesEx(false), pkg) {
+				warns = append(warns, BlueprintLintItem{
+					Name:        "Compliance",
+					Description: fmt.Sprintf("package %s is no longer required by policy", pkg),
+				})
 			}
 		}
 	}
 
-	if services := bp.Customizations.GetServices(); services != nil {
+	return errs, warns
+}
+
+func lintFilesystems(policyBP *blueprint.Blueprint, snapshotCust, currentCust *Customizations, fixup bool) ([]BlueprintLintItem, []BlueprintLintItem) {
+	var errs []BlueprintLintItem
+	var warns []BlueprintLintItem
+
+	// Only check if policy actually defines filesystem requirements
+	if policyBP.Customizations != nil {
+		for _, fsc := range policyBP.Customizations.GetFilesystems() {
+			if currentCust.Filesystem == nil || !slices.ContainsFunc(*currentCust.Filesystem, func(fs Filesystem) bool { return fs.Mountpoint == fsc.Mountpoint }) {
+				errs = append(errs, BlueprintLintItem{
+					Name:        "Compliance",
+					Description: fmt.Sprintf("mountpoint %s required by policy is not present", fsc.Mountpoint),
+				})
+				if fixup {
+					currentCust.Filesystem = common.ToPtr(append(common.FromPtr(currentCust.Filesystem), Filesystem{
+						Mountpoint: fsc.Mountpoint,
+						MinSize:    fsc.MinSize,
+					}))
+				}
+			}
+		}
+	}
+
+	// Warnings: filesystems in saved policy no longer required
+	if snapshotCust != nil {
+		var policyFilesystems []blueprint.FilesystemCustomization
+		if policyBP.Customizations != nil {
+			policyFilesystems = policyBP.Customizations.GetFilesystems()
+		}
+		for _, fs := range common.FromPtr(snapshotCust.Filesystem) {
+			if !slices.ContainsFunc(policyFilesystems, func(fsc blueprint.FilesystemCustomization) bool { return fsc.Mountpoint == fs.Mountpoint }) {
+				warns = append(warns, BlueprintLintItem{
+					Name:        "Compliance",
+					Description: fmt.Sprintf("mountpoint %s is no longer required by policy", fs.Mountpoint),
+				})
+			}
+		}
+	}
+
+	return errs, warns
+}
+
+func lintServices(policyBP *blueprint.Blueprint, snapshotCust, currentCust *Customizations, fixup bool) ([]BlueprintLintItem, []BlueprintLintItem) {
+	var errs []BlueprintLintItem
+	var warns []BlueprintLintItem
+
+	if policyBP.Customizations != nil && policyBP.Customizations.GetServices() != nil {
+		services := policyBP.Customizations.GetServices()
 		for _, e := range services.Enabled {
-			if cust.Services == nil || cust.Services.Enabled == nil || !slices.Contains(*cust.Services.Enabled, e) {
-				lintErrors = append(lintErrors, BlueprintLintItem{
+			if currentCust.Services == nil || currentCust.Services.Enabled == nil || !slices.Contains(*currentCust.Services.Enabled, e) {
+				errs = append(errs, BlueprintLintItem{
 					Name:        "Compliance",
 					Description: fmt.Sprintf("service %s required as enabled by policy is not present", e),
 				})
 				if fixup {
-					cust.Services = common.ToPtr(common.FromPtr(cust.Services))
-					cust.Services.Enabled = common.ToPtr(append(common.FromPtr(cust.Services.Enabled), e))
+					currentCust.Services = common.ToPtr(common.FromPtr(currentCust.Services))
+					currentCust.Services.Enabled = common.ToPtr(append(common.FromPtr(currentCust.Services.Enabled), e))
 				}
 			}
 		}
 		for _, m := range services.Masked {
-			if cust.Services == nil || cust.Services.Masked == nil || !slices.Contains(*cust.Services.Masked, m) {
-				lintErrors = append(lintErrors, BlueprintLintItem{
+			if currentCust.Services == nil || currentCust.Services.Masked == nil || !slices.Contains(*currentCust.Services.Masked, m) {
+				errs = append(errs, BlueprintLintItem{
 					Name:        "Compliance",
 					Description: fmt.Sprintf("service %s required as masked by policy is not present", m),
 				})
 				if fixup {
-					cust.Services = common.ToPtr(common.FromPtr(cust.Services))
-					cust.Services.Masked = common.ToPtr(append(common.FromPtr(cust.Services.Masked), m))
+					currentCust.Services = common.ToPtr(common.FromPtr(currentCust.Services))
+					currentCust.Services.Masked = common.ToPtr(append(common.FromPtr(currentCust.Services.Masked), m))
 				}
 			}
 		}
 		for _, d := range services.Disabled {
-			if cust.Services == nil || cust.Services.Disabled == nil || !slices.Contains(*cust.Services.Disabled, d) {
-				lintErrors = append(lintErrors, BlueprintLintItem{
+			if currentCust.Services == nil || currentCust.Services.Disabled == nil || !slices.Contains(*currentCust.Services.Disabled, d) {
+				errs = append(errs, BlueprintLintItem{
 					Name:        "Compliance",
 					Description: fmt.Sprintf("service %s required as disabled by policy is not present", d),
 				})
 				if fixup {
-					cust.Services = common.ToPtr(common.FromPtr(cust.Services))
-					cust.Services.Disabled = common.ToPtr(append(common.FromPtr(cust.Services.Disabled), d))
+					currentCust.Services = common.ToPtr(common.FromPtr(currentCust.Services))
+					currentCust.Services.Disabled = common.ToPtr(append(common.FromPtr(currentCust.Services.Disabled), d))
 				}
 			}
 		}
 	}
 
-	if kernel := bp.Customizations.Kernel; kernel != nil {
-		if kernel.Name != "" && (cust.Kernel == nil || *cust.Kernel.Name != kernel.Name) {
-			lintErrors = append(lintErrors, BlueprintLintItem{
+	// Warnings: services from saved policy no longer required by current policy
+	if snapshotCust == nil || snapshotCust.Services == nil {
+		return errs, warns
+	}
+
+	var policyServices *blueprint.ServicesCustomization
+	if policyBP.Customizations != nil {
+		policyServices = policyBP.Customizations.GetServices()
+	}
+
+	checkErrs, checkWarns := checkObsoleteServices(snapshotCust.Services.Enabled, "enabled", func(service string) bool {
+		return policyServices != nil && slices.Contains(policyServices.Enabled, service)
+	})
+	errs = append(errs, checkErrs...)
+	warns = append(warns, checkWarns...)
+
+	checkErrs, checkWarns = checkObsoleteServices(snapshotCust.Services.Disabled, "disabled", func(service string) bool {
+		return policyServices != nil && slices.Contains(policyServices.Disabled, service)
+	})
+	errs = append(errs, checkErrs...)
+	warns = append(warns, checkWarns...)
+
+	checkErrs, checkWarns = checkObsoleteServices(snapshotCust.Services.Masked, "masked", func(service string) bool {
+		return policyServices != nil && slices.Contains(policyServices.Masked, service)
+	})
+	errs = append(errs, checkErrs...)
+	warns = append(warns, checkWarns...)
+
+	return errs, warns
+}
+
+func checkObsoleteServices(services *[]string, serviceType string, isStillRequired func(string) bool) ([]BlueprintLintItem, []BlueprintLintItem) {
+	var warns []BlueprintLintItem
+	if services == nil {
+		return nil, nil
+	}
+	for _, service := range *services {
+		if !isStillRequired(service) {
+			warns = append(warns, BlueprintLintItem{
 				Name:        "Compliance",
-				Description: fmt.Sprintf("kernel name %s required by policy not set", kernel.Name),
+				Description: fmt.Sprintf("service %s is no longer required as %s by policy", service, serviceType),
 			})
-			if fixup {
-				cust.Kernel = common.ToPtr(common.FromPtr(cust.Kernel))
-				cust.Kernel.Name = common.ToPtr(kernel.Name)
-			}
 		}
-		kernelcmd := strings.Split(kernel.Append, " ")
-		for _, kcmd := range kernelcmd {
-			if cust.Kernel == nil || !strings.Contains(*cust.Kernel.Append, kcmd) {
-				lintErrors = append(lintErrors, BlueprintLintItem{
-					Name:        "Compliance",
-					Description: fmt.Sprintf("kernel command line parameter '%s' required by policy not set", kcmd),
-				})
+	}
+	return nil, warns
+}
+
+func lintKernel(policyBP *blueprint.Blueprint, snapshotCust, currentCust *Customizations, fixup bool) ([]BlueprintLintItem, []BlueprintLintItem) {
+	var errs []BlueprintLintItem
+	var warns []BlueprintLintItem
+
+	if policyBP.Customizations != nil {
+		if kernel := policyBP.Customizations.Kernel; kernel != nil {
+			if kernel.Name != "" {
+				if currentCust.Kernel == nil || currentCust.Kernel.Name == nil || *currentCust.Kernel.Name != kernel.Name {
+					errs = append(errs, BlueprintLintItem{
+						Name:        "Compliance",
+						Description: fmt.Sprintf("kernel name %s required by policy not set", kernel.Name),
+					})
+					if fixup {
+						currentCust.Kernel = common.ToPtr(common.FromPtr(currentCust.Kernel))
+						currentCust.Kernel.Name = common.ToPtr(kernel.Name)
+					}
+				}
 			}
-			if fixup {
-				cust.Kernel = common.ToPtr(common.FromPtr(cust.Kernel))
-				cust.Kernel.Append = common.ToPtr(fmt.Sprintf("%s %s", common.FromPtr(cust.Kernel.Append), kcmd))
+			for _, kcmd := range strings.Fields(kernel.Append) {
+				if kcmd == "" {
+					continue
+				}
+				if currentCust.Kernel == nil || currentCust.Kernel.Append == nil || !strings.Contains(*currentCust.Kernel.Append, kcmd) {
+					errs = append(errs, BlueprintLintItem{
+						Name:        "Compliance",
+						Description: fmt.Sprintf("kernel command line parameter '%s' required by policy not set", kcmd),
+					})
+					if fixup {
+						currentCust.Kernel = common.ToPtr(common.FromPtr(currentCust.Kernel))
+						currentCust.Kernel.Append = common.ToPtr(fmt.Sprintf("%s %s", common.FromPtr(currentCust.Kernel.Append), kcmd))
+					}
+				}
 			}
 		}
 	}
 
-	if fips := bp.Customizations.FIPS; fips != nil {
-		if *fips && (cust.Fips == nil || cust.Fips.Enabled == nil) {
-			lintErrors = append(lintErrors, BlueprintLintItem{
+	// Warnings from saved policy
+	if snapshotCust != nil && snapshotCust.Kernel != nil {
+		var policyKernel *blueprint.KernelCustomization
+		if policyBP.Customizations != nil {
+			policyKernel = policyBP.Customizations.Kernel
+		}
+		if snapshotCust.Kernel.Name != nil {
+			if policyKernel == nil || policyKernel.Name != *snapshotCust.Kernel.Name {
+				warns = append(warns, BlueprintLintItem{
+					Name:        "Compliance",
+					Description: fmt.Sprintf("kernel name %s is no longer required by policy", *snapshotCust.Kernel.Name),
+				})
+			}
+		}
+		if snapshotCust.Kernel.Append != nil {
+			for _, kcmd := range strings.Fields(*snapshotCust.Kernel.Append) {
+				if kcmd == "" {
+					continue
+				}
+				if policyKernel == nil || !strings.Contains(policyKernel.Append, kcmd) {
+					warns = append(warns, BlueprintLintItem{
+						Name:        "Compliance",
+						Description: fmt.Sprintf("kernel command line parameter '%s' is no longer required by policy", kcmd),
+					})
+				}
+			}
+		}
+	}
+
+	return errs, warns
+}
+
+func lintFIPS(policyBP *blueprint.Blueprint, snapshotCust, currentCust *Customizations, fixup bool) ([]BlueprintLintItem, []BlueprintLintItem) {
+	var errs []BlueprintLintItem
+	var warns []BlueprintLintItem
+
+	if policyBP.Customizations == nil || policyBP.Customizations.FIPS == nil {
+		return nil, nil
+	}
+
+	fips := policyBP.Customizations.FIPS
+	fipsNotSet := currentCust.Fips == nil || currentCust.Fips.Enabled == nil || !*currentCust.Fips.Enabled
+
+	if fipsNotSet {
+		if fixup {
+			currentCust.Fips = &FIPS{Enabled: fips}
+		} else {
+			errs = append(errs, BlueprintLintItem{
 				Name:        "Compliance",
 				Description: fmt.Sprintf("FIPS required '%t' by policy but not set", *fips),
 			})
-			if fixup {
-				cust.Fips = &FIPS{
-					Enabled: fips,
-				}
-			}
 		}
 	}
 
-	return lintErrors, nil
+	// Warnings: saved policy had FIPS enabled previously but not now
+	if snapshotCust != nil && snapshotCust.Fips != nil && snapshotCust.Fips.Enabled != nil && *snapshotCust.Fips.Enabled {
+		if fips == nil || !*fips {
+			warns = append(warns, BlueprintLintItem{
+				Name:        "Compliance",
+				Description: "FIPS is no longer required by policy",
+			})
+		}
+	}
+
+	return errs, warns
 }


### PR DESCRIPTION
Move OpenSCAP-specific validation and error handling from lintBlueprint into lintOpenscap to improve separation of concerns and prepare lintBlueprint for future extensibility. Changes made:
- Move nil check for Customizations.Openscap
- Move AsOpenSCAPCompliance() validation and error handling
- Move ErrorTailoringNotFound handling logic
- Simplify lintBlueprint to focus on orchestration This refactoring addresses review feedback to make lintBlueprint more generic so it can handle additional lintable components in the future while keeping OpenSCAP-specific logic properly encapsulated within lintOpenscap.

related to JIRA TICKET: [HMS-9059](https://issues.redhat.com/browse/HMS-9059)