### PR TITLE
v1/internal: Do not enable rhcd service for RHEL 10 (HMS-8756)

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -1173,14 +1173,21 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 	// if openscap and subscription customizations are set, otherwise
 	// the insights-client doesn't register properly
 	if cust.Subscription != nil && cust.Subscription.Insights && cust.Openscap != nil {
-		if res.Services == nil {
-			res.Services = &composer.Services{}
+		major, _, err := d.RHELMajorMinor()
+		if err != nil {
+			return nil, err
 		}
-		if res.Services.Enabled == nil {
-			res.Services.Enabled = &[]string{}
-		}
-		if !slices.Contains(*res.Services.Enabled, "rhcd") {
-			*res.Services.Enabled = append(*res.Services.Enabled, "rhcd")
+		// Since RHEL 10, there is no rhcd service.
+		if major < 10 {
+			if res.Services == nil {
+				res.Services = &composer.Services{}
+			}
+			if res.Services.Enabled == nil {
+				res.Services.Enabled = &[]string{}
+			}
+			if !slices.Contains(*res.Services.Enabled, "rhcd") {
+				*res.Services.Enabled = append(*res.Services.Enabled, "rhcd")
+			}
 		}
 	}
 


### PR DESCRIPTION
Because `rhcd` is no longer used in RHEL 10, enabling it causes RHEL 10 builds to fail.

The `rhcd` service is enabled for images that have an OpenSCAP profile. This customization does not appear in the blueprint, rather it is injected into the compose request.

This commit removes this behavior for RHEL 10.

We should also revisit enabling rhcd altogether in the future. It is probably an antipattern. Consider:
1. What happens if a user explicitly masks or disables rhcd?
2. Should we even be doing this? We don't know why we need to do this.
3. If we do need to do this, shouldn't this knowledge live in osbuild/images?