### PR TITLE
Check content-sources for snapshot os version

### DIFF
--- a/internal/distribution/distroregistry.go
+++ b/internal/distribution/distroregistry.go
@@ -2,6 +2,8 @@ package distribution
 
 import (
 	"os"
+	"strconv"
+	"strings"
 )
 
 // AllDistroRegistry holds all distribution that image-builder knows
@@ -114,4 +116,39 @@ func (dr DistroRegistry) Get(name string) (*DistributionFile, error) {
 	}
 
 	return df, nil
+}
+
+// FindByMajorMinor returns the first RHEL distribution in the registry matching
+// the given major and minor version. Returns nil if no match is found.
+func (dr DistroRegistry) FindByMajorMinor(major, minor int) *DistributionFile {
+	for _, d := range dr.distros {
+		m, mn, err := d.RHELMajorMinor()
+		if err == nil && m == major && mn == minor {
+			return d
+		}
+	}
+	return nil
+}
+
+// FindByMajorMinorStr parses a "major.minor" version string (e.g. "9.4") and
+// returns the composer distribution name for the matching RHEL distribution.
+// Returns an empty string if the version cannot be parsed or no match is found.
+func (dr DistroRegistry) FindByMajorMinorStr(majorMinor string) string {
+	parts := strings.SplitN(majorMinor, ".", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	major, errMaj := strconv.Atoi(parts[0])
+	minor, errMin := strconv.Atoi(parts[1])
+	if errMaj != nil || errMin != nil {
+		return ""
+	}
+	d := dr.FindByMajorMinor(major, minor)
+	if d == nil {
+		return ""
+	}
+	if d.Distribution.ComposerName != nil {
+		return *d.Distribution.ComposerName
+	}
+	return d.Distribution.Name
 }

--- a/internal/distribution/distroregistry_test.go
+++ b/internal/distribution/distroregistry_test.go
@@ -14,6 +14,7 @@ func TestDistroRegistry_List(t *testing.T) {
 		"no-packages",
 		"restricted-access",
 		"rhel-1.2",
+		"rhel-34",
 		"standard",
 		"with-bootc",
 	}
@@ -21,6 +22,7 @@ func TestDistroRegistry_List(t *testing.T) {
 		"no-packages",
 		"restricted-access",
 		"rhel-1.2",
+		"rhel-34",
 		"standard",
 		"with-bootc",
 	}
@@ -132,4 +134,34 @@ func TestDistroRegistry_Get(t *testing.T) {
 	result, err = dr.Available(false).Get("toucan-42")
 	require.Nil(t, result)
 	require.Equal(t, ErrDistributionNotFound, err)
+}
+
+func TestDistroRegistry_FindByMajorMinorStr(t *testing.T) {
+	dr, err := LoadDistroRegistry("./testdata/distributions")
+	require.NoError(t, err)
+	registry := dr.Available(true)
+
+	cases := []struct {
+		input    string
+		expected string
+		desc     string
+	}{
+		// rhel-1.2 has no composer_name → returns distribution name
+		{"1.2", "rhel-1.2", "returns distribution name when no composer_name is set"},
+		// rhel-3.4 has composer_name "rhel-3.4" → returns composer_name
+		{"3.4", "rhel-3.4", "returns composer_name when set"},
+		// no distribution matches this version
+		{"9.99", "", "returns empty string for unknown version"},
+		// malformed inputs
+		{"notanumber", "", "returns empty string for non-numeric input"},
+		{"1", "", "returns empty string when minor version is missing"},
+		{"1.2.3", "", "returns empty string when minor part is not a plain integer"},
+		{"", "", "returns empty string for empty input"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.expected, registry.FindByMajorMinorStr(tc.input))
+		})
+	}
 }

--- a/internal/distribution/testdata/distributions/rhel-3.4/rhel-3.4.json
+++ b/internal/distribution/testdata/distributions/rhel-3.4/rhel-3.4.json
@@ -1,0 +1,17 @@
+{
+  "module_platform_id": "platform:rhel",
+  "distribution": {
+    "name": "rhel-34",
+    "composer_name": "rhel-3.4",
+    "description": "A distribution for rhel major/minor discovery with composer_name",
+    "no_package_list": true
+  },
+  "x86_64": {
+    "image_types": ["rhel"],
+    "repositories": []
+  },
+  "aarch64": {
+    "image_types": ["rhel"],
+    "repositories": []
+  }
+}

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -95,6 +95,7 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 	}
 
 	var repositories []composer.Repository
+	var detectedOsVersion *string
 	// We should only build repository snapshots in the case where there is a snapshot date and no content template
 	if composeRequest.ImageRequests[0].SnapshotDate != nil && composeRequest.ImageRequests[0].ContentTemplate == nil {
 		repoURLs := []string{}
@@ -117,11 +118,12 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 			}
 		}
 
-		snapshotRepos, _, err := h.buildRepositorySnapshots(ctx, repoURLs, nil, false, *composeRequest.ImageRequests[0].SnapshotDate)
+		snapshotRepos, _, snapshotOsVersion, err := h.buildRepositorySnapshots(ctx, repoURLs, nil, false, *composeRequest.ImageRequests[0].SnapshotDate)
 		if err != nil {
 			return ComposeResponse{}, err
 		}
 		repositories = append(repositories, snapshotRepos...)
+		detectedOsVersion = snapshotOsVersion
 
 		// A sanity check to make sure there's a snapshot for each repo
 		expected := 0
@@ -134,10 +136,12 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 			return ComposeResponse{}, fmt.Errorf("no snapshots found for all repositories (found %d, expected %d)", len(repositories), expected)
 		}
 	} else if composeRequest.ImageRequests[0].ContentTemplate != nil {
-		_, _, repositories, err = h.buildTemplateRepositories(ctx, *composeRequest.ImageRequests[0].ContentTemplate)
+		var templateOsVersion *string
+		_, _, repositories, templateOsVersion, err = h.buildTemplateRepositories(ctx, *composeRequest.ImageRequests[0].ContentTemplate)
 		if err != nil {
 			return ComposeResponse{}, err
 		}
+		detectedOsVersion = templateOsVersion
 	} else {
 		repositories, err = h.buildRepositoriesWithLatestSnapshots(ctx, arch, composeRequest.ImageRequests[0].ImageType)
 		if err != nil {
@@ -158,6 +162,16 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 	distro := d.Distribution.Name
 	if d.Distribution.ComposerName != nil {
 		distro = *d.Distribution.ComposerName
+	}
+
+	// When the snapshot contains a detected OS version (e.g. "9.4"), override the
+	// distribution sent to osbuild-composer with the matching minor-version
+	// distribution. This prevents composer from requesting packages that are only
+	// available in a newer minor version (e.g. system-reinstall-bootc in 9.6+).
+	if detectedOsVersion != nil {
+		if v := h.server.distroRegistry(ctx).FindByMajorMinorStr(*detectedOsVersion); v != "" {
+			distro = v
+		}
 	}
 
 	cloudCR := composer.ComposeRequest{
@@ -339,14 +353,17 @@ func (h *Handlers) buildComposerRepositoryFromSnapshot(snapshotPath string, useP
 	return composerRepo, nil
 }
 
-func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string, repoIDs []string, external bool, snapshotDate string) ([]composer.Repository, []composer.CustomRepository, error) {
+// buildRepositorySnapshots resolves repository snapshots for the given date.
+// The third return value is the detected OS version (e.g. "9.4") reported by
+// content-sources for the snapshot if available.
+func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string, repoIDs []string, external bool, snapshotDate string) ([]composer.Repository, []composer.CustomRepository, *string, error) {
 	date, err := time.Parse(time.RFC3339, snapshotDate)
 	if err != nil {
 		date, err = time.Parse(time.DateOnly, snapshotDate)
 	}
 
 	if err != nil {
-		return nil, nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Snapshot date %s is not in DateOnly (yyyy-mm-dd) or RFC3339 (yyyy-mm-ddThh:mm:ssZ) format", snapshotDate))
+		return nil, nil, nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Snapshot date %s is not in DateOnly (yyyy-mm-dd) or RFC3339 (yyyy-mm-ddThh:mm:ssZ) format", snapshotDate))
 	}
 
 	repoMap := content_sources.RepositoryByID{}
@@ -355,7 +372,7 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 		rhRepoMap, err := h.server.csClient.GetRepositories(ctx.Request().Context(), repoURLs, repoIDs, false)
 		if err != nil {
 			ctx.Logger().Warnf("Unable to get RH repositories for base urls: %v", err)
-			return nil, nil, fmt.Errorf("unable to retrieve RH repositories: %v", err)
+			return nil, nil, nil, fmt.Errorf("unable to retrieve RH repositories: %v", err)
 		} else {
 			for id, repo := range rhRepoMap {
 				repoMap[id] = repo
@@ -365,7 +382,7 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 		nonRHRepoMap, err := h.server.csClient.GetRepositories(ctx.Request().Context(), repoURLs, repoIDs, true)
 		if err != nil {
 			ctx.Logger().Warnf("Unable to get non-RH repositories for base urls: %v", err)
-			return nil, nil, fmt.Errorf("unable to retrieve non-RH repositories: %v", err)
+			return nil, nil, nil, fmt.Errorf("unable to retrieve non-RH repositories: %v", err)
 		} else {
 			for id, repo := range nonRHRepoMap {
 				repoMap[id] = repo
@@ -375,7 +392,7 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 		repoMap, err = h.server.csClient.GetRepositories(ctx.Request().Context(), repoURLs, repoIDs, external)
 		if err != nil {
 			ctx.Logger().Warnf("Unable to get repositories for base urls: %v", err)
-			return nil, nil, fmt.Errorf("unable to retrieve repositories: %v", err)
+			return nil, nil, nil, fmt.Errorf("unable to retrieve repositories: %v", err)
 		}
 	}
 
@@ -383,7 +400,7 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 	for id, repo := range repoMap {
 		repoUUIDs = append(repoUUIDs, id)
 		if !*repo.Snapshot {
-			return nil, nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Repository %s (id: %s) has snapshotting disabled", *repo.Url, id))
+			return nil, nil, nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Repository %s (id: %s) has snapshotting disabled", *repo.Url, id))
 		}
 	}
 
@@ -392,7 +409,7 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 		RepositoryUuids: repoUUIDs,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	defer closeBody(ctx, snapResp.Body)
 
@@ -400,22 +417,23 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 		if snapResp.StatusCode != http.StatusUnauthorized {
 			body, err := io.ReadAll(snapResp.Body)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			ctx.Logger().Warnf("Unable to resolve snapshots: %s", body)
 		}
-		return nil, nil, fmt.Errorf("unable to fetch snapshots for date, got %v response", snapResp.StatusCode)
+		return nil, nil, nil, fmt.Errorf("unable to fetch snapshots for date, got %v response", snapResp.StatusCode)
 	}
 
 	var csSnapshots content_sources.ApiListSnapshotByDateResponse
 	err = json.NewDecoder(snapResp.Body).Decode(&csSnapshots)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	var repositories []composer.Repository
 	var customRepositories []composer.CustomRepository
 	var errs []error
+	var detectedOsVersion *string
 
 	for _, snap := range *csSnapshots.Data {
 		repo, ok := repoMap[*snap.RepositoryUuid]
@@ -445,14 +463,19 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 		customRepo.ModuleHotfixes = repo.ModuleHotfixes
 		customRepo.CheckRepoGpg = repo.MetadataVerification
 		customRepositories = append(customRepositories, customRepo)
+
+		// Capture the first detected OS version seen across all snapshots.
+		if detectedOsVersion == nil && snap.Match.DetectedOsVersion != nil {
+			detectedOsVersion = snap.Match.DetectedOsVersion
+		}
 	}
 
 	if len(errs) > 0 {
-		return repositories, customRepositories, errors.Join(errs...)
+		return repositories, customRepositories, detectedOsVersion, errors.Join(errs...)
 	}
 
 	ctx.Logger().Debugf("Resolved snapshots: %v", repositories)
-	return repositories, customRepositories, nil
+	return repositories, customRepositories, detectedOsVersion, nil
 }
 
 func (h *Handlers) buildPayloadRepositories(ctx echo.Context, payloadRepos []Repository) ([]composer.Repository, error) {
@@ -611,22 +634,22 @@ func (h *Handlers) buildCustomRepositories(ctx echo.Context, custRepos []CustomR
 	return res, nil
 }
 
-func (h *Handlers) buildTemplateRepositories(ctx echo.Context, templateID string) ([]composer.Repository, []composer.CustomRepository, []composer.Repository, error) {
+func (h *Handlers) buildTemplateRepositories(ctx echo.Context, templateID string) ([]composer.Repository, []composer.CustomRepository, []composer.Repository, *string, error) {
 	var customRepoIDs []string
 	var rhRepoIDs []string
 
 	template, err := h.server.csClient.GetTemplateByID(ctx.Request().Context(), templateID)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("Unable to retrieve template: %v", err)
+		return nil, nil, nil, nil, fmt.Errorf("Unable to retrieve template: %v", err)
 	}
 
 	if template == nil || template.RepositoryUuids == nil {
-		return nil, nil, nil, fmt.Errorf("Template %v has no repositories", templateID)
+		return nil, nil, nil, nil, fmt.Errorf("Template %v has no repositories", templateID)
 	}
 
 	rhRepoMap, err := h.server.csClient.GetRepositories(ctx.Request().Context(), []string{}, *template.RepositoryUuids, false)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("Unable to retrieve Red Hat repositories: %v", err)
+		return nil, nil, nil, nil, fmt.Errorf("Unable to retrieve Red Hat repositories: %v", err)
 	}
 	for repoID := range rhRepoMap {
 		rhRepoIDs = append(rhRepoIDs, repoID)
@@ -634,7 +657,7 @@ func (h *Handlers) buildTemplateRepositories(ctx echo.Context, templateID string
 
 	customRepoMap, err := h.server.csClient.GetRepositories(ctx.Request().Context(), []string{}, *template.RepositoryUuids, true)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("Unable to retrieve custom repositories: %v", err)
+		return nil, nil, nil, nil, fmt.Errorf("Unable to retrieve custom repositories: %v", err)
 	}
 	for repoID := range customRepoMap {
 		customRepoIDs = append(customRepoIDs, repoID)
@@ -646,20 +669,26 @@ func (h *Handlers) buildTemplateRepositories(ctx echo.Context, templateID string
 	payloadRepositories := []composer.Repository{}
 	customRepositories := []composer.CustomRepository{}
 	var rhRepositories []composer.Repository
+	var detectedOsVersion *string
 
 	// We should never hit this condition, but checking just in case
 	if template.Snapshots == nil {
-		return nil, nil, nil, fmt.Errorf("Template %v has no snapshots", templateID)
+		return nil, nil, nil, nil, fmt.Errorf("Template %v has no snapshots", templateID)
 	}
 	for _, snap := range *template.Snapshots {
 		if snap.RepositoryUuid == nil {
-			return payloadRepositories, customRepositories, rhRepositories, fmt.Errorf("No repository UUID is associated with this snapshot")
+			return payloadRepositories, customRepositories, rhRepositories, detectedOsVersion, fmt.Errorf("No repository UUID is associated with this snapshot")
+		}
+
+		// Capture the first detected OS version seen across all template snapshots.
+		if detectedOsVersion == nil && snap.DetectedOsVersion != nil {
+			detectedOsVersion = snap.DetectedOsVersion
 		}
 
 		if slices.Contains(customRepoIDs, *snap.RepositoryUuid) {
 			repo, ok := customRepoMap[*snap.RepositoryUuid]
 			if !ok {
-				return payloadRepositories, customRepositories, rhRepositories, fmt.Errorf("Returned snapshot %v unexpected repository id %v", *snap.Uuid, *snap.RepositoryUuid)
+				return payloadRepositories, customRepositories, rhRepositories, detectedOsVersion, fmt.Errorf("Returned snapshot %v unexpected repository id %v", *snap.Uuid, *snap.RepositoryUuid)
 			}
 			// We don't want to set custom repositories when using a template, so here we only set the payload repositories
 			composerRepo := composer.Repository{
@@ -680,7 +709,7 @@ func (h *Handlers) buildTemplateRepositories(ctx echo.Context, templateID string
 			// Set the Red Hat repositories from the template
 			repo, ok := rhRepoMap[*snap.RepositoryUuid]
 			if !ok {
-				return payloadRepositories, customRepositories, rhRepositories, fmt.Errorf("Returned snapshot %v unexpected repository id %v", *snap.Uuid, *snap.RepositoryUuid)
+				return payloadRepositories, customRepositories, rhRepositories, detectedOsVersion, fmt.Errorf("Returned snapshot %v unexpected repository id %v", *snap.Uuid, *snap.RepositoryUuid)
 			}
 			rhRepo := composer.Repository{
 				Baseurl:  common.ToPtr(h.server.csReposURL.JoinPath(h.server.csReposPrefix, *snap.RepositoryPath).String()),
@@ -692,7 +721,7 @@ func (h *Handlers) buildTemplateRepositories(ctx echo.Context, templateID string
 		}
 	}
 
-	return payloadRepositories, customRepositories, rhRepositories, nil
+	return payloadRepositories, customRepositories, rhRepositories, detectedOsVersion, nil
 }
 
 func (h *Handlers) buildUploadOptions(ctx echo.Context, ur UploadRequest, it ImageTypes) (composer.UploadOptions, composer.ImageTypes, error) {
@@ -905,7 +934,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 	res := &composer.Customizations{}
 
 	if cr.ImageRequests[0].ContentTemplate != nil {
-		templatePayloadRepositories, templateCustomRepositories, _, err := h.buildTemplateRepositories(ctx, *cr.ImageRequests[0].ContentTemplate)
+		templatePayloadRepositories, templateCustomRepositories, _, _, err := h.buildTemplateRepositories(ctx, *cr.ImageRequests[0].ContentTemplate)
 		if err != nil {
 			return nil, err
 		}
@@ -979,7 +1008,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 					repoIDs = append(repoIDs, *payloadRepository.Id)
 				}
 			}
-			payloadRepositories, _, err := h.buildRepositorySnapshots(ctx, repoURLs, repoIDs, true, *snapshotDate)
+			payloadRepositories, _, _, err := h.buildRepositorySnapshots(ctx, repoURLs, repoIDs, true, *snapshotDate)
 			if err != nil {
 				return nil, err
 			}
@@ -1002,7 +1031,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 					repoIDs = append(repoIDs, repo.Id)
 				}
 			}
-			_, customRepositories, err := h.buildRepositorySnapshots(ctx, repoURLs, repoIDs, true, *snapshotDate)
+			_, customRepositories, _, err := h.buildRepositorySnapshots(ctx, repoURLs, repoIDs, true, *snapshotDate)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -3533,3 +3533,56 @@ func TestComposeWithLatestSnapshots(t *testing.T) {
 		composerRequest = composer.ComposeRequest{}
 	}
 }
+
+// TestComposeWithSnapshotDetectedOsVersion verifies that when content-sources returns a
+// detected_os_version on a snapshot, the compose request to osbuild-composer uses the
+// matching minor-version distribution instead of the distribution selected by the user.
+// This prevents builds from failing when osbuild-composer tries to install packages (e.g.
+// system-reinstall-bootc) that are only available in a newer minor version.
+func TestComposeWithSnapshotDetectedOsVersion(t *testing.T) {
+	var composerRequest composer.ComposeRequest
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer accesstoken", r.Header.Get("Authorization"))
+		err := json.NewDecoder(r.Body).Decode(&composerRequest)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		err = json.NewEncoder(w).Encode(composer.ComposeId{Id: uuid.New()})
+		require.NoError(t, err)
+	}))
+	defer apiSrv.Close()
+
+	// Use a CS mock that reports detected_os_version "9.4" for snapshots.
+	// The user requests "rhel-9" which normally maps to composer distribution "rhel-9.7",
+	// but the detected version should override it to "rhel-94".
+	srv := startServer(t, &testServerClientsConf{
+		ComposerURL: apiSrv.URL,
+		CSHandler:   mocks.ContentSourcesWithOsVersion(common.ToPtr("9.4")),
+	}, nil)
+	defer srv.Shutdown(t)
+
+	var uo v1.UploadRequest_Options
+	require.NoError(t, uo.FromAWSS3UploadRequestOptions(v1.AWSS3UploadRequestOptions{}))
+
+	ibRequest := v1.ComposeRequest{
+		Distribution: "rhel-9",
+		ImageRequests: []v1.ImageRequest{
+			{
+				Architecture: "x86_64",
+				ImageType:    v1.ImageTypesGuestImage,
+				SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
+				UploadRequest: v1.UploadRequest{
+					Type:    v1.UploadTypesAwsS3,
+					Options: uo,
+				},
+			},
+		},
+	}
+
+	respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", ibRequest)
+	require.Equal(t, http.StatusCreated, respStatusCode, "body: %s", body)
+
+	// The compose request should use "rhel-94" (the 9.4 minor-version distribution),
+	// NOT "rhel-9.7" which is what "rhel-9" would normally resolve to.
+	require.Equal(t, common.ToPtr("rhel-94"), composerRequest.Distribution)
+}

--- a/internal/v1/mocks/content_sources.go
+++ b/internal/v1/mocks/content_sources.go
@@ -156,17 +156,19 @@ func communityRepos(ids []string, urls []string) (res []content_sources.ApiRepos
 	return res
 }
 
-func snaps(uuids []string) (res []content_sources.ApiSnapshotForDate) {
+func snapsWithOsVersion(uuids []string, detectedOsVersion *string) (res []content_sources.ApiSnapshotForDate) {
 	if slices.Contains(uuids, RepoBaseID) {
-		res = append(res, content_sources.ApiSnapshotForDate{
+		snap := content_sources.ApiSnapshotForDate{
 			IsAfter: common.ToPtr(false),
 			Match: &content_sources.ApiSnapshotResponse{
-				CreatedAt:      common.ToPtr("1998-01-30T00:00:00Z"),
-				RepositoryPath: common.ToPtr("/snappy/baseos"),
-				Url:            common.ToPtr("http://snappy-url/snappy/baseos"),
+				CreatedAt:         common.ToPtr("1998-01-30T00:00:00Z"),
+				RepositoryPath:    common.ToPtr("/snappy/baseos"),
+				Url:               common.ToPtr("http://snappy-url/snappy/baseos"),
+				DetectedOsVersion: detectedOsVersion,
 			},
 			RepositoryUuid: common.ToPtr(RepoBaseID),
-		})
+		}
+		res = append(res, snap)
 	}
 
 	if slices.Contains(uuids, RepoAppstrID) {
@@ -377,77 +379,91 @@ func templateByID(uuid string) (res content_sources.ApiTemplateResponse) {
 }
 
 func ContentSources(w http.ResponseWriter, r *http.Request) {
-	if tutils.AuthString0 != r.Header.Get("x-rh-identity") {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
+	contentSourcesHandler(nil)(w, r)
+}
 
-	w.Header().Set("Content-Type", "application/json")
-	switch r.URL.Path {
-	case "/repositories/":
-		urlForm := r.URL.Query().Get("url")
-		urls := strings.Split(urlForm, ",")
+// ContentSourcesWithOsVersion returns a handler identical to ContentSources but
+// embeds the given detectedOsVersion in every snapshot-for-date response.
+// Pass a non-nil string to simulate content-sources reporting a specific OS
+// minor version (e.g. "9.4") for an older snapshot date.
+func ContentSourcesWithOsVersion(detectedOsVersion *string) http.HandlerFunc {
+	return contentSourcesHandler(detectedOsVersion)
+}
 
-		idForm := r.URL.Query().Get("uuid")
-		ids := strings.Split(idForm, ",")
+func contentSourcesHandler(detectedOsVersion *string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if tutils.AuthString0 != r.Header.Get("x-rh-identity") {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 
-		repos := []content_sources.ApiRepositoryResponse{}
-		switch r.URL.Query().Get("origin") {
-		case "red_hat":
-			repos = append(repos, rhRepos(ids, urls)...)
-		case "external,upload,community":
-			repos = append(repos, extRepos(ids, urls)...)
-			repos = append(repos, uploadRepos(ids, urls)...)
-			repos = append(repos, communityRepos(ids, urls)...)
-		}
-		err := json.NewEncoder(w).Encode(content_sources.ApiRepositoryCollectionResponse{
-			Data: &repos,
-		})
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-	case "/snapshots/for_date/":
-		var body content_sources.ApiListSnapshotByDateRequest
-		err := json.NewDecoder(r.Body).Decode(&body)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		if body.Date != "1999-01-30T00:00:00Z" {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		err = json.NewEncoder(w).Encode(content_sources.ApiListSnapshotByDateResponse{
-			Data: common.ToPtr(snaps(body.RepositoryUuids)),
-		})
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-	case "/repositories/bulk_export/":
-		var body content_sources.ApiRepositoryExportRequest
-		err := json.NewDecoder(r.Body).Decode(&body)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		err = json.NewEncoder(w).Encode(exports(body.RepositoryUuids))
-		if err != nil {
-			w.WriteHeader(http.StatusInsufficientStorage)
-			return
-		}
-	}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repositories/":
+			urlForm := r.URL.Query().Get("url")
+			urls := strings.Split(urlForm, ",")
 
-	if strings.HasPrefix(r.URL.Path, "/templates/") {
-		pathParts := strings.Split(strings.TrimPrefix(r.URL.Path, "/templates/"), "/")
-		if len(pathParts) == 1 {
-			uuid := pathParts[0]
-			err := json.NewEncoder(w).Encode(templateByID(uuid))
+			idForm := r.URL.Query().Get("uuid")
+			ids := strings.Split(idForm, ",")
+
+			repos := []content_sources.ApiRepositoryResponse{}
+			switch r.URL.Query().Get("origin") {
+			case "red_hat":
+				repos = append(repos, rhRepos(ids, urls)...)
+			case "external,upload,community":
+				repos = append(repos, extRepos(ids, urls)...)
+				repos = append(repos, uploadRepos(ids, urls)...)
+				repos = append(repos, communityRepos(ids, urls)...)
+			}
+			err := json.NewEncoder(w).Encode(content_sources.ApiRepositoryCollectionResponse{
+				Data: &repos,
+			})
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		case "/snapshots/for_date/":
+			var body content_sources.ApiListSnapshotByDateRequest
+			err := json.NewDecoder(r.Body).Decode(&body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if body.Date != "1999-01-30T00:00:00Z" {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			err = json.NewEncoder(w).Encode(content_sources.ApiListSnapshotByDateResponse{
+				Data: common.ToPtr(snapsWithOsVersion(body.RepositoryUuids, detectedOsVersion)),
+			})
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		case "/repositories/bulk_export/":
+			var body content_sources.ApiRepositoryExportRequest
+			err := json.NewDecoder(r.Body).Decode(&body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			err = json.NewEncoder(w).Encode(exports(body.RepositoryUuids))
 			if err != nil {
 				w.WriteHeader(http.StatusInsufficientStorage)
+				return
 			}
-			return
+		}
+
+		if strings.HasPrefix(r.URL.Path, "/templates/") {
+			pathParts := strings.Split(strings.TrimPrefix(r.URL.Path, "/templates/"), "/")
+			if len(pathParts) == 1 {
+				uuid := pathParts[0]
+				err := json.NewEncoder(w).Encode(templateByID(uuid))
+				if err != nil {
+					w.WriteHeader(http.StatusInsufficientStorage)
+				}
+				return
+			}
 		}
 	}
 }

--- a/internal/v1/server_test.go
+++ b/internal/v1/server_test.go
@@ -108,6 +108,7 @@ type testServerClientsConf struct {
 	RecommendURL string
 	OAuthURL     string
 	Proxy        string
+	CSHandler    http.HandlerFunc
 }
 
 type testServer struct {
@@ -145,7 +146,11 @@ func startServer(t *testing.T, tscc *testServerClientsConf, conf *v1.ServerConfi
 	})
 	require.NoError(t, err)
 
-	csSrv := httptest.NewServer(http.HandlerFunc(mocks.ContentSources))
+	csHandler := http.HandlerFunc(mocks.ContentSources)
+	if tscc.CSHandler != nil {
+		csHandler = tscc.CSHandler
+	}
+	csSrv := httptest.NewServer(csHandler)
 	csClient, err := content_sources.NewClient(content_sources.ContentSourcesClientConfig{
 		URL: csSrv.URL,
 	})


### PR DESCRIPTION
Fixes ![HMS-8659](https://redhat.atlassian.net/browse/HMS-8659)

When using snapshots or content templates, check the snapshots for a detected_os_version.  If one is found, use that to determine the image builder distribution to use. 

Note that this was largely built with cursor using the bug report as the main prompt, but i have reviewed the code and the test.  If there's a way to test this locally, let me know, otherwise it will be easy to test in stage.




[HMS-8659]: https://redhat.atlassian.net/browse/HMS-8659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ