### PR TITLE
internal: add support for enabling additional RH repos on first boot (HMS-8857)

### DIFF
--- a/internal/clients/content_sources/client.go
+++ b/internal/clients/content_sources/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/osbuild/logging/pkg/strc"
@@ -124,6 +125,30 @@ func (csc *ContentSourcesClient) GetRepositories(ctx context.Context, repoURLs [
 	}
 
 	return result, nil
+}
+
+func (csc *ContentSourcesClient) FindRepoByURL(repos []ApiRepositoryResponse, targetURL string) (ApiRepositoryResponse, bool) {
+	idx := slices.IndexFunc(repos, func(r ApiRepositoryResponse) bool {
+		return r.Url != nil && *r.Url == targetURL
+	})
+
+	if idx == -1 {
+		return ApiRepositoryResponse{}, false
+	}
+
+	return repos[idx], true
+}
+
+func (csc *ContentSourcesClient) FindRepoByID(repos []ApiRepositoryResponse, targetID string) (ApiRepositoryResponse, bool) {
+	idx := slices.IndexFunc(repos, func(r ApiRepositoryResponse) bool {
+		return r.Uuid != nil && *r.Uuid == targetID
+	})
+
+	if idx == -1 {
+		return ApiRepositoryResponse{}, false
+	}
+
+	return repos[idx], true
 }
 
 // returns []ApiRepositoryExportResponse

--- a/internal/clients/content_sources/client.go
+++ b/internal/clients/content_sources/client.go
@@ -151,6 +151,27 @@ func (csc *ContentSourcesClient) FindRepoByID(repos []ApiRepositoryResponse, tar
 	return repos[idx], true
 }
 
+func (csc *ContentSourcesClient) FetchLabelsFromNonBaseRHRepos(ctx context.Context, repoIDs []string) ([]string, error) {
+	rhRepoMap, err := csc.GetRepositories(ctx, nil, repoIDs, false)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve RH repositories: %v", err)
+	}
+
+	var labels []string
+	for _, repoID := range repoIDs {
+		if repo, ok := rhRepoMap[repoID]; ok {
+			if repo.Label != nil && *repo.Label != "" {
+				if strings.Contains(*repo.Label, "baseos") || strings.Contains(*repo.Label, "appstream") {
+					continue
+				}
+				labels = append(labels, *repo.Label)
+			}
+		}
+	}
+
+	return labels, nil
+}
+
 // returns []ApiRepositoryExportResponse
 func (csc *ContentSourcesClient) BulkExportRepositories(ctx context.Context, body ApiRepositoryExportRequest) (*http.Response, error) {
 	id, ok := identity.GetIdentityHeader(ctx)

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -94,7 +94,9 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 		if err != nil {
 			return ComposeResponse{}, err
 		}
-		customizations, err = h.buildCustomizations(ctx, &composeRequest, d)
+
+		var extraRHRepos []content_sources.ApiRepositoryResponse
+		customizations, extraRHRepos, err = h.buildCustomizations(ctx, &composeRequest, d)
 		if err != nil {
 			ctx.Logger().Errorf("Failed building customizations: %v", err)
 			if _, ok := err.(*echo.HTTPError); ok {
@@ -104,7 +106,7 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 		}
 
 		var detectedOsVersion *string
-		repositories, detectedOsVersion, err = h.buildRepositories(ctx, composeRequest, arch)
+		repositories, detectedOsVersion, err = h.buildRepositories(ctx, composeRequest, arch, extraRHRepos)
 		if err != nil {
 			return ComposeResponse{}, err
 		}
@@ -217,7 +219,7 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 	}, nil
 }
 
-func (h *Handlers) buildRepositories(ctx echo.Context, composeRequest ComposeRequest, arch *distribution.Architecture) ([]composer.Repository, *string, error) {
+func (h *Handlers) buildRepositories(ctx echo.Context, composeRequest ComposeRequest, arch *distribution.Architecture, extraRHRepos []content_sources.ApiRepositoryResponse) ([]composer.Repository, *string, error) {
 	var repositories []composer.Repository
 	var detectedOsVersion *string
 	var err error
@@ -248,6 +250,13 @@ func (h *Handlers) buildRepositories(ctx echo.Context, composeRequest ComposeReq
 			}
 		}
 
+		// Add extra RH repos from the customizations to the URLs we send to buildRepositorySnapshots
+		for _, r := range extraRHRepos {
+			if r.Url != nil {
+				repoURLs = append(repoURLs, *r.Url)
+			}
+		}
+
 		snapshotRepos, _, snapshotOsVersion, err := h.buildRepositorySnapshots(ctx, repoURLs, nil, false, *composeRequest.ImageRequests[0].SnapshotDate)
 		if err != nil {
 			return nil, nil, err
@@ -262,6 +271,7 @@ func (h *Handlers) buildRepositories(ctx echo.Context, composeRequest ComposeReq
 				expected++
 			}
 		}
+		expected += len(extraRHRepos)
 		if len(repositories) != expected {
 			return nil, nil, fmt.Errorf("no snapshots found for all repositories (found %d, expected %d)", len(repositories), expected)
 		}
@@ -273,7 +283,7 @@ func (h *Handlers) buildRepositories(ctx echo.Context, composeRequest ComposeReq
 		}
 		detectedOsVersion = templateOsVersion
 	} else {
-		repositories, err = h.buildRepositoriesWithLatestSnapshots(ctx, arch, composeRequest.ImageRequests[0].ImageType)
+		repositories, err = h.buildRepositoriesWithLatestSnapshots(ctx, arch, composeRequest.ImageRequests[0].ImageType, extraRHRepos)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -283,7 +293,7 @@ func (h *Handlers) buildRepositories(ctx echo.Context, composeRequest ComposeReq
 
 // buildRepositoriesWithLatestSnapshots transforms the CDN repository URLs to the latest snapshot URL
 // or falls back to CDN if snapshot is not available
-func (h *Handlers) buildRepositoriesWithLatestSnapshots(ctx echo.Context, arch *distribution.Architecture, imageType ImageTypes) ([]composer.Repository, error) {
+func (h *Handlers) buildRepositoriesWithLatestSnapshots(ctx echo.Context, arch *distribution.Architecture, imageType ImageTypes, extraRHRepos []content_sources.ApiRepositoryResponse) ([]composer.Repository, error) {
 	var repositories []composer.Repository
 	var cdnRepoURLs []string
 	var errs []error
@@ -299,7 +309,7 @@ func (h *Handlers) buildRepositoriesWithLatestSnapshots(ctx echo.Context, arch *
 		var err error
 		repoMap, err = h.server.csClient.GetRepositories(ctx.Request().Context(), cdnRepoURLs, nil, false)
 		if err != nil {
-			return nil, fmt.Errorf("unable to retrieve get repositories: %w", err)
+			return nil, fmt.Errorf("unable to retrieve Red Hat repositories: %w", err)
 		}
 	}
 
@@ -315,6 +325,21 @@ func (h *Handlers) buildRepositoriesWithLatestSnapshots(ctx echo.Context, arch *
 		}
 
 		repositories = append(repositories, composerRepo)
+	}
+
+	for _, r := range extraRHRepos {
+		if r.LatestSnapshotUrl != nil && *r.LatestSnapshotUrl != "" {
+			repoURL, err := url.Parse(*r.LatestSnapshotUrl)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse snapshot URL for repository %s: %w", *r.Url, err)
+			}
+			composerRepo, err := h.buildComposerRepositoryFromSnapshot(repoURL.Path, false, &r)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			repositories = append(repositories, composerRepo)
+		}
 	}
 
 	if len(errs) > 0 {
@@ -579,6 +604,117 @@ func (h *Handlers) buildPayloadRepositories(ctx echo.Context, payloadRepos []Rep
 		res[i].Rhsm = common.ToPtr(pyrepo.Rhsm)
 	}
 	return res, nil
+}
+
+// Filters out RH repos from payload repos and returns remaining payload repos
+func (h *Handlers) filterRHFromPayloadRepos(rhRepos []content_sources.ApiRepositoryResponse, unfilteredPayloadRepos []Repository) ([]Repository, []string, []string) {
+	var filteredPayloadRepos []Repository
+	var filteredPayloadURLs []string
+	var filteredPayloadIDs []string
+
+	for _, payloadRepository := range unfilteredPayloadRepos {
+		if payloadRepository.Baseurl != nil {
+			if _, isRedHat := h.server.csClient.FindRepoByURL(rhRepos, *payloadRepository.Baseurl); !isRedHat {
+				filteredPayloadRepos = append(filteredPayloadRepos, payloadRepository)
+				filteredPayloadURLs = append(filteredPayloadURLs, *payloadRepository.Baseurl)
+			}
+			continue
+		}
+		if payloadRepository.Id != nil {
+			if _, isRedHat := h.server.csClient.FindRepoByID(rhRepos, *payloadRepository.Id); !isRedHat {
+				filteredPayloadRepos = append(filteredPayloadRepos, payloadRepository)
+				filteredPayloadIDs = append(filteredPayloadIDs, *payloadRepository.Id)
+			}
+		}
+	}
+
+	return filteredPayloadRepos, filteredPayloadURLs, filteredPayloadIDs
+}
+
+// Filters out RH repos from custom repos and returns remaining custom repos
+func (h *Handlers) filterRHFromCustomRepos(rhRepos []content_sources.ApiRepositoryResponse, unfilteredCustomRepos []CustomRepository) ([]CustomRepository, []string, []string) {
+	var filteredCustomRepos []CustomRepository
+	var filteredCustomURLs []string
+	var filteredCustomIDs []string
+
+	for _, customRepository := range unfilteredCustomRepos {
+		if customRepository.Baseurl != nil && len(*customRepository.Baseurl) > 0 {
+			if _, isRedHat := h.server.csClient.FindRepoByURL(rhRepos, (*customRepository.Baseurl)[0]); !isRedHat {
+				filteredCustomRepos = append(filteredCustomRepos, customRepository)
+				filteredCustomURLs = append(filteredCustomURLs, (*customRepository.Baseurl)[0])
+			}
+			continue
+		}
+		if customRepository.Id != "" {
+			if _, isRedHat := h.server.csClient.FindRepoByID(rhRepos, customRepository.Id); !isRedHat {
+				filteredCustomRepos = append(filteredCustomRepos, customRepository)
+				filteredCustomIDs = append(filteredCustomIDs, customRepository.Id)
+			}
+		}
+	}
+
+	return filteredCustomRepos, filteredCustomURLs, filteredCustomIDs
+}
+
+// Checks for RH repos from given custom repos
+// Returns custom repo URLs and IDs unchanged and any matched RH repos
+func (h *Handlers) checkForRHReposInCustom(ctx echo.Context, customRepos []CustomRepository) ([]string, []string, []content_sources.ApiRepositoryResponse, error) {
+	var repoURLs []string
+	var repoIDs []string
+
+	for _, repo := range customRepos {
+		if repo.Baseurl != nil && len(*repo.Baseurl) > 0 {
+			repoURLs = append(repoURLs, (*repo.Baseurl)[0])
+		} else if repo.Id != "" {
+			repoIDs = append(repoIDs, repo.Id)
+		}
+	}
+
+	rhRepoMap, err := h.server.csClient.GetRepositories(ctx.Request().Context(), repoURLs, repoIDs, false)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("unable to retrieve RH repositories: %v", err)
+	}
+
+	var rhRepos []content_sources.ApiRepositoryResponse
+	for _, repo := range customRepos {
+		if repo.Id != "" {
+			if rhRepo, ok := rhRepoMap[repo.Id]; ok {
+				rhRepos = append(rhRepos, rhRepo)
+			}
+		}
+	}
+
+	return repoURLs, repoIDs, rhRepos, nil
+}
+
+// Checks for RH repos from given payload repos
+// Returns repo URLs and IDs unchanged and any matched RH repos
+func (h *Handlers) checkForRHReposInPayload(ctx echo.Context, payloadRepos []Repository) ([]string, []string, []content_sources.ApiRepositoryResponse, error) {
+	var repoURLs []string
+	var repoIDs []string
+
+	for _, payloadRepository := range payloadRepos {
+		if payloadRepository.Baseurl != nil {
+			repoURLs = append(repoURLs, *payloadRepository.Baseurl)
+		} else if payloadRepository.Id != nil {
+			repoIDs = append(repoIDs, *payloadRepository.Id)
+		}
+	}
+	rhRepoMap, err := h.server.csClient.GetRepositories(ctx.Request().Context(), repoURLs, repoIDs, false)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("unable to retrieve RH repositories: %v", err)
+	}
+
+	var rhRepos []content_sources.ApiRepositoryResponse
+	for _, repo := range payloadRepos {
+		if repo.Id != nil {
+			if rhRepo, ok := rhRepoMap[*repo.Id]; ok {
+				rhRepos = append(rhRepos, rhRepo)
+			}
+		}
+	}
+
+	return repoURLs, repoIDs, rhRepos, nil
 }
 
 func (h *Handlers) buildCustomRepositories(ctx echo.Context, custRepos []CustomRepository) ([]composer.CustomRepository, error) {
@@ -964,13 +1100,14 @@ func validateComposeRequest(cr *ComposeRequest) error {
 	return nil
 }
 
-func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *distribution.DistributionFile) (*composer.Customizations, error) {
+func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *distribution.DistributionFile) (*composer.Customizations, []content_sources.ApiRepositoryResponse, error) {
 	res := &composer.Customizations{}
+	var extraRHRepos []content_sources.ApiRepositoryResponse
 
 	if cr.ImageRequests[0].ContentTemplate != nil {
 		templatePayloadRepositories, templateCustomRepositories, _, _, err := h.buildTemplateRepositories(ctx, *cr.ImageRequests[0].ContentTemplate)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if len(templateCustomRepositories) > 0 {
 			res.CustomRepositories = &templateCustomRepositories
@@ -984,9 +1121,9 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 	if cust == nil {
 		// If no customizations requested, just return the payload repository snapshots resolved from the content template if one was specified
 		if res.PayloadRepositories != nil {
-			return res, nil
+			return res, nil, nil
 		}
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	if cust.Subscription != nil {
@@ -1003,7 +1140,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 		if d != nil && cr.ImageRequests[0].ContentTemplate != nil {
 			major, minor, err := d.RHELMajorMinor()
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if ((major >= 9 && minor >= 6) || (major >= 10)) && cr.ImageRequests[0].ContentTemplateName != nil {
 				res.Subscription.TemplateName = cr.ImageRequests[0].ContentTemplateName
@@ -1033,56 +1170,108 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 	if cr.ImageRequests[0].ContentTemplate == nil {
 		snapshotDate := cr.ImageRequests[0].SnapshotDate
 		if cust.PayloadRepositories != nil && snapshotDate != nil {
-			var repoURLs []string
-			var repoIDs []string
-			for _, payloadRepository := range *cust.PayloadRepositories {
-				if payloadRepository.Baseurl != nil {
-					repoURLs = append(repoURLs, *payloadRepository.Baseurl)
-				} else if payloadRepository.Id != nil {
-					repoIDs = append(repoIDs, *payloadRepository.Id)
+			repoURLs, repoIDs, rhRepos, err := h.checkForRHReposInPayload(ctx, *cust.PayloadRepositories)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(rhRepos) == 0 {
+				payloadRepositories, _, _, err := h.buildRepositorySnapshots(ctx, repoURLs, repoIDs, true, *snapshotDate)
+				if err != nil {
+					return nil, nil, err
+				}
+				res.PayloadRepositories = &payloadRepositories
+			} else {
+				_, filteredRepoURLs, filteredRepoIDs := h.filterRHFromPayloadRepos(rhRepos, *cust.PayloadRepositories)
+				if len(filteredRepoIDs) == 0 && len(filteredRepoURLs) == 0 {
+					res.PayloadRepositories = nil
+				} else {
+					payloadRepositories, _, _, err := h.buildRepositorySnapshots(ctx, filteredRepoURLs, filteredRepoIDs, true, *snapshotDate)
+					if err != nil {
+						return nil, nil, err
+					}
+					res.PayloadRepositories = &payloadRepositories
 				}
 			}
-			payloadRepositories, _, _, err := h.buildRepositorySnapshots(ctx, repoURLs, repoIDs, true, *snapshotDate)
-			if err != nil {
-				return nil, err
-			}
-			res.PayloadRepositories = &payloadRepositories
 		} else if cust.PayloadRepositories != nil && len(*cust.PayloadRepositories) > 0 {
-			plrepos, err := h.buildPayloadRepositories(ctx, *cust.PayloadRepositories)
+			_, _, rhRepos, err := h.checkForRHReposInPayload(ctx, *cust.PayloadRepositories)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
-			res.PayloadRepositories = &plrepos
+			if len(rhRepos) == 0 {
+				plrepos, err := h.buildPayloadRepositories(ctx, *cust.PayloadRepositories)
+				if err != nil {
+					return nil, nil, err
+				}
+				res.PayloadRepositories = &plrepos
+			} else {
+				filteredPayloadRepos, _, _ := h.filterRHFromPayloadRepos(rhRepos, *cust.PayloadRepositories)
+				if len(filteredPayloadRepos) == 0 {
+					res.PayloadRepositories = nil
+				} else {
+					plrepos, err := h.buildPayloadRepositories(ctx, filteredPayloadRepos)
+					if err != nil {
+						return nil, nil, err
+					}
+					res.PayloadRepositories = &plrepos
+				}
+			}
 		}
 
 		if cust.CustomRepositories != nil && snapshotDate != nil {
-			var repoURLs []string
-			var repoIDs []string
-			for _, repo := range *cust.CustomRepositories {
-				if repo.Baseurl != nil && len(*repo.Baseurl) > 0 {
-					repoURLs = append(repoURLs, (*repo.Baseurl)[0])
-				} else if repo.Id != "" {
-					repoIDs = append(repoIDs, repo.Id)
+			repoURLs, repoIDs, rhRepos, err := h.checkForRHReposInCustom(ctx, *cust.CustomRepositories)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(rhRepos) == 0 {
+				_, customRepositories, _, err := h.buildRepositorySnapshots(ctx, repoURLs, repoIDs, true, *snapshotDate)
+				if err != nil {
+					return nil, nil, err
+				}
+				res.CustomRepositories = &customRepositories
+			} else {
+				extraRHRepos = rhRepos
+				_, filteredRepoURLs, filteredRepoIDs := h.filterRHFromCustomRepos(rhRepos, *cust.CustomRepositories)
+				if len(filteredRepoIDs) == 0 && len(filteredRepoURLs) == 0 {
+					res.CustomRepositories = nil
+				} else {
+					_, customRepositories, _, err := h.buildRepositorySnapshots(ctx, filteredRepoURLs, filteredRepoIDs, true, *snapshotDate)
+					if err != nil {
+						return nil, nil, err
+					}
+					res.CustomRepositories = &customRepositories
 				}
 			}
-			_, customRepositories, _, err := h.buildRepositorySnapshots(ctx, repoURLs, repoIDs, true, *snapshotDate)
-			if err != nil {
-				return nil, err
-			}
-			res.CustomRepositories = &customRepositories
 		} else if cust.CustomRepositories != nil && len(*cust.CustomRepositories) > 0 {
-			custrepos, err := h.buildCustomRepositories(ctx, *cust.CustomRepositories)
+			_, _, rhRepos, err := h.checkForRHReposInCustom(ctx, *cust.CustomRepositories)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
-			res.CustomRepositories = &custrepos
+			if len(rhRepos) == 0 {
+				custrepos, err := h.buildCustomRepositories(ctx, *cust.CustomRepositories)
+				if err != nil {
+					return nil, nil, err
+				}
+				res.CustomRepositories = &custrepos
+			} else {
+				extraRHRepos = rhRepos
+				filteredCustomRepos, _, _ := h.filterRHFromCustomRepos(rhRepos, *cust.CustomRepositories)
+				if len(filteredCustomRepos) == 0 {
+					res.CustomRepositories = nil
+				} else {
+					custrepos, err := h.buildCustomRepositories(ctx, filteredCustomRepos)
+					if err != nil {
+						return nil, nil, err
+					}
+					res.CustomRepositories = &custrepos
+				}
+			}
 		}
 	}
 
 	if cust.Openscap != nil {
 		profile, err := cust.Openscap.AsOpenSCAPProfile()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		if profile.ProfileId != "" {
@@ -1093,30 +1282,30 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 		policy, err := cust.Openscap.AsOpenSCAPCompliance()
 		if err != nil {
 			ctx.Logger().Error(err.Error())
-			return nil, err
+			return nil, nil, err
 		}
 
 		if policy.PolicyId != uuid.Nil {
 			if !unleash.Enabled(unleash.CompliancePolicies) {
-				return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Feature %s not enabled", string(unleash.CompliancePolicies)))
+				return nil, nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Feature %s not enabled", string(unleash.CompliancePolicies)))
 			}
 
 			major, minor, err := d.RHELMajorMinor()
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 
 			pdata, err := h.server.complianceClient.PolicyDataForMinorVersion(ctx.Request().Context(), major, minor, policy.PolicyId.String())
 			if errors.Is(err, compliance.ErrorAuth) {
-				return nil, echo.NewHTTPError(http.StatusForbidden, fmt.Sprintf("User is not authorized to get compliance data for given policy ID (%s)", policy.PolicyId.String()))
+				return nil, nil, echo.NewHTTPError(http.StatusForbidden, fmt.Sprintf("User is not authorized to get compliance data for given policy ID (%s)", policy.PolicyId.String()))
 			} else if errors.Is(err, compliance.ErrorMajorVersion) {
-				return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Compliance policy (%s) does not support requested major version %d", policy.PolicyId.String(), major))
+				return nil, nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Compliance policy (%s) does not support requested major version %d", policy.PolicyId.String(), major))
 			} else if errors.Is(err, compliance.ErrorPolicyNotFound) {
-				return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Compliance policy (%s) does not exist", policy.PolicyId.String()))
+				return nil, nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Compliance policy (%s) does not exist", policy.PolicyId.String()))
 			} else if errors.Is(err, compliance.ErrorTailoringNotFound) {
-				return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Compliance policy (%s) does not have tailoring for RHEL %d, minor version %d", policy.PolicyId.String(), major, minor))
+				return nil, nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Compliance policy (%s) does not have tailoring for RHEL %d, minor version %d", policy.PolicyId.String(), major, minor))
 			} else if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 
 			if pdata.TailoringData != nil {
@@ -1220,7 +1409,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 				if err == nil {
 					err = group.FromDirectoryGroup0(dg0)
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 
 				}
@@ -1228,7 +1417,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 				if err == nil {
 					err = group.FromDirectoryGroup1(dg1)
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 				}
 			}
@@ -1240,14 +1429,14 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 				if err == nil {
 					err = user.FromDirectoryUser0(du0)
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 				}
 				du1, err := d.User.AsDirectoryUser1()
 				if err == nil {
 					err = user.FromDirectoryUser1(composer.DirectoryUser1(du1))
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 				}
 			}
@@ -1278,7 +1467,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 				if err == nil {
 					err = group.FromFileGroup0(fg0)
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 				}
 
@@ -1286,7 +1475,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 				if err == nil {
 					err = group.FromFileGroup1(fg1)
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 				}
 			}
@@ -1298,14 +1487,14 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 				if err == nil {
 					err = user.FromFileUser0(fu0)
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 				}
 				fu1, err := f.User.AsFileUser1()
 				if err == nil {
 					err = user.FromFileUser1(composer.FileUser1(fu1))
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 				}
 			}
@@ -1313,7 +1502,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 			if f.Data != nil && f.DataEncoding != nil && *f.DataEncoding == "base64" {
 				buf, err := base64.StdEncoding.DecodeString(*f.Data)
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 				f.Data = common.ToPtr(string(buf))
 			}
@@ -1363,7 +1552,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 	if cust.Subscription != nil && cust.Subscription.Insights && cust.Openscap != nil {
 		major, _, err := d.RHELMajorMinor()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		// Since RHEL 10, there is no rhcd service.
 		if major < 10 {
@@ -1454,12 +1643,12 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 			SkipTlsVerification: aap.SkipTlsVerification != nil && *aap.SkipTlsVerification,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		serviceUnit, err := tmpl.RenderAAPServiceUnit(ctx.Request().Context())
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		files := []composer.File{
@@ -1511,5 +1700,8 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 	// IB API Disk uses the same type as the osbuild-composer Disk
 	res.Disk = cust.Disk
 
-	return res, nil
+	if len(extraRHRepos) > 0 {
+		return res, extraRHRepos, nil
+	}
+	return res, nil, nil
 }

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -1149,6 +1149,25 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 				res.Subscription.TemplateUuid = cr.ImageRequests[0].ContentTemplate
 			}
 		}
+
+		// Fetch content labels from any extra RH repositories in the customizations (not baseos/appstream)
+		// and add these to the subscription
+		if cust.CustomRepositories != nil {
+			var repoIDs []string
+
+			for _, repo := range *cust.CustomRepositories {
+				repoIDs = append(repoIDs, repo.Id)
+			}
+
+			if len(repoIDs) > 0 {
+				labels, err := h.server.csClient.FetchLabelsFromNonBaseRHRepos(ctx.Request().Context(), repoIDs)
+				if err != nil {
+					ctx.Logger().Warnf("Failed to get labels from repositories: %v", err)
+				} else if len(labels) > 0 {
+					res.Subscription.ContentSets = &labels
+				}
+			}
+		}
 	}
 
 	if cust.Packages != nil {

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -1498,7 +1498,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 				},
 			},
 		},
-		// 1 payload and custom repository from additional RH repos
+		// 2 payload & custom non-base rhel repos, 1 payload & custom non-rhel repo
 		{
 			imageBuilderRequest: v1.ComposeRequest{
 				Distribution: common.ToPtr(v1.Distributions("rhel-9.7")),
@@ -1516,12 +1516,42 @@ func TestComposeWithSnapshots(t *testing.T) {
 				Customizations: &v1.Customizations{
 					PayloadRepositories: &[]v1.Repository{
 						{
-							Id: common.ToPtr(mocks.RepoCodeReadyID),
+							Id:           common.ToPtr(mocks.RepoCodeReadyID),
+							Baseurl:      common.ToPtr("https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/"),
+							CheckGpg:     common.ToPtr(true),
+							CheckRepoGpg: common.ToPtr(true),
+							Gpgkey:       common.ToPtr(mocks.RhelGPG),
+							IgnoreSsl:    common.ToPtr(false),
+							Rhsm:         false,
+						},
+						{
+							Id:           common.ToPtr(mocks.RepoHighAvailabilityID),
+							Baseurl:      common.ToPtr("https://cdn.redhat.com/content/dist/rhel9/9/x86_64/highavailability/os/"),
+							CheckGpg:     common.ToPtr(true),
+							CheckRepoGpg: common.ToPtr(true),
+							Gpgkey:       common.ToPtr(mocks.RhelGPG),
+							IgnoreSsl:    common.ToPtr(false),
+							Rhsm:         false,
+						},
+						{
+							Id: common.ToPtr(mocks.RepoPLID3),
 						},
 					},
 					CustomRepositories: &[]v1.CustomRepository{
 						{
-							Id: mocks.RepoCodeReadyID,
+							Id:       mocks.RepoCodeReadyID,
+							Baseurl:  &[]string{"https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/"},
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   &[]string{mocks.RhelGPG},
+						},
+						{
+							Id:       mocks.RepoHighAvailabilityID,
+							Baseurl:  &[]string{"https://cdn.redhat.com/content/dist/rhel9/9/x86_64/highavailability/os/"},
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   &[]string{mocks.RhelGPG},
+						},
+						{
+							Id: mocks.RepoPLID3,
 						},
 					},
 				},
@@ -1552,6 +1582,26 @@ func TestComposeWithSnapshots(t *testing.T) {
 							Mirrorlist:  nil,
 							PackageSets: nil,
 						},
+						{
+							Baseurl:     common.ToPtr("https://content-sources.org/api/neat/snappy/codeready"),
+							Rhsm:        common.ToPtr(false),
+							Gpgkey:      common.ToPtr(mocks.RhelGPG),
+							CheckGpg:    common.ToPtr(true),
+							IgnoreSsl:   nil,
+							Metalink:    nil,
+							Mirrorlist:  nil,
+							PackageSets: nil,
+						},
+						{
+							Baseurl:     common.ToPtr("https://content-sources.org/api/neat/snappy/highavailability"),
+							Rhsm:        common.ToPtr(false),
+							Gpgkey:      common.ToPtr(mocks.RhelGPG),
+							CheckGpg:    common.ToPtr(true),
+							IgnoreSsl:   nil,
+							Metalink:    nil,
+							Mirrorlist:  nil,
+							PackageSets: nil,
+						},
 					},
 					UploadOptions: makeUploadOptions(t, composer.AWSS3UploadOptions{
 						Region: "",
@@ -1560,20 +1610,16 @@ func TestComposeWithSnapshots(t *testing.T) {
 				Customizations: &composer.Customizations{
 					PayloadRepositories: &[]composer.Repository{
 						{
-							Baseurl:  common.ToPtr("https://content-sources.org/api/neat/snappy/codeready"),
-							Rhsm:     common.ToPtr(false),
-							CheckGpg: common.ToPtr(true),
-							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+							Baseurl: common.ToPtr("https://content-sources.org/api/neat/snappy/payload3"),
+							Rhsm:    common.ToPtr(false),
 						},
 					},
 					CustomRepositories: &[]composer.CustomRepository{
 						{
-							Baseurl:  &[]string{"http://snappy-url/snappy/codeready"},
-							Name:     common.ToPtr("codeready"),
-							Enabled:  common.ToPtr(false),
-							Id:       mocks.RepoCodeReadyID,
-							CheckGpg: common.ToPtr(true),
-							Gpgkey:   &[]string{mocks.RhelGPG},
+							Baseurl: &[]string{"http://snappy-url/snappy/payload3"},
+							Name:    common.ToPtr("payload3"),
+							Enabled: common.ToPtr(false),
+							Id:      mocks.RepoPLID3,
 						},
 					},
 				},
@@ -3317,6 +3363,296 @@ WantedBy=basic.target
 						{
 							Baseurl:  common.ToPtr("https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os"),
 							Rhsm:     common.ToPtr(true),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+							CheckGpg: common.ToPtr(true),
+						},
+					},
+					UploadOptions: makeUploadOptions(t, composer.AWSS3UploadOptions{
+						Region: "",
+					}),
+				},
+			},
+		},
+		//subscription, 1 non-base rhel repo
+		{
+			imageBuilderRequest: v1.ComposeRequest{
+				Customizations: &v1.Customizations{
+					Subscription: &v1.Subscription{
+						Insights: true,
+					},
+					PayloadRepositories: &[]v1.Repository{
+						{
+							Id:           common.ToPtr(mocks.RepoCodeReadyID),
+							Baseurl:      common.ToPtr("https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/"),
+							CheckGpg:     common.ToPtr(true),
+							CheckRepoGpg: common.ToPtr(true),
+							Gpgkey:       common.ToPtr(mocks.RhelGPG),
+							IgnoreSsl:    common.ToPtr(false),
+							Rhsm:         false,
+						},
+					},
+					CustomRepositories: &[]v1.CustomRepository{
+						{
+							Id:       mocks.RepoCodeReadyID,
+							Baseurl:  &[]string{"https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/"},
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   &[]string{mocks.RhelGPG},
+						},
+					},
+				},
+				Distribution: common.ToPtr(v1.Distributions("rhel-9")),
+				ImageRequests: []v1.ImageRequest{
+					{
+						Architecture: "x86_64",
+						ImageType:    v1.ImageTypesGuestImage,
+						UploadRequest: v1.UploadRequest{
+							Type:    v1.UploadTypesAwsS3,
+							Options: uo,
+						},
+					},
+				},
+			},
+			composerRequest: composer.ComposeRequest{
+				Distribution: common.ToPtr("rhel-9.7"),
+				Customizations: &composer.Customizations{
+					Subscription: &composer.Subscription{
+						Insights:            true,
+						Rhc:                 common.ToPtr(false),
+						Organization:        "0",
+						InsightsClientProxy: common.ToPtr(""),
+						ContentSets:         common.ToPtr([]string{"codeready-builder-for-rhel-9-x86_64-rpms"}),
+					},
+				},
+				ImageRequest: &composer.ImageRequest{
+					Architecture: "x86_64",
+					ImageType:    composer.ImageTypesGuestImage,
+					Repositories: []composer.Repository{
+						{
+							Baseurl:  common.ToPtr("https://content-sources.org/snappy/baseos"),
+							Rhsm:     common.ToPtr(false),
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+						},
+						{
+							Baseurl:  common.ToPtr("https://content-sources.org/snappy/appstream"),
+							Rhsm:     common.ToPtr(false),
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+						},
+						{
+							Baseurl:  common.ToPtr("https://content-sources.org/snappy/codeready"),
+							Rhsm:     common.ToPtr(false),
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+						},
+					},
+					UploadOptions: makeUploadOptions(t, composer.AWSS3UploadOptions{
+						Region: "",
+					}),
+				},
+			},
+		},
+		// subscription, 1 non-base rhel repo, 1 non-rhel repo
+		{
+			imageBuilderRequest: v1.ComposeRequest{
+				Customizations: &v1.Customizations{
+					Subscription: &v1.Subscription{
+						Insights: true,
+					},
+					PayloadRepositories: &[]v1.Repository{
+						{
+							Id:           common.ToPtr(mocks.RepoCodeReadyID),
+							Baseurl:      common.ToPtr("https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/"),
+							CheckGpg:     common.ToPtr(true),
+							CheckRepoGpg: common.ToPtr(true),
+							Gpgkey:       common.ToPtr(mocks.RhelGPG),
+							IgnoreSsl:    common.ToPtr(false),
+							Rhsm:         false,
+						},
+						{
+							Baseurl:      common.ToPtr("https://some-repo-base-url.org"),
+							CheckGpg:     common.ToPtr(true),
+							CheckRepoGpg: common.ToPtr(true),
+							Gpgkey:       common.ToPtr("some-gpg-key"),
+							IgnoreSsl:    common.ToPtr(false),
+							Rhsm:         false,
+						},
+					},
+					CustomRepositories: &[]v1.CustomRepository{
+						{
+							Id:       mocks.RepoCodeReadyID,
+							Baseurl:  &[]string{"https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/"},
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   &[]string{mocks.RhelGPG},
+						},
+						{
+							Id:       "some-repo-id",
+							Baseurl:  &[]string{"https://some-repo-base-url.org"},
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   &[]string{"some-gpg-key"},
+						},
+					},
+				},
+				Distribution: common.ToPtr(v1.Distributions("rhel-9")),
+				ImageRequests: []v1.ImageRequest{
+					{
+						Architecture: "x86_64",
+						ImageType:    v1.ImageTypesGuestImage,
+						UploadRequest: v1.UploadRequest{
+							Type:    v1.UploadTypesAwsS3,
+							Options: uo,
+						},
+					},
+				},
+			},
+			composerRequest: composer.ComposeRequest{
+				Distribution: common.ToPtr("rhel-9.7"),
+				Customizations: &composer.Customizations{
+					Subscription: &composer.Subscription{
+						Insights:            true,
+						Rhc:                 common.ToPtr(false),
+						Organization:        "0",
+						InsightsClientProxy: common.ToPtr(""),
+						ContentSets:         common.ToPtr([]string{"codeready-builder-for-rhel-9-x86_64-rpms"}),
+					},
+					PayloadRepositories: &[]composer.Repository{
+						{
+							Baseurl:      common.ToPtr("https://some-repo-base-url.org"),
+							CheckGpg:     common.ToPtr(true),
+							CheckRepoGpg: common.ToPtr(true),
+							Gpgkey:       common.ToPtr("some-gpg-key"),
+							IgnoreSsl:    common.ToPtr(false),
+							Rhsm:         common.ToPtr(false),
+						},
+					},
+					CustomRepositories: &[]composer.CustomRepository{
+						{
+							Id:       "some-repo-id",
+							Baseurl:  &[]string{"https://some-repo-base-url.org"},
+							Gpgkey:   &[]string{"some-gpg-key"},
+							CheckGpg: common.ToPtr(true),
+						},
+					},
+				},
+				ImageRequest: &composer.ImageRequest{
+					Architecture: "x86_64",
+					ImageType:    composer.ImageTypesGuestImage,
+					Repositories: []composer.Repository{
+						{
+							Baseurl:  common.ToPtr("https://content-sources.org/snappy/baseos"),
+							Rhsm:     common.ToPtr(false),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+							CheckGpg: common.ToPtr(true),
+						},
+						{
+							Baseurl:  common.ToPtr("https://content-sources.org/snappy/appstream"),
+							Rhsm:     common.ToPtr(false),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+							CheckGpg: common.ToPtr(true),
+						},
+						{
+							Baseurl:  common.ToPtr("https://content-sources.org/snappy/codeready"),
+							Rhsm:     common.ToPtr(false),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+							CheckGpg: common.ToPtr(true),
+						},
+					},
+					UploadOptions: makeUploadOptions(t, composer.AWSS3UploadOptions{
+						Region: "",
+					}),
+				},
+			},
+		},
+		// subscription, 2 non-base rhel repos
+		{
+			imageBuilderRequest: v1.ComposeRequest{
+				Customizations: &v1.Customizations{
+					Subscription: &v1.Subscription{
+						Insights: true,
+					},
+					PayloadRepositories: &[]v1.Repository{
+						{
+							Id:           common.ToPtr(mocks.RepoCodeReadyID),
+							Baseurl:      common.ToPtr("https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/"),
+							CheckGpg:     common.ToPtr(true),
+							CheckRepoGpg: common.ToPtr(true),
+							Gpgkey:       common.ToPtr(mocks.RhelGPG),
+							IgnoreSsl:    common.ToPtr(false),
+							Rhsm:         false,
+						},
+						{
+							Id:           common.ToPtr(mocks.RepoHighAvailabilityID),
+							Baseurl:      common.ToPtr("https://cdn.redhat.com/content/dist/rhel9/9/x86_64/highavailability/os/"),
+							CheckGpg:     common.ToPtr(true),
+							CheckRepoGpg: common.ToPtr(true),
+							Gpgkey:       common.ToPtr(mocks.RhelGPG),
+							IgnoreSsl:    common.ToPtr(false),
+							Rhsm:         false,
+						},
+					},
+					CustomRepositories: &[]v1.CustomRepository{
+						{
+							Id:       mocks.RepoCodeReadyID,
+							Baseurl:  &[]string{"https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/"},
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   &[]string{mocks.RhelGPG},
+						},
+						{
+							Id:       mocks.RepoHighAvailabilityID,
+							Baseurl:  &[]string{"https://cdn.redhat.com/content/dist/rhel9/9/x86_64/highavailability/os/"},
+							CheckGpg: common.ToPtr(true),
+							Gpgkey:   &[]string{mocks.RhelGPG},
+						},
+					},
+				},
+				Distribution: common.ToPtr(v1.Distributions("rhel-9")),
+				ImageRequests: []v1.ImageRequest{
+					{
+						Architecture: "x86_64",
+						ImageType:    v1.ImageTypesGuestImage,
+						UploadRequest: v1.UploadRequest{
+							Type:    v1.UploadTypesAwsS3,
+							Options: uo,
+						},
+					},
+				},
+			},
+			composerRequest: composer.ComposeRequest{
+				Distribution: common.ToPtr("rhel-9.7"),
+				Customizations: &composer.Customizations{
+					Subscription: &composer.Subscription{
+						Insights:            true,
+						Rhc:                 common.ToPtr(false),
+						Organization:        "0",
+						InsightsClientProxy: common.ToPtr(""),
+						ContentSets:         common.ToPtr([]string{"codeready-builder-for-rhel-9-x86_64-rpms", "rhel-9-for-x86_64-highavailability-rpms"}),
+					},
+				},
+				ImageRequest: &composer.ImageRequest{
+					Architecture: "x86_64",
+					ImageType:    composer.ImageTypesGuestImage,
+					Repositories: []composer.Repository{
+						{
+							Baseurl:  common.ToPtr("https://content-sources.org/snappy/baseos"),
+							Rhsm:     common.ToPtr(false),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+							CheckGpg: common.ToPtr(true),
+						},
+						{
+							Baseurl:  common.ToPtr("https://content-sources.org/snappy/appstream"),
+							Rhsm:     common.ToPtr(false),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+							CheckGpg: common.ToPtr(true),
+						},
+						{
+							Baseurl:  common.ToPtr("https://content-sources.org/snappy/codeready"),
+							Rhsm:     common.ToPtr(false),
+							Gpgkey:   common.ToPtr(mocks.RhelGPG),
+							CheckGpg: common.ToPtr(true),
+						},
+						{
+							Baseurl:  common.ToPtr("https://content-sources.org/snappy/highavailability"),
+							Rhsm:     common.ToPtr(false),
 							Gpgkey:   common.ToPtr(mocks.RhelGPG),
 							CheckGpg: common.ToPtr(true),
 						},

--- a/internal/v1/mocks/content_sources.go
+++ b/internal/v1/mocks/content_sources.go
@@ -17,21 +17,22 @@ const (
 )
 
 const (
-	RepoBaseID       = "2531793b-c607-4e1c-80b2-fbbaf9d12790"
-	RepoAppstrID     = "dbd21dfc-1733-4877-b1c8-8fb5a98beeb4"
-	RepoCodeReadyID  = "e2d9e12f-5658-408f-8bfd-5d218919d57e"
-	RepoPLID         = "a7ec8864-0e3c-4af2-8c06-567891280af5"
-	RepoPLID2        = "c01c2d9c-4624-4558-9ca9-8abcc5eb4437"
-	RepoPLID3        = "d064585d-5d25-4e10-88d0-9ab4d192b21d"
-	RepoUplID        = "7fa07d5a-3df4-4c83-bfe3-79633a0ad27d"
-	RepoSharedEpelID = "5d63ec94-6c45-4e1b-a2e9-9979c1a9d4aa"
-	TemplateID       = "267232b1-d5af-467f-b6c0-2b502fa02d3d"
-	TemplateID2      = "f3203472-e8ed-4d52-8a98-0e9905e91953"
-	TemplateID3      = "71c14af2-2970-4c0d-a60c-a2ab1247cec6"
-	SnapshotID       = "6161fd44-ade8-4300-882b-ede6d65ee56e"
-	SnapshotID2      = "470f9dfa-10dd-4d70-aacb-96ba9a3d9f06"
-	SnapshotBaseID   = "fb1551cc-706d-4fb5-bd14-4a29e7aeef3a"
-	SnapshotAppstrID = "f00957e0-0d1d-4777-81a6-9ff072452fb1"
+	RepoBaseID             = "2531793b-c607-4e1c-80b2-fbbaf9d12790"
+	RepoAppstrID           = "dbd21dfc-1733-4877-b1c8-8fb5a98beeb4"
+	RepoCodeReadyID        = "e2d9e12f-5658-408f-8bfd-5d218919d57e"
+	RepoHighAvailabilityID = "baab8d8d-43ed-49e9-b0a6-764f5d62b97b"
+	RepoPLID               = "a7ec8864-0e3c-4af2-8c06-567891280af5"
+	RepoPLID2              = "c01c2d9c-4624-4558-9ca9-8abcc5eb4437"
+	RepoPLID3              = "d064585d-5d25-4e10-88d0-9ab4d192b21d"
+	RepoUplID              = "7fa07d5a-3df4-4c83-bfe3-79633a0ad27d"
+	RepoSharedEpelID       = "5d63ec94-6c45-4e1b-a2e9-9979c1a9d4aa"
+	TemplateID             = "267232b1-d5af-467f-b6c0-2b502fa02d3d"
+	TemplateID2            = "f3203472-e8ed-4d52-8a98-0e9905e91953"
+	TemplateID3            = "71c14af2-2970-4c0d-a60c-a2ab1247cec6"
+	SnapshotID             = "6161fd44-ade8-4300-882b-ede6d65ee56e"
+	SnapshotID2            = "470f9dfa-10dd-4d70-aacb-96ba9a3d9f06"
+	SnapshotBaseID         = "fb1551cc-706d-4fb5-bd14-4a29e7aeef3a"
+	SnapshotAppstrID       = "f00957e0-0d1d-4777-81a6-9ff072452fb1"
 )
 
 func rhRepos(ids []string, urls []string) (res []content_sources.ApiRepositoryResponse) {
@@ -43,6 +44,7 @@ func rhRepos(ids []string, urls []string) (res []content_sources.ApiRepositoryRe
 			LatestSnapshotUrl: common.ToPtr("http://snappy-url/snappy/baseos"),
 			Snapshot:          common.ToPtr(true),
 			Name:              common.ToPtr("baseos"),
+			Label:             common.ToPtr("rhel-9-for-x86_64-baseos-rpms"),
 		})
 	}
 
@@ -54,6 +56,7 @@ func rhRepos(ids []string, urls []string) (res []content_sources.ApiRepositoryRe
 			LatestSnapshotUrl: common.ToPtr("http://snappy-url/snappy/appstream"),
 			Snapshot:          common.ToPtr(true),
 			Name:              common.ToPtr("appstream"),
+			Label:             common.ToPtr("rhel-9-for-x86_64-appstream-rpms"),
 		})
 	}
 
@@ -64,6 +67,7 @@ func rhRepos(ids []string, urls []string) (res []content_sources.ApiRepositoryRe
 			Url:      common.ToPtr("https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os"),
 			Snapshot: common.ToPtr(true),
 			Name:     common.ToPtr("baseos"),
+			Label:    common.ToPtr("rhel-8-for-x86_64-baseos-rpms"),
 		})
 	}
 
@@ -74,16 +78,31 @@ func rhRepos(ids []string, urls []string) (res []content_sources.ApiRepositoryRe
 			Url:      common.ToPtr("https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os"),
 			Snapshot: common.ToPtr(true),
 			Name:     common.ToPtr("appstream"),
+			Label:    common.ToPtr("rhel-8-for-x86_64-appstream-rpms"),
 		})
 	}
 
 	if slices.Contains(urls, "https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/") || slices.Contains(ids, RepoCodeReadyID) {
 		res = append(res, content_sources.ApiRepositoryResponse{
-			GpgKey:   common.ToPtr(RhelGPG),
-			Uuid:     common.ToPtr(RepoCodeReadyID),
-			Url:      common.ToPtr("https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/"),
-			Snapshot: common.ToPtr(true),
-			Name:     common.ToPtr("codeready"),
+			GpgKey:            common.ToPtr(RhelGPG),
+			Uuid:              common.ToPtr(RepoCodeReadyID),
+			Url:               common.ToPtr("https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/"),
+			LatestSnapshotUrl: common.ToPtr("http://snappy-url/snappy/codeready"),
+			Snapshot:          common.ToPtr(true),
+			Name:              common.ToPtr("codeready"),
+			Label:             common.ToPtr("codeready-builder-for-rhel-9-x86_64-rpms"),
+		})
+	}
+
+	if slices.Contains(urls, "https://cdn.redhat.com/content/dist/rhel9/9/x86_64/highavailability/os/") || slices.Contains(ids, RepoHighAvailabilityID) {
+		res = append(res, content_sources.ApiRepositoryResponse{
+			GpgKey:            common.ToPtr(RhelGPG),
+			Uuid:              common.ToPtr(RepoHighAvailabilityID),
+			Url:               common.ToPtr("https://cdn.redhat.com/content/dist/rhel9/9/x86_64/highavailability/os/"),
+			LatestSnapshotUrl: common.ToPtr("http://snappy-url/snappy/highavailability"),
+			Snapshot:          common.ToPtr(true),
+			Name:              common.ToPtr("highavailability"),
+			Label:             common.ToPtr("rhel-9-for-x86_64-highavailability-rpms"),
 		})
 	}
 
@@ -247,6 +266,19 @@ func snapsWithOsVersion(uuids []string, detectedOsVersion *string) (res []conten
 			RepositoryUuid: common.ToPtr(RepoCodeReadyID),
 		})
 	}
+
+	if slices.Contains(uuids, RepoHighAvailabilityID) {
+		res = append(res, content_sources.ApiSnapshotForDate{
+			IsAfter: common.ToPtr(false),
+			Match: &content_sources.ApiSnapshotResponse{
+				CreatedAt:      common.ToPtr("1998-01-30T00:00:00Z"),
+				RepositoryPath: common.ToPtr("/snappy/highavailability"),
+				Url:            common.ToPtr("http://snappy-url/snappy/highavailability"),
+			},
+			RepositoryUuid: common.ToPtr(RepoHighAvailabilityID),
+		})
+	}
+
 	return res
 }
 


### PR DESCRIPTION
- Looks up any non-base RH repo labels from content-sources and adds these to the subscription options, which are used to enable these repos after registration
- Additional non-base RH repos are requested in the custom and payload customizations, but we need these to be sent in the image request with the base RH repos, so if any are found in the customizations this moves them to the image request 
  - This is a big ugly change -- any input on how it could be improved or done differently is appreciated!

Follow up to https://github.com/osbuild/osbuild-composer/pull/4981 

Jira: https://issues.redhat.com/browse/HMS-8857