### PR TITLE
unleash: add context support (HMS-10567)

### DIFF
--- a/internal/unleash/unleash.go
+++ b/internal/unleash/unleash.go
@@ -1,11 +1,15 @@
 package unleash
 
 import (
+	"context"
 	"fmt"
+	"maps"
 	"net/http"
 
 	"github.com/Unleash/unleash-client-go/v4"
 	ucontext "github.com/Unleash/unleash-client-go/v4/context"
+	fedora_identity "github.com/osbuild/community-gateway/oidc-authorizer/pkg/identity"
+	rh_identity "github.com/redhatinsights/identity"
 )
 
 type FeatureFlag string
@@ -14,7 +18,8 @@ const (
 	unleashProjectName = "default"
 	unleashAppName     = "image-builder"
 
-	CompliancePolicies FeatureFlag = "image-builder.compliance-policies.enabled"
+	CompliancePolicies  FeatureFlag = "image-builder.compliance-policies.enabled"
+	BootcDistroDisabled FeatureFlag = "image-builder.bootc-distro.disabled"
 )
 
 type Config struct {
@@ -37,7 +42,103 @@ func Initialize(conf Config) error {
 	return nil
 }
 
+// Enabled evaluates a feature flag without Unleash context.
 func Enabled(flag FeatureFlag) bool {
-	ctx := ucontext.Context{}
-	return unleash.IsEnabled(string(flag), unleash.WithContext(ctx), unleash.WithFallback(true))
+	return IsEnabled(ucontext.Context{}, string(flag))
+}
+
+// IsEnabled evaluates a feature flag with Unleash user context.
+func IsEnabled(uc ucontext.Context, name string) bool {
+	return IsEnabledWithFallback(uc, name, true)
+}
+
+// EnabledCtx evaluates a feature flag with Unleash context derived from the request context.
+func EnabledCtx(ctx context.Context, flag FeatureFlag) bool {
+	return IsEnabled(unleashContextFromRequest(ctx), string(flag))
+}
+
+// EnabledBootcCtx reports whether bootc is allowed for the distro / image-type combination.
+// It matches osDistro unleash flag against distroName first, then distroName+"-"+imageType.
+// For disable-style flags, evaluation uses fallback false so missing or unknown state does not hide bootc.
+func EnabledBootcCtx(ctx context.Context, flag FeatureFlag, distroName, imageType string) bool {
+	uc := unleashContextFromRequest(ctx)
+	if distroName != "" {
+		if !IsEnabledWithFallback(withOsDistro(uc, distroName), string(flag), false) {
+			return true
+		}
+	}
+	if imageType == "" {
+		return false
+	}
+	return !IsEnabledWithFallback(withOsDistro(uc, distroName+"-"+imageType), string(flag), false)
+}
+
+func withOsDistro(base ucontext.Context, osDistro string) ucontext.Context {
+	out := ucontext.Context{
+		UserId:        base.UserId,
+		SessionId:     base.SessionId,
+		RemoteAddress: base.RemoteAddress,
+		Environment:   base.Environment,
+		AppName:       base.AppName,
+		CurrentTime:   base.CurrentTime,
+		Properties:    make(map[string]string, len(base.Properties)+1),
+	}
+	maps.Copy(out.Properties, base.Properties)
+	if osDistro != "" {
+		out.Properties["osDistro"] = osDistro
+	}
+	return out
+}
+
+// IsEnabledWithFallback evaluates a feature flag (name, Unleash user context, SDK fallback default).
+// Defaults to the Unleash client; tests may temporarily replace this variable and restore it afterward.
+var IsEnabledWithFallback = defaultIsEnabledWithFallback
+
+func defaultIsEnabledWithFallback(uc ucontext.Context, name string, fallback bool) bool {
+	opts := []unleash.FeatureOption{unleash.WithFallback(fallback)}
+	if uc.UserId != "" || len(uc.Properties) > 0 {
+		opts = append(opts, unleash.WithContext(uc))
+	}
+	return unleash.IsEnabled(name, opts...)
+}
+
+func unleashContextFromRequest(ctx context.Context) ucontext.Context {
+	if xrhid, ok := rh_identity.Get(ctx); ok {
+		return unleashContextFromXRHID(xrhid)
+	}
+	if val := ctx.Value(fedora_identity.IDHeaderKey); val != nil {
+		if fid, ok := val.(*fedora_identity.Identity); ok {
+			return unleashContextFromFedora(fid)
+		}
+	}
+	return ucontext.Context{}
+}
+
+func unleashContextFromXRHID(xrhid rh_identity.XRHID) ucontext.Context {
+	uc := ucontext.Context{
+		Properties: map[string]string{},
+	}
+	if org := xrhid.Identity.OrgID; org != "" {
+		uc.Properties["orgId"] = org
+	}
+	user := xrhid.Identity.User.UserID
+	if user == "" {
+		user = xrhid.Identity.User.Username
+	}
+	if user == "" {
+		user = xrhid.Identity.AccountNumber
+	}
+	uc.UserId = user
+	return uc
+}
+
+func unleashContextFromFedora(fid *fedora_identity.Identity) ucontext.Context {
+	uc := ucontext.Context{
+		Properties: map[string]string{},
+	}
+	if fid.User != "" {
+		uc.UserId = fid.User
+		uc.Properties["orgId"] = fid.User
+	}
+	return uc
 }

--- a/internal/unleash/unleash_test.go
+++ b/internal/unleash/unleash_test.go
@@ -1,0 +1,147 @@
+package unleash
+
+import (
+	"context"
+	"testing"
+
+	ucontext "github.com/Unleash/unleash-client-go/v4/context"
+	fedora_identity "github.com/osbuild/community-gateway/oidc-authorizer/pkg/identity"
+	"github.com/stretchr/testify/require"
+
+	rh_identity "github.com/redhatinsights/identity"
+)
+
+func TestEnabled_and_EnabledCtx_swapped(t *testing.T) {
+	rhCtx := context.WithValue(t.Context(), rh_identity.Key, rh_identity.XRHID{
+		Identity: rh_identity.Identity{
+			OrgID: "org-42",
+			User:  rh_identity.User{Username: "bob"},
+		},
+	})
+	fdCtx := context.WithValue(t.Context(), fedora_identity.IDHeaderKey, &fedora_identity.Identity{
+		User: "fedora-user",
+	})
+
+	tests := []struct {
+		name string
+		stub func(t *testing.T, uc ucontext.Context, n string, fb bool) bool
+		call func() bool
+		want bool
+	}{
+		{
+			name: "Enabled empty uc fallback true",
+			stub: func(t *testing.T, uc ucontext.Context, n string, fb bool) bool {
+				require.Empty(t, uc.UserId)
+				require.True(t, fb)
+				require.Equal(t, string(CompliancePolicies), n)
+				return false
+			},
+			call: func() bool { return Enabled(CompliancePolicies) },
+			want: false,
+		},
+		{
+			name: "EnabledCtx RH identity",
+			stub: func(t *testing.T, uc ucontext.Context, n string, fb bool) bool {
+				require.Equal(t, string(CompliancePolicies), n)
+				require.Equal(t, "bob", uc.UserId)
+				require.Equal(t, "org-42", uc.Properties["orgId"])
+				require.True(t, fb)
+				return true
+			},
+			call: func() bool { return EnabledCtx(rhCtx, CompliancePolicies) },
+			want: true,
+		},
+		{
+			name: "EnabledCtx Fedora identity",
+			stub: func(t *testing.T, uc ucontext.Context, n string, fb bool) bool {
+				require.Equal(t, "fedora-user", uc.UserId)
+				require.Equal(t, "fedora-user", uc.Properties["orgId"])
+				return true
+			},
+			call: func() bool { return EnabledCtx(fdCtx, CompliancePolicies) },
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := IsEnabledWithFallback
+			t.Cleanup(func() { IsEnabledWithFallback = orig })
+			IsEnabledWithFallback = func(uc ucontext.Context, n string, fb bool) bool {
+				return tt.stub(t, uc, n, fb)
+			}
+			require.Equal(t, tt.want, tt.call())
+		})
+	}
+}
+
+func TestEnabledBootcCtx_swapped(t *testing.T) {
+	rhCtx := context.WithValue(t.Context(), rh_identity.Key, rh_identity.XRHID{
+		Identity: rh_identity.Identity{
+			OrgID: "1",
+			User:  rh_identity.User{Username: "u"},
+		},
+	})
+
+	tests := []struct {
+		name      string
+		stub      func(t *testing.T, calls *int) func(uc ucontext.Context, n string, fb bool) bool
+		call      func() bool
+		want      bool
+		wantCalls int
+	}{
+		{
+			name: "distro disabled then distro-type allowed",
+			stub: func(t *testing.T, calls *int) func(uc ucontext.Context, n string, fb bool) bool {
+				return func(uc ucontext.Context, n string, fb bool) bool {
+					*calls++
+					require.Equal(t, string(BootcDistroDisabled), n)
+					require.False(t, fb)
+					switch uc.Properties["osDistro"] {
+					case "rhel-9":
+						return true
+					case "rhel-9-aws":
+						return false
+					default:
+						t.Fatalf("unexpected osDistro %q", uc.Properties["osDistro"])
+						return false
+					}
+				}
+			},
+			call:      func() bool { return EnabledBootcCtx(rhCtx, BootcDistroDisabled, "rhel-9", "aws") },
+			want:      true,
+			wantCalls: 2,
+		},
+		{
+			name: "distro only blocked no imageType",
+			stub: func(t *testing.T, calls *int) func(uc ucontext.Context, n string, fb bool) bool {
+				return func(uc ucontext.Context, n string, fb bool) bool {
+					*calls++
+					require.Equal(t, "solo", uc.Properties["osDistro"])
+					return true
+				}
+			},
+			call:      func() bool { return EnabledBootcCtx(t.Context(), BootcDistroDisabled, "solo", "") },
+			want:      false,
+			wantCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := IsEnabledWithFallback
+			t.Cleanup(func() { IsEnabledWithFallback = orig })
+			var calls int
+			IsEnabledWithFallback = tt.stub(t, &calls)
+			require.Equal(t, tt.want, tt.call())
+			require.Equal(t, tt.wantCalls, calls)
+		})
+	}
+}
+
+func TestIsEnabledWithFallback_defaultDoesNotPanic(t *testing.T) {
+	orig := IsEnabledWithFallback
+	t.Cleanup(func() { IsEnabledWithFallback = orig })
+	IsEnabledWithFallback = defaultIsEnabledWithFallback
+	require.NotPanics(t, func() { _ = Enabled(CompliancePolicies) })
+}

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/osbuild/image-builder-crc/internal/common"
 	"github.com/osbuild/image-builder-crc/internal/db"
 	"github.com/osbuild/image-builder-crc/internal/distribution"
+	"github.com/osbuild/image-builder-crc/internal/unleash"
 	"github.com/osbuild/logging"
 )
 
@@ -90,6 +91,9 @@ func (h *Handlers) GetDistributions(ctx echo.Context, params GetDistributionsPar
 				continue
 			}
 			if params.Type != nil && e.Type != *params.Type {
+				continue
+			}
+			if !unleash.EnabledBootcCtx(ctx.Request().Context(), unleash.BootcDistroDisabled, e.Distro, e.Type) {
 				continue
 			}
 			var item DistributionsResponse_Item

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -1097,7 +1097,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 		}
 
 		if policy.PolicyId != uuid.Nil {
-			if !unleash.Enabled(unleash.CompliancePolicies) {
+			if !unleash.EnabledCtx(ctx.Request().Context(), unleash.CompliancePolicies) {
 				return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Feature %s not enabled", string(unleash.CompliancePolicies)))
 			}
 


### PR DESCRIPTION
This extends our unleash support with context with custom field `osDistro` that is used by the new `image-builder.bootc-distro.disabled` feature flag to filter out (hide) particular bootc distros and/or image types. This can be useful during the insights freeze.

With this change, `orgId` field in Unleash can be used to enable/disable features. This can be useful for gradual releases or kill switch per-organization, it is a bonus feature.

I also added tests, this is kind of hard to test as I do not have credentials for stage and I do not want to deploy my own instance just for this. @croissanne 