### PR TITLE
distributions: change bootc ref to rhel-10 (HMS-10602)

### DIFF
--- a/distributions/rhel-10.1/rhel-10.1.json
+++ b/distributions/rhel-10.1/rhel-10.1.json
@@ -9,15 +9,15 @@
   },
   "x86_64": {
     "bootc": [
-      { "type": "aws", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest" },
-      { "type": "gcp", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-gcp:latest" },
-      { "type": "azure", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-azure:latest" },
-      { "type": "guest-image", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest" },
+      { "type": "aws", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest" },
+      { "type": "gcp", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-gcp:latest" },
+      { "type": "azure", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-azure:latest" },
+      { "type": "guest-image", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest" },
       {
         "type": "bootable-container-iso",
-        "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest",
+        "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-installer:latest",
         "iso_payload_references": [
-          "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"
+          "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest"
         ]
       }
     ],

--- a/internal/distribution/distroregistry_test.go
+++ b/internal/distribution/distroregistry_test.go
@@ -180,7 +180,7 @@ func TestDistroRegistry_ValidateBootcReferences(t *testing.T) {
 		// Base ref only
 		{
 			desc: "valid base reference",
-			ref:  "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest",
+			ref:  "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest",
 		},
 		{
 			desc:         "unknown base reference",
@@ -190,18 +190,18 @@ func TestDistroRegistry_ValidateBootcReferences(t *testing.T) {
 		// Base ref + payload
 		{
 			desc:          "valid installer ref + valid payload",
-			ref:           "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest",
-			isoPayloadRef: common.ToPtr("quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"),
+			ref:           "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-installer:latest",
+			isoPayloadRef: common.ToPtr("quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest"),
 		},
 		{
 			desc:          "valid installer ref + unknown payload",
-			ref:           "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest",
+			ref:           "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-installer:latest",
 			isoPayloadRef: common.ToPtr("duck"),
 			errSubstring:  "iso payload reference 'duck' not in its allowed list",
 		},
 		{
 			desc:          "ec2 ref + any payload (no allowlist)",
-			ref:           "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest",
+			ref:           "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest",
 			isoPayloadRef: common.ToPtr("duck"),
 			errSubstring:  "iso payload reference 'duck' not in its allowed list",
 		},
@@ -245,15 +245,15 @@ func TestDistroRegistry_CollectBootcFromRegistry(t *testing.T) {
 					Name:      "Test distro with bootc entries",
 					Type:      "ec2",
 					Arch:      "x86_64",
-					Reference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest",
+					Reference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest",
 				},
 				{
 					Distro:               "with-bootc",
 					Name:                 "Test distro with bootc entries",
 					Type:                 "bootable-container-iso",
 					Arch:                 "x86_64",
-					Reference:            "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest",
-					IsoPayloadReferences: []string{"quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"},
+					Reference:            "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-installer:latest",
+					IsoPayloadReferences: []string{"quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest"},
 				},
 			},
 		},

--- a/internal/distribution/testdata/distributions/with-bootc/with-bootc.json
+++ b/internal/distribution/testdata/distributions/with-bootc/with-bootc.json
@@ -9,12 +9,12 @@
     "image_types": ["qcow2"],
     "repositories": [],
     "bootc": [
-      { "type": "ec2", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest" },
+      { "type": "ec2", "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest" },
       {
         "type": "bootable-container-iso",
-        "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest",
+        "reference": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-installer:latest",
         "iso_payload_references": [
-          "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"
+          "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest"
         ]
       }
     ]

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -873,8 +873,8 @@ components:
             bootable-container-iso image type. Only present for
             bootable-container-iso entries.
           example: [
-            "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest",
-            "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest"
+            "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest",
+            "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest"
           ]
     BootcBody:
       type: object
@@ -889,7 +889,7 @@ components:
           description: |
             Image name from the bootc distributions list. Must match a reference
             returned by GET /distributions?kind=bootc.
-          example: 'quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest'
+          example: 'quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest'
         iso_payload_reference:
           type: string
           description: |

--- a/internal/v1/handler_post_compose_bootc_test.go
+++ b/internal/v1/handler_post_compose_bootc_test.go
@@ -28,7 +28,7 @@ func TestComposeBootcReferenceWithQuery(t *testing.T) {
 		{
 			name:          "aws uses bootc container reference from query",
 			queryExtra:    "distro=rhel-10.1&arch=x86_64&type=aws",
-			wantReference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest",
+			wantReference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest",
 			imageType:     v1.ImageTypesAws,
 			uploadType:    v1.UploadTypesAws,
 			uploadOpts: func(t *testing.T) v1.UploadRequest_Options {
@@ -42,7 +42,7 @@ func TestComposeBootcReferenceWithQuery(t *testing.T) {
 		{
 			name:          "guest-image uses bootc container reference from query",
 			queryExtra:    "distro=rhel-10.1&arch=x86_64&type=guest-image",
-			wantReference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest",
+			wantReference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest",
 			imageType:     v1.ImageTypesGuestImage,
 			uploadType:    v1.UploadTypesAwsS3,
 			uploadOpts: func(t *testing.T) v1.UploadRequest_Options {
@@ -146,10 +146,10 @@ func TestComposeBootcUnknownReferenceRejected(t *testing.T) {
 func TestComposeBootableContainerIso(t *testing.T) {
 	distsDir := "../../distributions"
 
-	installerRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest"
-	validPayloadRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"
+	installerRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-installer:latest"
+	validPayloadRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest"
 	invalidPayloadRef := "quay.io/example/not-in-allowed-list:latest"
-	awsBootcRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest"
+	awsBootcRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest"
 
 	tests := []struct {
 		name             string

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -919,8 +919,8 @@ func TestGetDistributions(t *testing.T) {
 func TestGetBootcDistributions(t *testing.T) {
 	distsDir := "../../distributions"
 	allowFile := "../common/testdata/allow.json"
-	rhel101BootcAWSRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-ec2:latest"
-	rhel101BootcGuestImageRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"
+	rhel101BootcAWSRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest"
+	rhel101BootcGuestImageRef := "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest"
 
 	tests := []struct {
 		name     string
@@ -995,9 +995,9 @@ func TestGetBootcDistributions(t *testing.T) {
 			wantLen: 1,
 			check: func(t *testing.T, result []v1.BootcDistributionItem) {
 				require.Equal(t, "bootable-container-iso", result[0].Type)
-				require.Equal(t, "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest", result[0].Reference)
+				require.Equal(t, "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-installer:latest", result[0].Reference)
 				require.NotNil(t, result[0].IsoPayloadReferences)
-				require.Equal(t, []string{"quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"}, *result[0].IsoPayloadReferences)
+				require.Equal(t, []string{"quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest"}, *result[0].IsoPayloadReferences)
 			},
 		},
 		{


### PR DESCRIPTION
We are now publishing from `latest` tag and the destination repos changed from `10.1` to just `10`. This reflects that.

The second commit also updates tests I do not want the `10.1` lingering around we might not even use minor releases for bootc in the future who knows.