### PR TITLE
Handle empty string for detectedOsVersion

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -463,8 +463,10 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 		customRepo.CheckRepoGpg = repo.MetadataVerification
 		customRepositories = append(customRepositories, customRepo)
 
-		// Capture the first detected OS version seen across all snapshots.
-		if detectedOsVersion == nil && snap.Match.DetectedOsVersion != nil {
+		// Capture the first non-empty detected OS version seen across all snapshots.
+		// Only baseos snapshots carry a meaningful version; other snapshots may
+		// return an empty string, so we skip those.
+		if detectedOsVersion == nil && snap.Match.DetectedOsVersion != nil && *snap.Match.DetectedOsVersion != "" {
 			detectedOsVersion = snap.Match.DetectedOsVersion
 		}
 	}
@@ -679,8 +681,10 @@ func (h *Handlers) buildTemplateRepositories(ctx echo.Context, templateID string
 			return payloadRepositories, customRepositories, rhRepositories, detectedOsVersion, fmt.Errorf("No repository UUID is associated with this snapshot")
 		}
 
-		// Capture the first detected OS version seen across all template snapshots.
-		if detectedOsVersion == nil && snap.DetectedOsVersion != nil {
+		// Capture the first non-empty detected OS version seen across all template
+		// snapshots. Only baseos snapshots carry a meaningful version; other
+		// snapshots may return an empty string, so we skip those.
+		if detectedOsVersion == nil && snap.DetectedOsVersion != nil && *snap.DetectedOsVersion != "" {
 			detectedOsVersion = snap.DetectedOsVersion
 		}
 

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -3585,3 +3585,52 @@ func TestComposeWithSnapshotDetectedOsVersion(t *testing.T) {
 	// NOT "rhel-9.7" which is what "rhel-9" would normally resolve to.
 	require.Equal(t, common.ToPtr("rhel-94"), composerRequest.Distribution)
 }
+
+// TestComposeWithSnapshotEmptyDetectedOsVersion verifies that when content-sources
+// returns an empty string for detected_os_version (e.g. for non-baseos repos), the
+// distribution is not overridden. Empty strings are non-nil in Go and must be skipped
+// to avoid blocking a valid version from a later snapshot.
+func TestComposeWithSnapshotEmptyDetectedOsVersion(t *testing.T) {
+	var composerRequest composer.ComposeRequest
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer accesstoken", r.Header.Get("Authorization"))
+		err := json.NewDecoder(r.Body).Decode(&composerRequest)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		err = json.NewEncoder(w).Encode(composer.ComposeId{Id: uuid.New()})
+		require.NoError(t, err)
+	}))
+	defer apiSrv.Close()
+
+	srv := startServer(t, &testServerClientsConf{
+		ComposerURL: apiSrv.URL,
+		CSHandler:   mocks.ContentSourcesWithOsVersion(common.ToPtr("")),
+	}, nil)
+	defer srv.Shutdown(t)
+
+	var uo v1.UploadRequest_Options
+	require.NoError(t, uo.FromAWSS3UploadRequestOptions(v1.AWSS3UploadRequestOptions{}))
+
+	ibRequest := v1.ComposeRequest{
+		Distribution: "rhel-9",
+		ImageRequests: []v1.ImageRequest{
+			{
+				Architecture: "x86_64",
+				ImageType:    v1.ImageTypesGuestImage,
+				SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
+				UploadRequest: v1.UploadRequest{
+					Type:    v1.UploadTypesAwsS3,
+					Options: uo,
+				},
+			},
+		},
+	}
+
+	respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", ibRequest)
+	require.Equal(t, http.StatusCreated, respStatusCode, "body: %s", body)
+
+	// Empty detected_os_version should be ignored — the compose should use the
+	// default "rhel-9.7" distribution, not attempt to look up an empty version.
+	require.Equal(t, common.ToPtr("rhel-9.7"), composerRequest.Distribution)
+}

--- a/internal/v1/mocks/content_sources.go
+++ b/internal/v1/mocks/content_sources.go
@@ -175,9 +175,10 @@ func snapsWithOsVersion(uuids []string, detectedOsVersion *string) (res []conten
 		res = append(res, content_sources.ApiSnapshotForDate{
 			IsAfter: common.ToPtr(false),
 			Match: &content_sources.ApiSnapshotResponse{
-				CreatedAt:      common.ToPtr("1998-01-30T00:00:00Z"),
-				RepositoryPath: common.ToPtr("/snappy/appstream"),
-				Url:            common.ToPtr("http://snappy-url/snappy/appstream"),
+				CreatedAt:         common.ToPtr("1998-01-30T00:00:00Z"),
+				RepositoryPath:    common.ToPtr("/snappy/appstream"),
+				Url:               common.ToPtr("http://snappy-url/snappy/appstream"),
+				DetectedOsVersion: common.ToPtr(""),
 			},
 			RepositoryUuid: common.ToPtr(RepoAppstrID),
 		})
@@ -187,9 +188,10 @@ func snapsWithOsVersion(uuids []string, detectedOsVersion *string) (res []conten
 		res = append(res, content_sources.ApiSnapshotForDate{
 			IsAfter: common.ToPtr(false),
 			Match: &content_sources.ApiSnapshotResponse{
-				CreatedAt:      common.ToPtr("1998-01-30T00:00:00Z"),
-				RepositoryPath: common.ToPtr("/snappy/payload"),
-				Url:            common.ToPtr("http://snappy-url/snappy/payload"),
+				CreatedAt:         common.ToPtr("1998-01-30T00:00:00Z"),
+				RepositoryPath:    common.ToPtr("/snappy/payload"),
+				Url:               common.ToPtr("http://snappy-url/snappy/payload"),
+				DetectedOsVersion: common.ToPtr(""),
 			},
 			RepositoryUuid: common.ToPtr(RepoPLID),
 		})
@@ -199,9 +201,10 @@ func snapsWithOsVersion(uuids []string, detectedOsVersion *string) (res []conten
 		res = append(res, content_sources.ApiSnapshotForDate{
 			IsAfter: common.ToPtr(false),
 			Match: &content_sources.ApiSnapshotResponse{
-				CreatedAt:      common.ToPtr("1998-01-30T00:00:00Z"),
-				RepositoryPath: common.ToPtr("/snappy/payload2"),
-				Url:            common.ToPtr("http://snappy-url/snappy/payload2"),
+				CreatedAt:         common.ToPtr("1998-01-30T00:00:00Z"),
+				RepositoryPath:    common.ToPtr("/snappy/payload2"),
+				Url:               common.ToPtr("http://snappy-url/snappy/payload2"),
+				DetectedOsVersion: common.ToPtr(""),
 			},
 			RepositoryUuid: common.ToPtr(RepoPLID2),
 		})
@@ -211,9 +214,10 @@ func snapsWithOsVersion(uuids []string, detectedOsVersion *string) (res []conten
 		res = append(res, content_sources.ApiSnapshotForDate{
 			IsAfter: common.ToPtr(false),
 			Match: &content_sources.ApiSnapshotResponse{
-				CreatedAt:      common.ToPtr("1998-01-30T00:00:00Z"),
-				RepositoryPath: common.ToPtr("/snappy/payload3"),
-				Url:            common.ToPtr("http://snappy-url/snappy/payload3"),
+				CreatedAt:         common.ToPtr("1998-01-30T00:00:00Z"),
+				RepositoryPath:    common.ToPtr("/snappy/payload3"),
+				Url:               common.ToPtr("http://snappy-url/snappy/payload3"),
+				DetectedOsVersion: common.ToPtr(""),
 			},
 			RepositoryUuid: common.ToPtr(RepoPLID3),
 		})
@@ -223,9 +227,10 @@ func snapsWithOsVersion(uuids []string, detectedOsVersion *string) (res []conten
 		res = append(res, content_sources.ApiSnapshotForDate{
 			IsAfter: common.ToPtr(false),
 			Match: &content_sources.ApiSnapshotResponse{
-				CreatedAt:      common.ToPtr("1998-01-30T00:00:00Z"),
-				RepositoryPath: common.ToPtr("/snappy/epel10"),
-				Url:            common.ToPtr("http://snappy-url/snappy/epel10"),
+				CreatedAt:         common.ToPtr("1998-01-30T00:00:00Z"),
+				RepositoryPath:    common.ToPtr("/snappy/epel10"),
+				Url:               common.ToPtr("http://snappy-url/snappy/epel10"),
+				DetectedOsVersion: common.ToPtr(""),
 			},
 			RepositoryUuid: common.ToPtr(RepoSharedEpelID),
 		})


### PR DESCRIPTION
The previous change https://github.com/osbuild/image-builder-crc/pull/1789 anticipated that content sources would return nil for detectedOSVersion, but it actually returns empty string.  This can cause the detection not to work, as it would be set to ""  which would cause it to default to rhel-9/rhel-10