### PR TITLE
v1: drop distribution from compose request if bootc is set

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -200,6 +200,12 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 			UploadOptions: &uploadOptions,
 		},
 	}
+	// XXX/HACK: Composer expects either bootc or distribution to be set, but not both. Ideally
+	// distribution is marked as no longer required in the API.
+	if cloudCR.Bootc != nil {
+		ctx.Logger().Infof("Dropped distribution %s from compose request, because bootc ref %s is set", cloudCR.Distribution, cloudCR.Bootc.Reference)
+		cloudCR.Distribution = nil
+	}
 
 	resp, err := h.server.cClient.Compose(ctx.Request().Context(), cloudCR)
 	if err != nil {

--- a/internal/v1/handler_post_compose_bootc_test.go
+++ b/internal/v1/handler_post_compose_bootc_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/image-builder-crc/internal/clients/composer"
-	"github.com/osbuild/image-builder-crc/internal/common"
 	"github.com/osbuild/image-builder-crc/internal/tutils"
 	v1 "github.com/osbuild/image-builder-crc/internal/v1"
 )
@@ -110,7 +109,7 @@ func TestComposeBootcReferenceWithQuery(t *testing.T) {
 
 			require.NotNil(t, gotComposer.Bootc)
 			require.Equal(t, tt.wantReference, gotComposer.Bootc.Reference)
-			require.Equal(t, common.ToPtr("rhel-10.1"), gotComposer.Distribution)
+			require.Nil(t, gotComposer.Distribution)
 		})
 	}
 }


### PR DESCRIPTION
Composer expects either bootc or distribution, but not both. Ideally this would be enforced, and distribution would no longer be required in the API. However, this might have unforseen consequences in the frontend and considering the tight deadline for this, add the hack for now.