### PR TITLE
Fix null repositories in bootc compose requests

### DIFF
--- a/internal/v1/composer_schema_test.go
+++ b/internal/v1/composer_schema_test.go
@@ -1,0 +1,51 @@
+package v1_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+var composerSpec *openapi3.T
+
+// loadComposerSpec loads the composer OpenAPI spec from the file system once
+// and returns a pointer to it.
+func loadComposerSpec(t *testing.T) *openapi3.T {
+	t.Helper()
+	if composerSpec != nil {
+		return composerSpec
+	}
+	loader := openapi3.NewLoader()
+	var err error
+	composerSpec, err = loader.LoadFromFile("../../internal/clients/composer/openapi.v2.yml")
+	require.NoError(t, err)
+	return composerSpec
+}
+
+// validatingComposerHandler wraps an http.Handler and validates every
+// POST /compose request body against the composer ComposeRequest schema.
+func validatingComposerHandler(t *testing.T, inner http.Handler) http.Handler {
+	t.Helper()
+	spec := loadComposerSpec(t)
+	schemaRef := spec.Components.Schemas["ComposeRequest"]
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/compose") {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			r.Body = io.NopCloser(bytes.NewReader(body))
+
+			var raw any
+			require.NoError(t, json.Unmarshal(body, &raw))
+			err = schemaRef.Value.VisitJSON(raw)
+			require.NoError(t, err, "composer ComposeRequest schema validation failed:\n%s", body)
+		}
+		inner.ServeHTTP(w, r)
+	})
+}

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -520,7 +520,7 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 
 	composeRequests := []composer.ComposeRequest{}
 	ids := []uuid.UUID{}
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	apiSrv := httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		newId := uuid.New()
 		if r.Header.Get("Authorization") == "Bearer" {
 			w.WriteHeader(http.StatusUnauthorized)
@@ -542,7 +542,7 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 		ids = append(ids, newId)
 		encodeErr := json.NewEncoder(w).Encode(result)
 		require.NoError(t, encodeErr)
-	}))
+	})))
 	defer apiSrv.Close()
 
 	srv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, nil)
@@ -1102,7 +1102,7 @@ func TestHandlers_ExportBlueprint(t *testing.T) {
 
 	var composeId uuid.UUID
 	var composerRequest composer.ComposeRequest
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	apiSrv := httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "Bearer" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -1119,7 +1119,7 @@ func TestHandlers_ExportBlueprint(t *testing.T) {
 		}
 		err = json.NewEncoder(w).Encode(result)
 		require.NoError(t, err)
-	}))
+	})))
 	defer apiSrv.Close()
 
 	dbase, srvURL, shutdownFn := makeTestServer(t, &apiSrv.URL)

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -79,7 +79,7 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 		return ComposeResponse{}, echo.NewHTTPError(http.StatusBadRequest, "bootc is required for bootable-container-iso image type")
 	}
 
-	var repositories []composer.Repository
+	repositories := []composer.Repository{}
 	var customizations *composer.Customizations
 	var distro *string
 	var bootc *composer.Bootc

--- a/internal/v1/handler_post_compose_bootc_test.go
+++ b/internal/v1/handler_post_compose_bootc_test.go
@@ -58,7 +58,7 @@ func TestComposeBootcReferenceWithQuery(t *testing.T) {
 			wantComposeID := uuid.New()
 			var gotComposer composer.ComposeRequest
 
-			apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			apiSrv := httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, "Bearer accesstoken", r.Header.Get("Authorization"))
 				err := json.NewDecoder(r.Body).Decode(&gotComposer)
 				require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestComposeBootcReferenceWithQuery(t *testing.T) {
 				w.WriteHeader(http.StatusCreated)
 				err = json.NewEncoder(w).Encode(composer.ComposeId{Id: wantComposeID})
 				require.NoError(t, err)
-			}))
+			})))
 			defer apiSrv.Close()
 
 			srv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, &v1.ServerConfig{

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -443,7 +443,7 @@ func TestComposeStatusError(t *testing.T) {
 }
 
 func TestComposeImageErrorsWhenStatusCodeIsNotStatusCreated(t *testing.T) {
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	apiSrv := httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "Bearer" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -460,7 +460,7 @@ func TestComposeImageErrorsWhenStatusCodeIsNotStatusCreated(t *testing.T) {
 		}
 		err := json.NewEncoder(w).Encode(serviceError)
 		require.NoError(t, err)
-	}))
+	})))
 	defer apiSrv.Close()
 
 	srv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, nil)
@@ -490,7 +490,7 @@ func TestComposeImageErrorsWhenStatusCodeIsNotStatusCreated(t *testing.T) {
 }
 
 func TestComposeImageErrorResolvingOSTree(t *testing.T) {
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	apiSrv := httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "Bearer" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -504,7 +504,7 @@ func TestComposeImageErrorResolvingOSTree(t *testing.T) {
 		}
 		err := json.NewEncoder(w).Encode(serviceStat)
 		require.NoError(t, err)
-	}))
+	})))
 	defer apiSrv.Close()
 
 	srv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, nil)
@@ -540,7 +540,7 @@ func TestComposeImageErrorResolvingOSTree(t *testing.T) {
 }
 
 func TestComposeImageErrorsWhenCannotParseResponse(t *testing.T) {
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	apiSrv := httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "Bearer" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -551,7 +551,7 @@ func TestComposeImageErrorsWhenCannotParseResponse(t *testing.T) {
 		s := "not a composer.ComposeId data structure"
 		err := json.NewEncoder(w).Encode(s)
 		require.NoError(t, err)
-	}))
+	})))
 	defer apiSrv.Close()
 
 	srv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, nil)
@@ -610,7 +610,7 @@ func TestComposeImageErrorsWhenDistributionNotExists(t *testing.T) {
 
 func TestComposeImageReturnsIdWhenNoErrors(t *testing.T) {
 	id := uuid.New()
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	apiSrv := httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "Bearer" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -623,7 +623,7 @@ func TestComposeImageReturnsIdWhenNoErrors(t *testing.T) {
 		}
 		err := json.NewEncoder(w).Encode(result)
 		require.NoError(t, err)
-	}))
+	})))
 	defer apiSrv.Close()
 
 	srv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, nil)
@@ -661,7 +661,7 @@ func TestComposeImageAllowList(t *testing.T) {
 	id := uuid.New()
 
 	createApiSrv := func() *httptest.Server {
-		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		return httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Header.Get("Authorization") == "Bearer" {
 				w.WriteHeader(http.StatusUnauthorized)
 				return
@@ -674,7 +674,7 @@ func TestComposeImageAllowList(t *testing.T) {
 			}
 			err := json.NewEncoder(w).Encode(result)
 			require.NoError(t, err)
-		}))
+		})))
 	}
 
 	createPayload := func(distro v1.Distributions) v1.ComposeRequest {
@@ -808,7 +808,7 @@ func TestCompliancePolicyErrors(t *testing.T) {
 func TestComposeWithSnapshots(t *testing.T) {
 	var composeId uuid.UUID
 	var composerRequest composer.ComposeRequest
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	apiSrv := httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "Bearer" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -825,7 +825,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 		}
 		err = json.NewEncoder(w).Encode(result)
 		require.NoError(t, err)
-	}))
+	})))
 	defer apiSrv.Close()
 
 	srv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, nil)
@@ -1600,7 +1600,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 func TestComposeCustomizations(t *testing.T) {
 	var id uuid.UUID
 	var composerRequest composer.ComposeRequest
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	apiSrv := httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "Bearer" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -1618,7 +1618,7 @@ func TestComposeCustomizations(t *testing.T) {
 		}
 		err = json.NewEncoder(w).Encode(result)
 		require.NoError(t, err)
-	}))
+	})))
 	defer apiSrv.Close()
 
 	awsAccountId := "123456123456"
@@ -3347,7 +3347,7 @@ WantedBy=basic.target
 func TestComposeWithLatestSnapshots(t *testing.T) {
 	var composeId uuid.UUID
 	var composerRequest composer.ComposeRequest
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	apiSrv := httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "Bearer" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -3364,7 +3364,7 @@ func TestComposeWithLatestSnapshots(t *testing.T) {
 		}
 		err = json.NewEncoder(w).Encode(result)
 		require.NoError(t, err)
-	}))
+	})))
 	defer apiSrv.Close()
 
 	srv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, nil)
@@ -3540,7 +3540,7 @@ func TestComposeWithLatestSnapshots(t *testing.T) {
 // system-reinstall-bootc) that are only available in a newer minor version.
 func TestComposeWithSnapshotDetectedOsVersion(t *testing.T) {
 	var composerRequest composer.ComposeRequest
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	apiSrv := httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "Bearer accesstoken", r.Header.Get("Authorization"))
 		err := json.NewDecoder(r.Body).Decode(&composerRequest)
 		require.NoError(t, err)
@@ -3548,7 +3548,7 @@ func TestComposeWithSnapshotDetectedOsVersion(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 		err = json.NewEncoder(w).Encode(composer.ComposeId{Id: uuid.New()})
 		require.NoError(t, err)
-	}))
+	})))
 	defer apiSrv.Close()
 
 	// Use a CS mock that reports detected_os_version "9.4" for snapshots.
@@ -3592,7 +3592,7 @@ func TestComposeWithSnapshotDetectedOsVersion(t *testing.T) {
 // to avoid blocking a valid version from a later snapshot.
 func TestComposeWithSnapshotEmptyDetectedOsVersion(t *testing.T) {
 	var composerRequest composer.ComposeRequest
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	apiSrv := httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "Bearer accesstoken", r.Header.Get("Authorization"))
 		err := json.NewDecoder(r.Body).Decode(&composerRequest)
 		require.NoError(t, err)
@@ -3600,7 +3600,7 @@ func TestComposeWithSnapshotEmptyDetectedOsVersion(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 		err = json.NewEncoder(w).Encode(composer.ComposeId{Id: uuid.New()})
 		require.NoError(t, err)
-	}))
+	})))
 	defer apiSrv.Close()
 
 	srv := startServer(t, &testServerClientsConf{


### PR DESCRIPTION
The bootc compose code path left the `repositories` variable as a nil slice, which serializes to `"repositories": null` in JSON. The composer API requires this field to be an array, causing schema validation failures. Initialize `repositories` to an empty slice so it correctly serializes as `"repositories": []`. Add OpenAPI schema validation to mock composer servers in tests to catch this class of bug going forward.

## Architectural Changes

Introduce a reusable `validatingComposerHandler` test helper that wraps mock composer HTTP handlers and validates every `POST /compose` request body against the vendored composer OpenAPI spec (`openapi.v2.yml`). This shifts serialization correctness checks from manual inspection to automated schema enforcement at test time.

## Key Changes

- Initialize `repositories` as `[]composer.Repository{}` instead of `var repositories []composer.Repository` in `handleCommonCompose` to prevent JSON null serialization
- Add `composer_schema_test.go` with a `validatingComposerHandler` that validates compose request bodies against the `ComposeRequest` schema from the composer OpenAPI spec
- Wrap all mock composer servers across compose, blueprint, and bootc test suites with the validating handler