### PR TITLE
many: support bootc compose requests (HMS-10356)

### DIFF
--- a/distributions/rhel-10.1/rhel-10.1.json
+++ b/distributions/rhel-10.1/rhel-10.1.json
@@ -9,10 +9,10 @@
   },
   "x86_64": {
     "bootc": [
-      { "id": "rhel-10.1-ec2", "type": "ec2", "reference": "rhel/10.1-ec2" },
-      { "id": "rhel-10.1-gcp", "type": "gcp", "reference": "rhel/10.1-gcp" },
-      { "id": "rhel-10.1-azure", "type": "azure", "reference": "rhel/10.1-azure" },
-      { "id": "rhel-10.1-qcow2", "type": "qcow2", "reference": "rhel/10.1-qcow2" }
+      { "type": "ec2", "reference": "rhel/10.1-ec2" },
+      { "type": "gcp", "reference": "rhel/10.1-gcp" },
+      { "type": "azure", "reference": "rhel/10.1-azure" },
+      { "type": "qcow2", "reference": "rhel/10.1-qcow2" }
     ],
     "image_types": ["aws", "azure", "gcp", "guest-image", "image-installer", "network-installer", "oci", "pxe-tar-xz", "vsphere", "vsphere-ova", "wsl"],
     "repositories": [{

--- a/distributions/rhel-10.1/rhel-10.1.json
+++ b/distributions/rhel-10.1/rhel-10.1.json
@@ -9,10 +9,10 @@
   },
   "x86_64": {
     "bootc": [
-      { "id": "rhel-10.1-ec2", "type": "ec2", "image_name": "rhel/10.1-ec2" },
-      { "id": "rhel-10.1-gcp", "type": "gcp", "image_name": "rhel/10.1-gcp" },
-      { "id": "rhel-10.1-azure", "type": "azure", "image_name": "rhel/10.1-azure" },
-      { "id": "rhel-10.1-qcow2", "type": "qcow2", "image_name": "rhel/10.1-qcow2" }
+      { "id": "rhel-10.1-ec2", "type": "ec2", "reference": "rhel/10.1-ec2" },
+      { "id": "rhel-10.1-gcp", "type": "gcp", "reference": "rhel/10.1-gcp" },
+      { "id": "rhel-10.1-azure", "type": "azure", "reference": "rhel/10.1-azure" },
+      { "id": "rhel-10.1-qcow2", "type": "qcow2", "reference": "rhel/10.1-qcow2" }
     ],
     "image_types": ["aws", "azure", "gcp", "guest-image", "image-installer", "network-installer", "oci", "pxe-tar-xz", "vsphere", "vsphere-ova", "wsl"],
     "repositories": [{

--- a/distributions/rhel-10.1/rhel-10.1.json
+++ b/distributions/rhel-10.1/rhel-10.1.json
@@ -9,10 +9,10 @@
   },
   "x86_64": {
     "bootc": [
-      { "type": "ec2", "reference": "rhel/10.1-ec2" },
-      { "type": "gcp", "reference": "rhel/10.1-gcp" },
-      { "type": "azure", "reference": "rhel/10.1-azure" },
-      { "type": "qcow2", "reference": "rhel/10.1-qcow2" }
+      { "type": "aws", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest" },
+      { "type": "gcp", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-gcp:latest" },
+      { "type": "azure", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-azure:latest" },
+      { "type": "guest-image", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest" }
     ],
     "image_types": ["aws", "azure", "gcp", "guest-image", "image-installer", "network-installer", "oci", "pxe-tar-xz", "vsphere", "vsphere-ova", "wsl"],
     "repositories": [{

--- a/internal/distribution/bootc_distributions.go
+++ b/internal/distribution/bootc_distributions.go
@@ -1,7 +1,6 @@
 package distribution
 
 type BootcDistributionEntry struct {
-	ID        string `json:"id"`
 	Distro    string `json:"distro"`
 	Name      string `json:"name"`
 	Type      string `json:"type"`

--- a/internal/distribution/bootc_distributions.go
+++ b/internal/distribution/bootc_distributions.go
@@ -6,5 +6,5 @@ type BootcDistributionEntry struct {
 	Name      string `json:"name"`
 	Type      string `json:"type"`
 	Arch      string `json:"arch"`
-	ImageName string `json:"image_name"`
+	Reference string `json:"reference"`
 }

--- a/internal/distribution/bootc_distributions.go
+++ b/internal/distribution/bootc_distributions.go
@@ -1,9 +1,21 @@
 package distribution
 
+import "fmt"
+
 type BootcDistributionEntry struct {
 	Distro    string `json:"distro"`
 	Name      string `json:"name"`
 	Type      string `json:"type"`
 	Arch      string `json:"arch"`
 	Reference string `json:"reference"`
+}
+
+func (arch Architecture) ValidateBootcReference(reference string) error {
+	for _, image := range arch.Bootc {
+		if image.Reference == reference {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("bootc reference '%s' not found", reference)
 }

--- a/internal/distribution/bootc_distributions_test.go
+++ b/internal/distribution/bootc_distributions_test.go
@@ -17,7 +17,7 @@ func TestCollectBootcFromRegistry(t *testing.T) {
 		require.Equal(t, "Test distro with bootc entries", list[0].Name)
 		require.Equal(t, "ec2", list[0].Type)
 		require.Equal(t, "x86_64", list[0].Arch)
-		require.Equal(t, "test/ec2", list[0].ImageName)
+		require.Equal(t, "test/ec2", list[0].Reference)
 	})
 
 	t.Run("empty registry returns empty list", func(t *testing.T) {

--- a/internal/distribution/bootc_distributions_test.go
+++ b/internal/distribution/bootc_distributions_test.go
@@ -16,7 +16,7 @@ func TestCollectBootcFromRegistry(t *testing.T) {
 		require.Equal(t, "Test distro with bootc entries", list[0].Name)
 		require.Equal(t, "ec2", list[0].Type)
 		require.Equal(t, "x86_64", list[0].Arch)
-		require.Equal(t, "test/ec2", list[0].Reference)
+		require.Equal(t, "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest", list[0].Reference)
 	})
 
 	t.Run("empty registry returns empty list", func(t *testing.T) {

--- a/internal/distribution/bootc_distributions_test.go
+++ b/internal/distribution/bootc_distributions_test.go
@@ -6,6 +6,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestArchitectureValidateBootcReference(t *testing.T) {
+	t.Run("returns nil when reference matches a bootc entry", func(t *testing.T) {
+		arch := Architecture{
+			Bootc: []BootcImage{
+				{Type: "ec2", Reference: "ref-ec2"},
+				{Type: "gcp", Reference: "ref-gcp"},
+			},
+		}
+		require.NoError(t, arch.ValidateBootcReference("ref-ec2"))
+		require.NoError(t, arch.ValidateBootcReference("ref-gcp"))
+	})
+
+	t.Run("returns error when reference is not in bootc list", func(t *testing.T) {
+		arch := Architecture{
+			Bootc: []BootcImage{{Type: "ec2", Reference: "r"}},
+		}
+		err := arch.ValidateBootcReference("other-ref")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bootc reference 'other-ref' not found")
+	})
+
+	t.Run("returns error when bootc list is empty", func(t *testing.T) {
+		arch := Architecture{Bootc: []BootcImage{}}
+		err := arch.ValidateBootcReference("any-ref")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bootc reference 'any-ref' not found")
+	})
+}
+
 func TestCollectBootcFromRegistry(t *testing.T) {
 	t.Run("collects bootc from distro architectures", func(t *testing.T) {
 		adr, err := LoadDistroRegistry("testdata/distributions")

--- a/internal/distribution/bootc_distributions_test.go
+++ b/internal/distribution/bootc_distributions_test.go
@@ -12,7 +12,6 @@ func TestCollectBootcFromRegistry(t *testing.T) {
 		require.NoError(t, err)
 		list := adr.CollectBootcFromRegistry()
 		require.Len(t, list, 1)
-		require.Equal(t, "with-bootc-ec2", list[0].ID)
 		require.Equal(t, "with-bootc", list[0].Distro)
 		require.Equal(t, "Test distro with bootc entries", list[0].Name)
 		require.Equal(t, "ec2", list[0].Type)

--- a/internal/distribution/bootc_distributions_test.go
+++ b/internal/distribution/bootc_distributions_test.go
@@ -7,50 +7,101 @@ import (
 )
 
 func TestArchitectureValidateBootcReference(t *testing.T) {
-	t.Run("returns nil when reference matches a bootc entry", func(t *testing.T) {
-		arch := Architecture{
-			Bootc: []BootcImage{
-				{Type: "ec2", Reference: "ref-ec2"},
-				{Type: "gcp", Reference: "ref-gcp"},
-			},
-		}
-		require.NoError(t, arch.ValidateBootcReference("ref-ec2"))
-		require.NoError(t, arch.ValidateBootcReference("ref-gcp"))
-	})
+	archBoth := Architecture{
+		Bootc: []BootcImage{
+			{Type: "ec2", Reference: "ref-ec2"},
+			{Type: "gcp", Reference: "ref-gcp"},
+		},
+	}
+	archEC2Only := Architecture{
+		Bootc: []BootcImage{{Type: "ec2", Reference: "r"}},
+	}
+	archEmpty := Architecture{Bootc: []BootcImage{}}
 
-	t.Run("returns error when reference is not in bootc list", func(t *testing.T) {
-		arch := Architecture{
-			Bootc: []BootcImage{{Type: "ec2", Reference: "r"}},
-		}
-		err := arch.ValidateBootcReference("other-ref")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "bootc reference 'other-ref' not found")
-	})
+	tests := []struct {
+		name         string
+		arch         Architecture
+		reference    string
+		wantErr      bool
+		errSubstring string
+	}{
+		{
+			name:      "reference matches first bootc entry",
+			arch:      archBoth,
+			reference: "ref-ec2",
+		},
+		{
+			name:      "reference matches second bootc entry",
+			arch:      archBoth,
+			reference: "ref-gcp",
+		},
+		{
+			name:         "reference not in bootc list",
+			arch:         archEC2Only,
+			reference:    "other-ref",
+			wantErr:      true,
+			errSubstring: "bootc reference 'other-ref' not found",
+		},
+		{
+			name:         "empty bootc list",
+			arch:         archEmpty,
+			reference:    "any-ref",
+			wantErr:      true,
+			errSubstring: "bootc reference 'any-ref' not found",
+		},
+	}
 
-	t.Run("returns error when bootc list is empty", func(t *testing.T) {
-		arch := Architecture{Bootc: []BootcImage{}}
-		err := arch.ValidateBootcReference("any-ref")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "bootc reference 'any-ref' not found")
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.arch.ValidateBootcReference(tt.reference)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errSubstring)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestCollectBootcFromRegistry(t *testing.T) {
-	t.Run("collects bootc from distro architectures", func(t *testing.T) {
-		adr, err := LoadDistroRegistry("testdata/distributions")
-		require.NoError(t, err)
-		list := adr.CollectBootcFromRegistry()
-		require.Len(t, list, 1)
-		require.Equal(t, "with-bootc", list[0].Distro)
-		require.Equal(t, "Test distro with bootc entries", list[0].Name)
-		require.Equal(t, "ec2", list[0].Type)
-		require.Equal(t, "x86_64", list[0].Arch)
-		require.Equal(t, "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest", list[0].Reference)
-	})
+	loaded, err := LoadDistroRegistry("testdata/distributions")
+	require.NoError(t, err)
 
-	t.Run("empty registry returns empty list", func(t *testing.T) {
-		adr := &AllDistroRegistry{distros: map[string]*DistributionFile{}}
-		list := adr.CollectBootcFromRegistry()
-		require.Empty(t, list)
-	})
+	tests := []struct {
+		name      string
+		registry  *AllDistroRegistry
+		want      []BootcDistributionEntry
+		wantEmpty bool
+	}{
+		{
+			name:     "collects bootc from distro architectures",
+			registry: loaded,
+			want: []BootcDistributionEntry{
+				{
+					Distro:    "with-bootc",
+					Name:      "Test distro with bootc entries",
+					Type:      "ec2",
+					Arch:      "x86_64",
+					Reference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest",
+				},
+			},
+		},
+		{
+			name:      "empty registry returns empty list",
+			registry:  &AllDistroRegistry{distros: map[string]*DistributionFile{}},
+			wantEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list := tt.registry.CollectBootcFromRegistry()
+			if tt.wantEmpty {
+				require.Empty(t, list)
+				return
+			}
+			require.Equal(t, tt.want, list)
+		})
+	}
 }

--- a/internal/distribution/distribution.go
+++ b/internal/distribution/distribution.go
@@ -44,9 +44,9 @@ type BootcImage struct {
 	ID string `json:"id"`
 	// Type is the target image type (e.g. "ec2", "gcp", "qcow2").
 	Type string `json:"type"`
-	// ImageName is the part of the container image reference used as the base for composing
+	// Reference is the part of the container image reference used as the base for composing
 	// (e.g. "rhel/10.1-ec2")
-	ImageName string `json:"image_name"`
+	Reference string `json:"reference"`
 }
 
 type Architecture struct {

--- a/internal/distribution/distribution.go
+++ b/internal/distribution/distribution.go
@@ -39,13 +39,10 @@ type DistributionFile struct {
 }
 
 type BootcImage struct {
-	// ID identifies the bootc entry, combining distribution version
-	// and target type (e.g. "rhel-10.1-ec2", "rhel-10.1-qcow2").
-	ID string `json:"id"`
 	// Type is the target image type (e.g. "ec2", "gcp", "qcow2").
 	Type string `json:"type"`
+
 	// Reference is the part of the container image reference used as the base for composing
-	// (e.g. "rhel/10.1-ec2")
 	Reference string `json:"reference"`
 }
 

--- a/internal/distribution/distroregistry.go
+++ b/internal/distribution/distroregistry.go
@@ -58,7 +58,7 @@ func (adr *AllDistroRegistry) CollectBootcFromRegistry() []BootcDistributionEntr
 					Name:      displayName,
 					Type:      b.Type,
 					Arch:      archName,
-					ImageName: b.ImageName,
+					Reference: b.Reference,
 				})
 			}
 		}

--- a/internal/distribution/distroregistry.go
+++ b/internal/distribution/distroregistry.go
@@ -53,7 +53,6 @@ func (adr *AllDistroRegistry) CollectBootcFromRegistry() []BootcDistributionEntr
 			}
 			for _, b := range arch.Bootc {
 				all = append(all, BootcDistributionEntry{
-					ID:        b.ID,
 					Distro:    d.Distribution.Name,
 					Name:      displayName,
 					Type:      b.Type,

--- a/internal/distribution/testdata/distributions/with-bootc/with-bootc.json
+++ b/internal/distribution/testdata/distributions/with-bootc/with-bootc.json
@@ -9,7 +9,7 @@
     "image_types": ["qcow2"],
     "repositories": [],
     "bootc": [
-      { "id": "with-bootc-ec2", "type": "ec2", "image_name": "test/ec2" }
+      { "id": "with-bootc-ec2", "type": "ec2", "reference": "test/ec2" }
     ]
   }
 }

--- a/internal/distribution/testdata/distributions/with-bootc/with-bootc.json
+++ b/internal/distribution/testdata/distributions/with-bootc/with-bootc.json
@@ -9,7 +9,7 @@
     "image_types": ["qcow2"],
     "repositories": [],
     "bootc": [
-      { "id": "with-bootc-ec2", "type": "ec2", "reference": "test/ec2" }
+      { "type": "ec2", "reference": "test/ec2" }
     ]
   }
 }

--- a/internal/distribution/testdata/distributions/with-bootc/with-bootc.json
+++ b/internal/distribution/testdata/distributions/with-bootc/with-bootc.json
@@ -9,7 +9,7 @@
     "image_types": ["qcow2"],
     "repositories": [],
     "bootc": [
-      { "type": "ec2", "reference": "test/ec2" }
+      { "type": "ec2", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest" }
     ]
   }
 }

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -680,7 +680,6 @@ type BootcBody struct {
 type BootcDistributionItem struct {
 	Arch   string `json:"arch"`
 	Distro string `json:"distro"`
-	Id     string `json:"id"`
 	Name   string `json:"name"`
 
 	// Reference Derived container image reference, only references listed in the bootc distributions list are allowed.
@@ -1530,7 +1529,7 @@ type GetComposesParams struct {
 // GetDistributionsParams defines parameters for GetDistributions.
 type GetDistributionsParams struct {
 	// Kind Kind of distributions to return. When set to 'bootc', returns bootc/image-mode
-	// distributions (each with id, name, type, arch, and reference). Defaults to classic distributions.
+	// distributions (each with distro, name, type, arch, and reference). Defaults to classic distributions.
 	Kind *DistributionKind `form:"kind,omitempty" json:"kind,omitempty"`
 
 	// Distro Filter bootc distributions by distribution name. Only applies when kind=bootc.

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -671,7 +671,7 @@ type BootMode = composer.ImageTypeInfoBootMode
 // BootcBody Bootc/Image Mode compose parameters. When present, the compose builds from the
 // specified bootc base image instead of the classic package-based flow.
 type BootcBody struct {
-	// Reference Image name from the bootc distributions list. Must match an image_name
+	// Reference Image name from the bootc distributions list. Must match a reference
 	// returned by GET /distributions?kind=bootc.
 	Reference string `json:"reference"`
 }
@@ -681,10 +681,10 @@ type BootcDistributionItem struct {
 	Arch   string `json:"arch"`
 	Distro string `json:"distro"`
 	Id     string `json:"id"`
+	Name   string `json:"name"`
 
-	// ImageName part of the container image name used as the base for composing
-	ImageName string `json:"image_name"`
-	Name      string `json:"name"`
+	// Reference part of the container image reference used as the base for composing
+	Reference string `json:"reference"`
 	Type      string `json:"type"`
 }
 
@@ -1530,7 +1530,7 @@ type GetComposesParams struct {
 // GetDistributionsParams defines parameters for GetDistributions.
 type GetDistributionsParams struct {
 	// Kind Kind of distributions to return. When set to 'bootc', returns bootc/image-mode
-	// distributions (each with id, name, type, arch, and image). Defaults to classic distributions.
+	// distributions (each with id, name, type, arch, and reference). Defaults to classic distributions.
 	Kind *DistributionKind `form:"kind,omitempty" json:"kind,omitempty"`
 
 	// Distro Filter bootc distributions by distribution name. Only applies when kind=bootc.

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -683,7 +683,7 @@ type BootcDistributionItem struct {
 	Id     string `json:"id"`
 	Name   string `json:"name"`
 
-	// Reference part of the container image reference used as the base for composing
+	// Reference Derived container image reference, only references listed in the bootc distributions list are allowed.
 	Reference string `json:"reference"`
 	Type      string `json:"type"`
 }

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -68,7 +68,7 @@ paths:
             $ref: '#/components/schemas/DistributionKind'
           description: |
             Kind of distributions to return. When set to 'bootc', returns bootc/image-mode
-            distributions (each with id, name, type, arch, and image). Defaults to classic distributions.
+            distributions (each with id, name, type, arch, and reference). Defaults to classic distributions.
         - in: query
           name: distro
           required: false
@@ -847,7 +847,7 @@ components:
         - name
         - type
         - arch
-        - image_name
+        - reference
       properties:
         id:
           type: string
@@ -864,9 +864,9 @@ components:
         arch:
           type: string
           example: 'x86_64'
-        image_name:
+        reference:
           type: string
-          description: 'part of the container image name used as the base for composing'
+          description: 'part of the container image reference used as the base for composing'
           example: 'rhel/10.0-ec2'
     BootcBody:
       type: object
@@ -879,7 +879,7 @@ components:
         reference:
           type: string
           description: |
-            Image name from the bootc distributions list. Must match an image_name
+            Image name from the bootc distributions list. Must match a reference
             returned by GET /distributions?kind=bootc.
           example: 'rhel/10.0-ec2'
     Architectures:

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -68,7 +68,7 @@ paths:
             $ref: '#/components/schemas/DistributionKind'
           description: |
             Kind of distributions to return. When set to 'bootc', returns bootc/image-mode
-            distributions (each with id, name, type, arch, and reference). Defaults to classic distributions.
+            distributions (each with distro, name, type, arch, and reference). Defaults to classic distributions.
         - in: query
           name: distro
           required: false
@@ -842,16 +842,12 @@ components:
     BootcDistributionItem:
       type: object
       required:
-        - id
         - distro
         - name
         - type
         - arch
         - reference
       properties:
-        id:
-          type: string
-          example: 'rhel-10.0-ec2'
         distro:
           type: string
           example: 'rhel-10.0'

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -90,7 +90,7 @@ paths:
           required: false
           schema:
             type: string
-            example: 'ec2'
+            example: 'aws'
           description: |
             Filter bootc distributions by image type. Only applies when kind=bootc.
       responses:
@@ -860,14 +860,14 @@ components:
           example: 'Red Hat Enterprise Linux 10.0'
         type:
           type: string
-          example: 'ec2'
+          example: 'aws'
         arch:
           type: string
           example: 'x86_64'
         reference:
           type: string
-          description: 'part of the container image reference used as the base for composing'
-          example: 'rhel/10.0-ec2'
+          description: 'Derived container image reference, only references listed in the bootc distributions list are allowed.'
+          example: 'quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest'
     BootcBody:
       type: object
       description: |
@@ -881,7 +881,7 @@ components:
           description: |
             Image name from the bootc distributions list. Must match a reference
             returned by GET /distributions?kind=bootc.
-          example: 'rhel/10.0-ec2'
+          example: 'quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest'
     Architectures:
       type: array
       items:

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -99,7 +99,7 @@ func (h *Handlers) GetDistributions(ctx echo.Context, params GetDistributionsPar
 				Name:      e.Name,
 				Type:      e.Type,
 				Arch:      e.Arch,
-				ImageName: e.ImageName,
+				Reference: e.Reference,
 			})
 			resp = append(resp, item)
 		}

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -94,7 +94,6 @@ func (h *Handlers) GetDistributions(ctx echo.Context, params GetDistributionsPar
 			}
 			var item DistributionsResponse_Item
 			_ = item.FromBootcDistributionItem(BootcDistributionItem{
-				Id:        e.ID,
 				Distro:    e.Distro,
 				Name:      e.Name,
 				Type:      e.Type,

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -85,6 +85,17 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 		return ComposeResponse{}, err
 	}
 
+	var bootc *composer.Bootc
+	if composeRequest.Bootc != nil {
+		err := arch.ValidateBootcReference(composeRequest.Bootc.Reference)
+		if err != nil {
+			return ComposeResponse{}, echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+		bootc = &composer.Bootc{
+			Reference: composeRequest.Bootc.Reference,
+		}
+	}
+
 	var customizations *composer.Customizations
 	customizations, err = h.buildCustomizations(ctx, &composeRequest, d)
 	if err != nil {
@@ -179,6 +190,7 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 		Distribution:   common.ToPtr(distro),
 		Customizations: customizations,
 		BlueprintId:    opts.BlueprintId,
+		Bootc:          bootc,
 		ImageRequest: &composer.ImageRequest{
 			Architecture:  string(composeRequest.ImageRequests[0].Architecture),
 			ImageType:     imageType,

--- a/internal/v1/handler_post_compose_bootc_test.go
+++ b/internal/v1/handler_post_compose_bootc_test.go
@@ -1,0 +1,147 @@
+package v1_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/image-builder-crc/internal/clients/composer"
+	"github.com/osbuild/image-builder-crc/internal/common"
+	"github.com/osbuild/image-builder-crc/internal/tutils"
+	v1 "github.com/osbuild/image-builder-crc/internal/v1"
+)
+
+func TestComposeBootcReferenceWithQuery(t *testing.T) {
+	distsDir := "../../distributions"
+
+	tests := []struct {
+		name          string
+		queryExtra    string
+		wantReference string
+		imageType     v1.ImageTypes
+		uploadType    v1.UploadTypes
+		uploadOpts    func(t *testing.T) v1.UploadRequest_Options
+	}{
+		{
+			name:          "aws uses bootc container reference from query",
+			queryExtra:    "distro=rhel-10.1&arch=x86_64&type=aws",
+			wantReference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest",
+			imageType:     v1.ImageTypesAws,
+			uploadType:    v1.UploadTypesAws,
+			uploadOpts: func(t *testing.T) v1.UploadRequest_Options {
+				var uo v1.UploadRequest_Options
+				require.NoError(t, uo.FromAWSUploadRequestOptions(v1.AWSUploadRequestOptions{
+					ShareWithAccounts: &[]string{"test-account"},
+				}))
+				return uo
+			},
+		},
+		{
+			name:          "guest-image uses bootc container reference from query",
+			queryExtra:    "distro=rhel-10.1&arch=x86_64&type=guest-image",
+			wantReference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest",
+			imageType:     v1.ImageTypesGuestImage,
+			uploadType:    v1.UploadTypesAwsS3,
+			uploadOpts: func(t *testing.T) v1.UploadRequest_Options {
+				var uo v1.UploadRequest_Options
+				require.NoError(t, uo.FromAWSS3UploadRequestOptions(v1.AWSS3UploadRequestOptions{}))
+				return uo
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wantComposeID := uuid.New()
+			var gotComposer composer.ComposeRequest
+
+			apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "Bearer accesstoken", r.Header.Get("Authorization"))
+				err := json.NewDecoder(r.Body).Decode(&gotComposer)
+				require.NoError(t, err)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				err = json.NewEncoder(w).Encode(composer.ComposeId{Id: wantComposeID})
+				require.NoError(t, err)
+			}))
+			defer apiSrv.Close()
+
+			srv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, &v1.ServerConfig{
+				DistributionsDir: distsDir,
+			})
+			defer srv.Shutdown(t)
+
+			distURL := srv.URL + "/api/image-builder/v1/distributions?kind=bootc&" + tt.queryExtra
+			status, body := tutils.GetResponseBody(t, distURL, &tutils.AuthString0)
+			require.Equal(t, http.StatusOK, status, body)
+			var bootcItems []v1.BootcDistributionItem
+			require.NoError(t, json.Unmarshal([]byte(body), &bootcItems))
+			require.Len(t, bootcItems, 1, body)
+			ref := bootcItems[0].Reference
+			require.NotEmpty(t, ref)
+			require.Equal(t, tt.wantReference, ref)
+
+			payload := v1.ComposeRequest{
+				Distribution: "rhel-10.1",
+				Bootc: &v1.BootcBody{
+					Reference: ref,
+				},
+				ImageRequests: []v1.ImageRequest{
+					{
+						Architecture: "x86_64",
+						ImageType:    tt.imageType,
+						UploadRequest: v1.UploadRequest{
+							Type:    tt.uploadType,
+							Options: tt.uploadOpts(t),
+						},
+					},
+				},
+			}
+
+			status, body = tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
+			require.Equal(t, http.StatusCreated, status, body)
+			var composeResp v1.ComposeResponse
+			require.NoError(t, json.Unmarshal([]byte(body), &composeResp))
+			require.Equal(t, wantComposeID, composeResp.Id)
+
+			require.NotNil(t, gotComposer.Bootc)
+			require.Equal(t, tt.wantReference, gotComposer.Bootc.Reference)
+			require.Equal(t, common.ToPtr("rhel-10.1"), gotComposer.Distribution)
+		})
+	}
+}
+
+func TestComposeBootcUnknownReferenceRejected(t *testing.T) {
+	srv := startServer(t, &testServerClientsConf{}, &v1.ServerConfig{
+		DistributionsDir: "../../distributions",
+	})
+	defer srv.Shutdown(t)
+
+	var uo v1.UploadRequest_Options
+	require.NoError(t, uo.FromAWSUploadRequestOptions(v1.AWSUploadRequestOptions{
+		ShareWithAccounts: &[]string{"test-account"},
+	}))
+	payload := v1.ComposeRequest{
+		Distribution: "rhel-10.1",
+		Bootc: &v1.BootcBody{
+			Reference: "quay.io/example/this-reference-is-not-in-the-distro-list:latest",
+		},
+		ImageRequests: []v1.ImageRequest{
+			{
+				Architecture: "x86_64",
+				ImageType:    v1.ImageTypesAws,
+				UploadRequest: v1.UploadRequest{
+					Type:    v1.UploadTypesAws,
+					Options: uo,
+				},
+			},
+		},
+	}
+	status, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
+	require.Equal(t, http.StatusBadRequest, status, body)
+	require.Contains(t, body, "bootc reference 'quay.io/example/this-reference-is-not-in-the-distro-list:latest' not found")
+}

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -919,6 +919,8 @@ func TestGetDistributions(t *testing.T) {
 func TestGetBootcDistributions(t *testing.T) {
 	distsDir := "../../distributions"
 	allowFile := "../common/testdata/allow.json"
+	rhel101BootcAWSRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest"
+	rhel101BootcGuestImageRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"
 
 	tests := []struct {
 		name     string
@@ -935,8 +937,8 @@ func TestGetBootcDistributions(t *testing.T) {
 				require.Equal(t, "rhel-10.1-ec2", result[0].Id)
 				require.Equal(t, "rhel-10.1", result[0].Distro)
 				require.Equal(t, "Red Hat Enterprise Linux (RHEL) 10", result[0].Name)
-				require.Equal(t, "ec2", result[0].Type)
-				require.Equal(t, "rhel/10.1-ec2", result[0].Reference)
+				require.Equal(t, "aws", result[0].Type)
+				require.Equal(t, rhel101BootcAWSRef, result[0].Reference)
 			},
 		},
 		{
@@ -971,20 +973,20 @@ func TestGetBootcDistributions(t *testing.T) {
 		},
 		{
 			name:    "filters by type",
-			query:   "kind=bootc&type=ec2",
+			query:   "kind=bootc&type=aws",
 			wantLen: 1,
 			check: func(t *testing.T, result []v1.BootcDistributionItem) {
-				require.Equal(t, "ec2", result[0].Type)
+				require.Equal(t, "aws", result[0].Type)
 			},
 		},
 		{
 			name:    "combines arch and type filters",
-			query:   "kind=bootc&arch=x86_64&type=qcow2",
+			query:   "kind=bootc&arch=x86_64&type=guest-image",
 			wantLen: 1,
 			check: func(t *testing.T, result []v1.BootcDistributionItem) {
-				require.Equal(t, "rhel-10.1-qcow2", result[0].Id)
+				require.Equal(t, rhel101BootcGuestImageRef, result[0].Reference)
 				require.Equal(t, "x86_64", result[0].Arch)
-				require.Equal(t, "qcow2", result[0].Type)
+				require.Equal(t, "guest-image", result[0].Type)
 			},
 		},
 		{

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -936,7 +936,7 @@ func TestGetBootcDistributions(t *testing.T) {
 				require.Equal(t, "rhel-10.1", result[0].Distro)
 				require.Equal(t, "Red Hat Enterprise Linux (RHEL) 10", result[0].Name)
 				require.Equal(t, "ec2", result[0].Type)
-				require.Equal(t, "rhel/10.1-ec2", result[0].ImageName)
+				require.Equal(t, "rhel/10.1-ec2", result[0].Reference)
 			},
 		},
 		{

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -934,7 +934,6 @@ func TestGetBootcDistributions(t *testing.T) {
 			query:   "kind=bootc",
 			wantLen: 4,
 			check: func(t *testing.T, result []v1.BootcDistributionItem) {
-				require.Equal(t, "rhel-10.1-ec2", result[0].Id)
 				require.Equal(t, "rhel-10.1", result[0].Distro)
 				require.Equal(t, "Red Hat Enterprise Linux (RHEL) 10", result[0].Name)
 				require.Equal(t, "aws", result[0].Type)


### PR DESCRIPTION
We rushed in an implementation based on "image ID", these turned useless since definitions are now part of regular (RPM) distros. It can be dropped now, we agreed on the following plan:

* [x] Drop ID from the distro definition, only image type and reference will be used
* [x] Make sure `reference` name is used to align with the composer api
* [x] Document the correct `reference` name and limitations
* [x] Make sure tags are part of the reference (currently only `latest`)
* [x] Lookup function will only use reference and will just validate
* [x] End to end that will query + use the reference

---

_Initially this PR had also some irrelevant optimalizations this was split into: https://github.com/osbuild/image-builder-crc/pull/1795_

https://redhat.atlassian.net/browse/HMS-10356