### PR TITLE
handler_blueprints: add Bootc to ComposeRequest

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -173,7 +173,6 @@ const (
 	Fedora42       Distributions = "fedora-42"
 	Fedora43       Distributions = "fedora-43"
 	Fedora44       Distributions = "fedora-44"
-	ImageMode      Distributions = "image-mode"
 	Rhel10         Distributions = "rhel-10"
 	Rhel100        Distributions = "rhel-10.0"
 	Rhel100Nightly Distributions = "rhel-10.0-nightly"
@@ -231,8 +230,6 @@ func (e Distributions) Valid() bool {
 	case Fedora43:
 		return true
 	case Fedora44:
-		return true
-	case ImageMode:
 		return true
 	case Rhel10:
 		return true

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1284,7 +1284,6 @@ components:
         - fedora-42
         - fedora-43
         - fedora-44
-        - image-mode
     ImageRequest:
       type: object
       additionalProperties: false

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -733,6 +733,7 @@ func (h *Handlers) ComposeBlueprint(ctx echo.Context, id openapi_types.UUID) err
 			ImageName:        &blueprintEntry.Name,
 			ImageDescription: &blueprintEntry.Description,
 			ClientId:         &clientId,
+			Bootc:            blueprint.Bootc,
 		}
 		composesResponse, err := h.handleCommonCompose(ctx, composeRequest, composeOpts{
 			BlueprintId:        &blueprintEntry.Id,


### PR DESCRIPTION
When a user triggers a compose from an image-mode blueprint, the bootc field was being dropped — the blueprint stored it correctly, but ComposeBlueprint never included it in the ComposeRequest passed to handleCommonCompose. This meant osbuild-composer received no bootc reference and built a non-bootc image.