### PR TITLE
Add bootable-container-iso compose support (HMS-10569)

### DIFF
--- a/distributions/rhel-10.1/rhel-10.1.json
+++ b/distributions/rhel-10.1/rhel-10.1.json
@@ -12,7 +12,14 @@
       { "type": "aws", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest" },
       { "type": "gcp", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-gcp:latest" },
       { "type": "azure", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-azure:latest" },
-      { "type": "guest-image", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest" }
+      { "type": "guest-image", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest" },
+      {
+        "type": "bootable-container-iso",
+        "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest",
+        "iso_payload_references": [
+          "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"
+        ]
+      }
     ],
     "image_types": ["aws", "azure", "gcp", "guest-image", "image-installer", "network-installer", "oci", "pxe-tar-xz", "vsphere", "vsphere-ova", "wsl"],
     "repositories": [{

--- a/internal/clients/composer/openapi.v2.gen.go
+++ b/internal/clients/composer/openapi.v2.gen.go
@@ -285,6 +285,7 @@ const (
 	ImageTypesAzureRhui                  ImageTypes = "azure-rhui"
 	ImageTypesAzureSapRhui               ImageTypes = "azure-sap-rhui"
 	ImageTypesAzureSapappsRhui           ImageTypes = "azure-sapapps-rhui"
+	ImageTypesBootableContainerIso       ImageTypes = "bootable-container-iso"
 	ImageTypesEdgeCommit                 ImageTypes = "edge-commit"
 	ImageTypesEdgeContainer              ImageTypes = "edge-container"
 	ImageTypesEdgeInstaller              ImageTypes = "edge-installer"
@@ -334,6 +335,8 @@ func (e ImageTypes) Valid() bool {
 	case ImageTypesAzureSapRhui:
 		return true
 	case ImageTypesAzureSapappsRhui:
+		return true
+	case ImageTypesBootableContainerIso:
 		return true
 	case ImageTypesEdgeCommit:
 		return true
@@ -781,7 +784,12 @@ type BlueprintUser struct {
 
 // Bootc defines model for Bootc.
 type Bootc struct {
-	Reference string `json:"reference"`
+	// IsoPayloadReference Optional container image reference for a payload container to embed
+	// in the ISO's container storage. When set, the payload container is
+	// available at install/boot time. Only valid for bootable-container-iso
+	// image type.
+	IsoPayloadReference *string `json:"iso_payload_reference,omitempty"`
+	Reference           string  `json:"reference"`
 }
 
 // BtrfsSubvolume defines model for BtrfsSubvolume.

--- a/internal/clients/composer/openapi.v2.yml
+++ b/internal/clients/composer/openapi.v2.yml
@@ -1388,6 +1388,14 @@ components:
         reference:
           type: string
           example: "quay.io/centos-bootc/centos-bootc:stream9"
+        iso_payload_reference:
+          type: string
+          description: |
+            Optional container image reference for a payload container to embed
+            in the ISO's container storage. When set, the payload container is
+            available at install/boot time. Only valid for bootable-container-iso
+            image type.
+          example: "quay.io/centos-bootc/centos-bootc:stream9"
     ImageRequest:
       additionalProperties: false
       required:
@@ -1442,6 +1450,7 @@ components:
         - azure-rhui
         - azure-sapapps-rhui
         - azure-sap-rhui
+        - bootable-container-iso
         - edge-commit
         - edge-container
         - edge-installer

--- a/internal/distribution/distribution.go
+++ b/internal/distribution/distribution.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -44,6 +45,9 @@ type BootcImage struct {
 
 	// Reference is the part of the container image reference used as the base for composing
 	Reference string `json:"reference"`
+
+	// IsoPayloadReferences is a list of allowed payload container references for bootable-container-iso image type.
+	IsoPayloadReferences []string `json:"iso_payload_references,omitempty"`
 }
 
 type Architecture struct {
@@ -163,16 +167,21 @@ func (arch Architecture) FindPackages(search string) []Package {
 	return pkgs
 }
 
-func (arch *Architecture) ValidateBootcReference(reference string) error {
+func (arch *Architecture) ValidateBootcReferences(reference string, isoPayloadRef *string) error {
 	if arch == nil {
 		return fmt.Errorf("bootc reference '%s' not found", reference)
 	}
 	for _, image := range arch.Bootc {
 		if image.Reference == reference {
+			if isoPayloadRef == nil {
+				return nil
+			}
+			if !slices.Contains(image.IsoPayloadReferences, *isoPayloadRef) {
+				return fmt.Errorf("iso payload reference '%s' not found in allowed list for bootc reference '%s'", *isoPayloadRef, reference)
+			}
 			return nil
 		}
 	}
-
 	return fmt.Errorf("bootc reference '%s' not found", reference)
 }
 

--- a/internal/distribution/distribution_test.go
+++ b/internal/distribution/distribution_test.go
@@ -191,55 +191,123 @@ func TestArchitecture_validate(t *testing.T) {
 	}
 }
 
-func TestArchitecture_ValidateBootcReference(t *testing.T) {
+func TestArchitecture_ValidateBootcReferences(t *testing.T) {
 	archBoth := Architecture{
 		Bootc: []BootcImage{
 			{Type: "ec2", Reference: "ref-ec2"},
 			{Type: "gcp", Reference: "ref-gcp"},
 		},
 	}
-	archEC2Only := Architecture{
-		Bootc: []BootcImage{{Type: "ec2", Reference: "r"}},
+	archWithISO := Architecture{
+		Bootc: []BootcImage{
+			{Type: "aws", Reference: "ref-aws"},
+			{
+				Type:                 "bootable-container-iso",
+				Reference:            "ref-installer",
+				IsoPayloadReferences: []string{"ref-payload-1", "ref-payload-2"},
+			},
+		},
+	}
+	archISONoPayloads := Architecture{
+		Bootc: []BootcImage{
+			{
+				Type:      "bootable-container-iso",
+				Reference: "ref-installer-empty",
+			},
+		},
 	}
 	archEmpty := Architecture{Bootc: []BootcImage{}}
 
 	tests := []struct {
-		name         string
-		arch         Architecture
-		reference    string
-		wantErr      bool
-		errSubstring string
+		name          string
+		arch          *Architecture
+		reference     string
+		isoPayloadRef *string
+		errSubstring  string
 	}{
+		// Base ref only (isoPayloadRef = nil)
 		{
 			name:      "reference matches first bootc entry",
-			arch:      archBoth,
+			arch:      &archBoth,
 			reference: "ref-ec2",
 		},
 		{
 			name:      "reference matches second bootc entry",
-			arch:      archBoth,
+			arch:      &archBoth,
 			reference: "ref-gcp",
 		},
 		{
 			name:         "reference not in bootc list",
-			arch:         archEC2Only,
+			arch:         &archBoth,
 			reference:    "other-ref",
-			wantErr:      true,
 			errSubstring: "bootc reference 'other-ref' not found",
 		},
 		{
 			name:         "empty bootc list",
-			arch:         archEmpty,
+			arch:         &archEmpty,
 			reference:    "any-ref",
-			wantErr:      true,
 			errSubstring: "bootc reference 'any-ref' not found",
+		},
+		{
+			name:         "nil architecture",
+			arch:         nil,
+			reference:    "any-ref",
+			errSubstring: "bootc reference 'any-ref' not found",
+		},
+		// Base ref + payload ref (isoPayloadRef != nil)
+		{
+			name:          "valid installer ref + valid payload",
+			arch:          &archWithISO,
+			reference:     "ref-installer",
+			isoPayloadRef: common.ToPtr("ref-payload-1"),
+		},
+		{
+			name:          "valid installer ref + second valid payload",
+			arch:          &archWithISO,
+			reference:     "ref-installer",
+			isoPayloadRef: common.ToPtr("ref-payload-2"),
+		},
+		{
+			name:          "valid installer ref + unknown payload",
+			arch:          &archWithISO,
+			reference:     "ref-installer",
+			isoPayloadRef: common.ToPtr("ref-unknown"),
+			errSubstring:  "iso payload reference 'ref-unknown' not found in allowed list for bootc reference 'ref-installer'",
+		},
+		{
+			name:          "installer ref with no IsoPayloadReferences configured",
+			arch:          &archISONoPayloads,
+			reference:     "ref-installer-empty",
+			isoPayloadRef: common.ToPtr("ref-payload-1"),
+			errSubstring:  "iso payload reference 'ref-payload-1' not found in allowed list for bootc reference 'ref-installer-empty'",
+		},
+		{
+			name:          "non-ISO bootc ref with no IsoPayloadReferences + payload",
+			arch:          &archWithISO,
+			reference:     "ref-aws",
+			isoPayloadRef: common.ToPtr("ref-payload-1"),
+			errSubstring:  "iso payload reference 'ref-payload-1' not found in allowed list for bootc reference 'ref-aws'",
+		},
+		{
+			name:          "unknown installer ref + payload",
+			arch:          &archWithISO,
+			reference:     "ref-nonexistent",
+			isoPayloadRef: common.ToPtr("ref-payload-1"),
+			errSubstring:  "bootc reference 'ref-nonexistent' not found",
+		},
+		{
+			name:          "nil architecture + payload",
+			arch:          nil,
+			reference:     "ref-installer",
+			isoPayloadRef: common.ToPtr("ref-payload-1"),
+			errSubstring:  "bootc reference 'ref-installer' not found",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.arch.ValidateBootcReference(tt.reference)
-			if tt.wantErr {
+			err := tt.arch.ValidateBootcReferences(tt.reference, tt.isoPayloadRef)
+			if tt.errSubstring != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errSubstring)
 			} else {

--- a/internal/distribution/distroregistry.go
+++ b/internal/distribution/distroregistry.go
@@ -14,11 +14,12 @@ type AllDistroRegistry struct {
 }
 
 type BootcDistributionEntry struct {
-	Distro    string `json:"distro"`
-	Name      string `json:"name"`
-	Type      string `json:"type"`
-	Arch      string `json:"arch"`
-	Reference string `json:"reference"`
+	Distro               string   `json:"distro"`
+	Name                 string   `json:"name"`
+	Type                 string   `json:"type"`
+	Arch                 string   `json:"arch"`
+	Reference            string   `json:"reference"`
+	IsoPayloadReferences []string `json:"iso_payload_references,omitempty"`
 }
 
 // LoadDistroRegistry loads all distributions from distsDir
@@ -62,11 +63,12 @@ func (adr *AllDistroRegistry) CollectBootcFromRegistry() []BootcDistributionEntr
 			}
 			for _, b := range arch.Bootc {
 				all = append(all, BootcDistributionEntry{
-					Distro:    d.Distribution.Name,
-					Name:      displayName,
-					Type:      b.Type,
-					Arch:      archName,
-					Reference: b.Reference,
+					Distro:               d.Distribution.Name,
+					Name:                 displayName,
+					Type:                 b.Type,
+					Arch:                 archName,
+					Reference:            b.Reference,
+					IsoPayloadReferences: b.IsoPayloadReferences,
 				})
 			}
 		}
@@ -161,14 +163,17 @@ func (dr DistroRegistry) FindByMajorMinorStr(majorMinor string) string {
 	return d.Distribution.Name
 }
 
-func (dr DistroRegistry) ValidateBootcReference(reference string) error {
+func (dr DistroRegistry) ValidateBootcReferences(reference string, isoPayloadRef *string) error {
 	for _, d := range dr.distros {
-		if d.ArchX86.ValidateBootcReference(reference) == nil {
+		if d.ArchX86.ValidateBootcReferences(reference, isoPayloadRef) == nil {
 			return nil
 		}
-		if d.Aarch64.ValidateBootcReference(reference) == nil {
+		if d.Aarch64.ValidateBootcReferences(reference, isoPayloadRef) == nil {
 			return nil
 		}
+	}
+	if isoPayloadRef != nil {
+		return fmt.Errorf("bootc reference '%s' not found or iso payload reference '%s' not in its allowed list", reference, *isoPayloadRef)
 	}
 	return fmt.Errorf("bootc reference '%s' not found", reference)
 }

--- a/internal/distribution/distroregistry_test.go
+++ b/internal/distribution/distroregistry_test.go
@@ -1,7 +1,6 @@
 package distribution
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -167,23 +166,62 @@ func TestDistroRegistry_FindByMajorMinorStr(t *testing.T) {
 	}
 }
 
-func TestDistroRegistry_ValidateBootcReference(t *testing.T) {
+func TestDistroRegistry_ValidateBootcReferences(t *testing.T) {
 	dr, err := LoadDistroRegistry("./testdata/distributions")
 	require.NoError(t, err)
 	registry := dr.Available(true)
 
 	cases := []struct {
-		ref  string
-		err  error
-		desc string
+		desc          string
+		ref           string
+		isoPayloadRef *string
+		errSubstring  string
 	}{
-		{"quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest", nil, "returns nil error on valid reference"},
-		{"duck", fmt.Errorf("bootc reference 'duck' not found"), "returns error on invalid reference"},
+		// Base ref only
+		{
+			desc: "valid base reference",
+			ref:  "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest",
+		},
+		{
+			desc:         "unknown base reference",
+			ref:          "duck",
+			errSubstring: "bootc reference 'duck' not found",
+		},
+		// Base ref + payload
+		{
+			desc:          "valid installer ref + valid payload",
+			ref:           "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest",
+			isoPayloadRef: common.ToPtr("quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"),
+		},
+		{
+			desc:          "valid installer ref + unknown payload",
+			ref:           "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest",
+			isoPayloadRef: common.ToPtr("duck"),
+			errSubstring:  "iso payload reference 'duck' not in its allowed list",
+		},
+		{
+			desc:          "ec2 ref + any payload (no allowlist)",
+			ref:           "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest",
+			isoPayloadRef: common.ToPtr("duck"),
+			errSubstring:  "iso payload reference 'duck' not in its allowed list",
+		},
+		{
+			desc:          "unknown ref + payload",
+			ref:           "duck",
+			isoPayloadRef: common.ToPtr("any-payload"),
+			errSubstring:  "bootc reference 'duck' not found or iso payload reference 'any-payload' not in its allowed list",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			require.Equal(t, tc.err, registry.ValidateBootcReference(tc.ref))
+			err := registry.ValidateBootcReferences(tc.ref, tc.isoPayloadRef)
+			if tc.errSubstring != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errSubstring)
+				return
+			}
+			require.NoError(t, err)
 		})
 	}
 }
@@ -208,6 +246,14 @@ func TestDistroRegistry_CollectBootcFromRegistry(t *testing.T) {
 					Type:      "ec2",
 					Arch:      "x86_64",
 					Reference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest",
+				},
+				{
+					Distro:               "with-bootc",
+					Name:                 "Test distro with bootc entries",
+					Type:                 "bootable-container-iso",
+					Arch:                 "x86_64",
+					Reference:            "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest",
+					IsoPayloadReferences: []string{"quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"},
 				},
 			},
 		},

--- a/internal/distribution/testdata/distributions/with-bootc/with-bootc.json
+++ b/internal/distribution/testdata/distributions/with-bootc/with-bootc.json
@@ -9,7 +9,14 @@
     "image_types": ["qcow2"],
     "repositories": [],
     "bootc": [
-      { "type": "ec2", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest" }
+      { "type": "ec2", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest" },
+      {
+        "type": "bootable-container-iso",
+        "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest",
+        "iso_payload_references": [
+          "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"
+        ]
+      }
     ]
   }
 }

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -370,23 +370,24 @@ func (e ImageStatusStatus) Valid() bool {
 
 // Defines values for ImageTypes.
 const (
-	ImageTypesAmi               ImageTypes = "ami"
-	ImageTypesAws               ImageTypes = "aws"
-	ImageTypesAzure             ImageTypes = "azure"
-	ImageTypesEdgeCommit        ImageTypes = "edge-commit"
-	ImageTypesEdgeInstaller     ImageTypes = "edge-installer"
-	ImageTypesGcp               ImageTypes = "gcp"
-	ImageTypesGuestImage        ImageTypes = "guest-image"
-	ImageTypesImageInstaller    ImageTypes = "image-installer"
-	ImageTypesNetworkInstaller  ImageTypes = "network-installer"
-	ImageTypesOci               ImageTypes = "oci"
-	ImageTypesPxeTarXz          ImageTypes = "pxe-tar-xz"
-	ImageTypesRhelEdgeCommit    ImageTypes = "rhel-edge-commit"
-	ImageTypesRhelEdgeInstaller ImageTypes = "rhel-edge-installer"
-	ImageTypesVhd               ImageTypes = "vhd"
-	ImageTypesVsphere           ImageTypes = "vsphere"
-	ImageTypesVsphereOva        ImageTypes = "vsphere-ova"
-	ImageTypesWsl               ImageTypes = "wsl"
+	ImageTypesAmi                  ImageTypes = "ami"
+	ImageTypesAws                  ImageTypes = "aws"
+	ImageTypesAzure                ImageTypes = "azure"
+	ImageTypesBootableContainerIso ImageTypes = "bootable-container-iso"
+	ImageTypesEdgeCommit           ImageTypes = "edge-commit"
+	ImageTypesEdgeInstaller        ImageTypes = "edge-installer"
+	ImageTypesGcp                  ImageTypes = "gcp"
+	ImageTypesGuestImage           ImageTypes = "guest-image"
+	ImageTypesImageInstaller       ImageTypes = "image-installer"
+	ImageTypesNetworkInstaller     ImageTypes = "network-installer"
+	ImageTypesOci                  ImageTypes = "oci"
+	ImageTypesPxeTarXz             ImageTypes = "pxe-tar-xz"
+	ImageTypesRhelEdgeCommit       ImageTypes = "rhel-edge-commit"
+	ImageTypesRhelEdgeInstaller    ImageTypes = "rhel-edge-installer"
+	ImageTypesVhd                  ImageTypes = "vhd"
+	ImageTypesVsphere              ImageTypes = "vsphere"
+	ImageTypesVsphereOva           ImageTypes = "vsphere-ova"
+	ImageTypesWsl                  ImageTypes = "wsl"
 )
 
 // Valid indicates whether the value is a known member of the ImageTypes enum.
@@ -397,6 +398,8 @@ func (e ImageTypes) Valid() bool {
 	case ImageTypesAws:
 		return true
 	case ImageTypesAzure:
+		return true
+	case ImageTypesBootableContainerIso:
 		return true
 	case ImageTypesEdgeCommit:
 		return true
@@ -668,6 +671,13 @@ type BootMode = composer.ImageTypeInfoBootMode
 // BootcBody Bootc/Image Mode compose parameters. When present, the compose builds from the
 // specified bootc base image instead of the classic package-based flow.
 type BootcBody struct {
+	// IsoPayloadReference Optional container image reference for a payload container to embed
+	// in the ISO. When set, the payload container is available at
+	// install/boot time. Only valid for bootable-container-iso image type.
+	// Must be one of the references listed in the distribution's bootc
+	// configuration.
+	IsoPayloadReference *string `json:"iso_payload_reference,omitempty"`
+
 	// Reference Image name from the bootc distributions list. Must match a reference
 	// returned by GET /distributions?kind=bootc.
 	Reference string `json:"reference"`
@@ -677,7 +687,12 @@ type BootcBody struct {
 type BootcDistributionItem struct {
 	Arch   string `json:"arch"`
 	Distro string `json:"distro"`
-	Name   string `json:"name"`
+
+	// IsoPayloadReferences List of allowed payload container references for
+	// bootable-container-iso image type. Only present for
+	// bootable-container-iso entries.
+	IsoPayloadReferences *[]string `json:"iso_payload_references,omitempty"`
+	Name                 string    `json:"name"`
 
 	// Reference Derived container image reference, only references listed in the bootc distributions list are allowed.
 	Reference string `json:"reference"`

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -864,6 +864,18 @@ components:
           type: string
           description: 'Derived container image reference, only references listed in the bootc distributions list are allowed.'
           example: 'quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest'
+        iso_payload_references:
+          type: array
+          items:
+            type: string
+          description: |
+            List of allowed payload container references for
+            bootable-container-iso image type. Only present for
+            bootable-container-iso entries.
+          example: [
+            "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest",
+            "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest"
+          ]
     BootcBody:
       type: object
       description: |
@@ -878,6 +890,14 @@ components:
             Image name from the bootc distributions list. Must match a reference
             returned by GET /distributions?kind=bootc.
           example: 'quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest'
+        iso_payload_reference:
+          type: string
+          description: |
+            Optional container image reference for a payload container to embed
+            in the ISO. When set, the payload container is available at
+            install/boot time. Only valid for bootable-container-iso image type.
+            Must be one of the references listed in the distribution's bootc
+            configuration.
     Architectures:
       type: array
       items:
@@ -1329,6 +1349,7 @@ components:
       enum:
         - aws
         - azure
+        - bootable-container-iso  # bootc-only, not in image_types
         - edge-commit
         - edge-installer
         - gcp

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -92,14 +92,18 @@ func (h *Handlers) GetDistributions(ctx echo.Context, params GetDistributionsPar
 			if params.Type != nil && e.Type != *params.Type {
 				continue
 			}
-			var item DistributionsResponse_Item
-			_ = item.FromBootcDistributionItem(BootcDistributionItem{
+			bdi := BootcDistributionItem{
 				Distro:    e.Distro,
 				Name:      e.Name,
 				Type:      e.Type,
 				Arch:      e.Arch,
 				Reference: e.Reference,
-			})
+			}
+			if len(e.IsoPayloadReferences) > 0 {
+				bdi.IsoPayloadReferences = &e.IsoPayloadReferences
+			}
+			var item DistributionsResponse_Item
+			_ = item.FromBootcDistributionItem(bdi)
 			resp = append(resp, item)
 		}
 		return ctx.JSON(http.StatusOK, resp)

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -119,7 +119,10 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 			}
 		}
 	} else if composeRequest.Bootc != nil {
-		err := h.server.distroRegistry(ctx).ValidateBootcReference(composeRequest.Bootc.Reference)
+		err := h.server.distroRegistry(ctx).ValidateBootcReferences(
+			composeRequest.Bootc.Reference,
+			composeRequest.Bootc.IsoPayloadReference,
+		)
 		if err != nil {
 			return ComposeResponse{}, echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -75,6 +75,10 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 		return ComposeResponse{}, echo.NewHTTPError(http.StatusBadRequest, "Either a snapshot date or content template can be specified, but not both")
 	}
 
+	if composeRequest.Bootc == nil && composeRequest.ImageRequests[0].ImageType == ImageTypesBootableContainerIso {
+		return ComposeResponse{}, echo.NewHTTPError(http.StatusBadRequest, "bootc is required for bootable-container-iso image type")
+	}
+
 	var repositories []composer.Repository
 	var customizations *composer.Customizations
 	var distro *string
@@ -119,6 +123,11 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 			}
 		}
 	} else if composeRequest.Bootc != nil {
+		imageType := composeRequest.ImageRequests[0].ImageType
+		if composeRequest.Bootc.IsoPayloadReference != nil && imageType != ImageTypesBootableContainerIso {
+			return ComposeResponse{}, echo.NewHTTPError(http.StatusBadRequest, "iso_payload_reference must not be set for non-ISO bootc image types")
+		}
+
 		err := h.server.distroRegistry(ctx).ValidateBootcReferences(
 			composeRequest.Bootc.Reference,
 			composeRequest.Bootc.IsoPayloadReference,
@@ -126,8 +135,10 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 		if err != nil {
 			return ComposeResponse{}, echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
+
 		bootc = &composer.Bootc{
-			Reference: composeRequest.Bootc.Reference,
+			Reference:           composeRequest.Bootc.Reference,
+			IsoPayloadReference: composeRequest.Bootc.IsoPayloadReference,
 		}
 	} else {
 		// 500 error as any validation should have happened before handing it off to the common compose function
@@ -842,6 +853,8 @@ func (h *Handlers) buildUploadOptions(ctx echo.Context, ur UploadRequest, it Ima
 			composerImageType = composer.ImageTypesVsphereOva
 		case ImageTypesWsl:
 			composerImageType = composer.ImageTypesWsl
+		case ImageTypesBootableContainerIso:
+			composerImageType = composer.ImageTypesBootableContainerIso
 		default:
 			return uploadOptions, "", echo.NewHTTPError(http.StatusBadRequest, "Invalid image type for upload target")
 		}

--- a/internal/v1/handler_post_compose_bootc_test.go
+++ b/internal/v1/handler_post_compose_bootc_test.go
@@ -142,3 +142,158 @@ func TestComposeBootcUnknownReferenceRejected(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, status, body)
 	require.Contains(t, body, "bootc reference 'quay.io/example/this-reference-is-not-in-the-distro-list:latest' not found")
 }
+
+func TestComposeBootableContainerIso(t *testing.T) {
+	distsDir := "../../distributions"
+
+	installerRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest"
+	validPayloadRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"
+	invalidPayloadRef := "quay.io/example/not-in-allowed-list:latest"
+	awsBootcRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest"
+
+	tests := []struct {
+		name             string
+		bootc            *v1.BootcBody
+		imageType        v1.ImageTypes
+		uploadType       v1.UploadTypes
+		uploadOpts       func(t *testing.T) v1.UploadRequest_Options
+		wantStatus       int
+		wantErrSubstring string
+		checkComposer    func(t *testing.T, cr composer.ComposeRequest)
+	}{
+		{
+			name: "bootable-container-iso with valid iso_payload_reference",
+			bootc: &v1.BootcBody{
+				Reference:           installerRef,
+				IsoPayloadReference: &validPayloadRef,
+			},
+			imageType:  v1.ImageTypesBootableContainerIso,
+			uploadType: v1.UploadTypesAwsS3,
+			uploadOpts: func(t *testing.T) v1.UploadRequest_Options {
+				var uo v1.UploadRequest_Options
+				require.NoError(t, uo.FromAWSS3UploadRequestOptions(v1.AWSS3UploadRequestOptions{}))
+				return uo
+			},
+			wantStatus: http.StatusCreated,
+			checkComposer: func(t *testing.T, cr composer.ComposeRequest) {
+				require.NotNil(t, cr.Bootc)
+				require.Equal(t, installerRef, cr.Bootc.Reference)
+				require.NotNil(t, cr.Bootc.IsoPayloadReference)
+				require.Equal(t, validPayloadRef, *cr.Bootc.IsoPayloadReference)
+			},
+		},
+		{
+			name: "bootable-container-iso without iso_payload_reference",
+			bootc: &v1.BootcBody{
+				Reference: installerRef,
+			},
+			imageType:  v1.ImageTypesBootableContainerIso,
+			uploadType: v1.UploadTypesAwsS3,
+			uploadOpts: func(t *testing.T) v1.UploadRequest_Options {
+				var uo v1.UploadRequest_Options
+				require.NoError(t, uo.FromAWSS3UploadRequestOptions(v1.AWSS3UploadRequestOptions{}))
+				return uo
+			},
+			wantStatus: http.StatusCreated,
+			checkComposer: func(t *testing.T, cr composer.ComposeRequest) {
+				require.NotNil(t, cr.Bootc)
+				require.Equal(t, installerRef, cr.Bootc.Reference)
+				require.Nil(t, cr.Bootc.IsoPayloadReference)
+			},
+		},
+		{
+			name: "bootable-container-iso with invalid iso_payload_reference",
+			bootc: &v1.BootcBody{
+				Reference:           installerRef,
+				IsoPayloadReference: &invalidPayloadRef,
+			},
+			imageType:  v1.ImageTypesBootableContainerIso,
+			uploadType: v1.UploadTypesAwsS3,
+			uploadOpts: func(t *testing.T) v1.UploadRequest_Options {
+				var uo v1.UploadRequest_Options
+				require.NoError(t, uo.FromAWSS3UploadRequestOptions(v1.AWSS3UploadRequestOptions{}))
+				return uo
+			},
+			wantStatus:       http.StatusBadRequest,
+			wantErrSubstring: "iso payload reference",
+		},
+		{
+			name: "iso_payload_reference rejected on non-ISO bootc type",
+			bootc: &v1.BootcBody{
+				Reference:           awsBootcRef,
+				IsoPayloadReference: &validPayloadRef,
+			},
+			imageType:  v1.ImageTypesAws,
+			uploadType: v1.UploadTypesAws,
+			uploadOpts: func(t *testing.T) v1.UploadRequest_Options {
+				var uo v1.UploadRequest_Options
+				require.NoError(t, uo.FromAWSUploadRequestOptions(v1.AWSUploadRequestOptions{
+					ShareWithAccounts: &[]string{"test-account"},
+				}))
+				return uo
+			},
+			wantStatus:       http.StatusBadRequest,
+			wantErrSubstring: "iso_payload_reference must not be set for non-ISO bootc image types",
+		},
+		{
+			name:       "bootable-container-iso requires bootc",
+			bootc:      nil,
+			imageType:  v1.ImageTypesBootableContainerIso,
+			uploadType: v1.UploadTypesAwsS3,
+			uploadOpts: func(t *testing.T) v1.UploadRequest_Options {
+				var uo v1.UploadRequest_Options
+				require.NoError(t, uo.FromAWSS3UploadRequestOptions(v1.AWSS3UploadRequestOptions{}))
+				return uo
+			},
+			wantStatus:       http.StatusBadRequest,
+			wantErrSubstring: "bootc is required for bootable-container-iso image type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wantComposeID := uuid.New()
+			var gotComposer composer.ComposeRequest
+
+			apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "Bearer accesstoken", r.Header.Get("Authorization"))
+				err := json.NewDecoder(r.Body).Decode(&gotComposer)
+				require.NoError(t, err)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				err = json.NewEncoder(w).Encode(composer.ComposeId{Id: wantComposeID})
+				require.NoError(t, err)
+			}))
+			defer apiSrv.Close()
+
+			srv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, &v1.ServerConfig{
+				DistributionsDir: distsDir,
+			})
+			defer srv.Shutdown(t)
+
+			payload := v1.ComposeRequest{
+				Bootc: tt.bootc,
+				ImageRequests: []v1.ImageRequest{
+					{
+						Architecture: "x86_64",
+						ImageType:    tt.imageType,
+						UploadRequest: v1.UploadRequest{
+							Type:    tt.uploadType,
+							Options: tt.uploadOpts(t),
+						},
+					},
+				},
+			}
+
+			status, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
+			require.Equal(t, tt.wantStatus, status, body)
+
+			if tt.wantErrSubstring != "" {
+				require.Contains(t, body, tt.wantErrSubstring)
+			}
+			if tt.checkComposer != nil {
+				tt.checkComposer(t, gotComposer)
+			}
+		})
+	}
+}

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -932,7 +932,7 @@ func TestGetBootcDistributions(t *testing.T) {
 		{
 			name:    "returns list from distribution JSON bootc field",
 			query:   "kind=bootc",
-			wantLen: 4,
+			wantLen: 5,
 			check: func(t *testing.T, result []v1.BootcDistributionItem) {
 				require.Equal(t, "rhel-10.1", result[0].Distro)
 				require.Equal(t, "Red Hat Enterprise Linux (RHEL) 10", result[0].Name)
@@ -943,7 +943,7 @@ func TestGetBootcDistributions(t *testing.T) {
 		{
 			name:    "filters by distro",
 			query:   "kind=bootc&distro=rhel-10.1",
-			wantLen: 4,
+			wantLen: 5,
 			check: func(t *testing.T, result []v1.BootcDistributionItem) {
 				for _, item := range result {
 					require.Equal(t, "rhel-10.1", item.Distro)
@@ -958,7 +958,7 @@ func TestGetBootcDistributions(t *testing.T) {
 		{
 			name:    "filters by arch",
 			query:   "kind=bootc&arch=x86_64",
-			wantLen: 4,
+			wantLen: 5,
 			check: func(t *testing.T, result []v1.BootcDistributionItem) {
 				for _, item := range result {
 					require.Equal(t, "x86_64", item.Arch)
@@ -976,6 +976,7 @@ func TestGetBootcDistributions(t *testing.T) {
 			wantLen: 1,
 			check: func(t *testing.T, result []v1.BootcDistributionItem) {
 				require.Equal(t, "aws", result[0].Type)
+				require.Nil(t, result[0].IsoPayloadReferences)
 			},
 		},
 		{
@@ -986,6 +987,17 @@ func TestGetBootcDistributions(t *testing.T) {
 				require.Equal(t, rhel101BootcGuestImageRef, result[0].Reference)
 				require.Equal(t, "x86_64", result[0].Arch)
 				require.Equal(t, "guest-image", result[0].Type)
+			},
+		},
+		{
+			name:    "filters by type bootable-container-iso includes iso_payload_references",
+			query:   "kind=bootc&type=bootable-container-iso",
+			wantLen: 1,
+			check: func(t *testing.T, result []v1.BootcDistributionItem) {
+				require.Equal(t, "bootable-container-iso", result[0].Type)
+				require.Equal(t, "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest", result[0].Reference)
+				require.NotNil(t, result[0].IsoPayloadReferences)
+				require.Equal(t, []string{"quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"}, *result[0].IsoPayloadReferences)
 			},
 		},
 		{


### PR DESCRIPTION
Enable bootable container ISO builds through the CRC API. This new image type allows users to compose bootable ISO images from container references, with optional embedded payload containers. In practice, the payload container ref must be always passed for our current version of the installer container (because it is referenced in the embedded kickstart). However, there is no technical limitation in the osbuild-composer or images library, preventing a bootable-container-iso build without any payload container if the installer container does not need it. The CRC API therefore keeps this flexibility for the future.

The changes span from the upstream composer OpenAPI spec through distribution configuration, API schema, reference validation, and compose handler logic.

`bootable-container-iso` is intentionally **not** added to the `image_types` array in distribution JSON files. It is discoverable only via `GET /distributions?kind=bootc`. This keeps the bootc compose flow separate from the classic `GET /architectures/{distribution}` path used by non-bootc UI flows.

`iso_payload_references` is modeled as an array because the set of embeddable payload containers may grow if we would allow customizing the container ref in the embedded kickstart, i.e. via a BP customization. So a list avoids a breaking schema change when new targets would be added.

## Architectural Changes

Extend the existing bootc reference validation into a combined `ValidateBootcReferences(reference, *isoPayloadRef)` method that validates both the installer reference and the optional payload reference against the same distribution entry. This prevents cross-distro or cross-architecture mismatches by design, reusing the existing per-architecture lookup rather than introducing a separate validation path.

Distribution entries gain an `iso_payload_references` allowlist so the distributions endpoint can advertise which payload containers are valid for each bootable-container-iso entry, keeping the validation source of truth in the JSON config files.

## Key Changes

- Update the composer client OpenAPI spec from upstream, gaining `iso_payload_reference` on `Bootc` and `bootable-container-iso` in the `ImageTypes` enum
- Extend the CRC API spec with `bootable-container-iso` image type, `iso_payload_reference` on `BootcBody`, and `iso_payload_references` on `BootcDistributionItem`
- Add `IsoPayloadReferences` to the distribution `BootcImage` struct and wire it through `CollectBootcFromRegistry` and `GetDistributions`
- Add `bootable-container-iso` entry to the `rhel-10.1` distribution config with an installer reference and allowed payload references
- Implement compose handler validation: require `bootc` for ISO type, reject `iso_payload_reference` on non-ISO types, validate payload against the distribution allowlist
- Pass `iso_payload_reference` through to the composer client and map `bootable-container-iso` to the S3 upload options

## Breaking Changes

This PR is fully backward compatible.

## Testing

- Extend `Architecture.ValidateBootcReferences` tests to cover base-only, base+valid-payload, base+invalid-payload, nil-architecture, and non-ISO-ref-with-payload scenarios
- Extend `DistroRegistry.ValidateBootcReferences` tests with combined base+payload validation cases against real test distribution data
- Add `TestComposeBootableContainerIso` integration test covering successful ISO compose with/without payload, invalid payload rejection, payload-on-non-ISO rejection, and missing bootc body rejection
- Update `TestGetBootcDistributions` to verify `iso_payload_references` is present for ISO entries and absent for non-ISO entries