### PR TITLE
v1: let bootc take priority over package mode

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -83,7 +83,25 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 	var customizations *composer.Customizations
 	var distro *string
 	var bootc *composer.Bootc
-	if composeRequest.Distribution != nil {
+	if composeRequest.Bootc != nil {
+		imageType := composeRequest.ImageRequests[0].ImageType
+		if composeRequest.Bootc.IsoPayloadReference != nil && imageType != ImageTypesBootableContainerIso {
+			return ComposeResponse{}, echo.NewHTTPError(http.StatusBadRequest, "iso_payload_reference must not be set for non-ISO bootc image types")
+		}
+
+		err := h.server.distroRegistry(ctx).ValidateBootcReferences(
+			composeRequest.Bootc.Reference,
+			composeRequest.Bootc.IsoPayloadReference,
+		)
+		if err != nil {
+			return ComposeResponse{}, echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+
+		bootc = &composer.Bootc{
+			Reference:           composeRequest.Bootc.Reference,
+			IsoPayloadReference: composeRequest.Bootc.IsoPayloadReference,
+		}
+	} else if composeRequest.Distribution != nil {
 		d, err := h.server.getDistro(ctx, *composeRequest.Distribution)
 		if err != nil {
 			return ComposeResponse{}, err
@@ -123,24 +141,6 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 			if v := h.server.distroRegistry(ctx).FindByMajorMinorStr(*detectedOsVersion); v != "" {
 				distro = &v
 			}
-		}
-	} else if composeRequest.Bootc != nil {
-		imageType := composeRequest.ImageRequests[0].ImageType
-		if composeRequest.Bootc.IsoPayloadReference != nil && imageType != ImageTypesBootableContainerIso {
-			return ComposeResponse{}, echo.NewHTTPError(http.StatusBadRequest, "iso_payload_reference must not be set for non-ISO bootc image types")
-		}
-
-		err := h.server.distroRegistry(ctx).ValidateBootcReferences(
-			composeRequest.Bootc.Reference,
-			composeRequest.Bootc.IsoPayloadReference,
-		)
-		if err != nil {
-			return ComposeResponse{}, echo.NewHTTPError(http.StatusBadRequest, err.Error())
-		}
-
-		bootc = &composer.Bootc{
-			Reference:           composeRequest.Bootc.Reference,
-			IsoPayloadReference: composeRequest.Bootc.IsoPayloadReference,
 		}
 	} else {
 		// 500 error as any validation should have happened before handing it off to the common compose function

--- a/internal/v1/handler_post_compose_bootc_test.go
+++ b/internal/v1/handler_post_compose_bootc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/image-builder-crc/internal/clients/composer"
+	"github.com/osbuild/image-builder-crc/internal/common"
 	"github.com/osbuild/image-builder-crc/internal/tutils"
 	v1 "github.com/osbuild/image-builder-crc/internal/v1"
 )
@@ -19,6 +20,7 @@ func TestComposeBootcReferenceWithQuery(t *testing.T) {
 
 	tests := []struct {
 		name          string
+		distro        string
 		queryExtra    string
 		wantReference string
 		imageType     v1.ImageTypes
@@ -60,6 +62,21 @@ func TestComposeBootcReferenceWithQuery(t *testing.T) {
 			uploadOpts: func(t *testing.T) v1.UploadRequest_Options {
 				var uo v1.UploadRequest_Options
 				require.NoError(t, uo.FromAWSS3UploadRequestOptions(v1.AWSS3UploadRequestOptions{}))
+				return uo
+			},
+		},
+		{
+			name:          "distribution is ignored in favour of bootc",
+			distro:        "rhel-10.1",
+			queryExtra:    "distro=rhel-10.1&arch=x86_64&type=aws",
+			wantReference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest",
+			imageType:     v1.ImageTypesAws,
+			uploadType:    v1.UploadTypesAws,
+			uploadOpts: func(t *testing.T) v1.UploadRequest_Options {
+				var uo v1.UploadRequest_Options
+				require.NoError(t, uo.FromAWSUploadRequestOptions(v1.AWSUploadRequestOptions{
+					ShareWithAccounts: &[]string{"test-account"},
+				}))
 				return uo
 			},
 		},
@@ -110,6 +127,9 @@ func TestComposeBootcReferenceWithQuery(t *testing.T) {
 						},
 					},
 				},
+			}
+			if tt.distro != "" {
+				payload.Distribution = common.ToPtr(v1.Distributions(tt.distro))
 			}
 
 			status, body = tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)


### PR DESCRIPTION
In case both distribution and bootc are set (the current case for requests coming from the frontend), let bootc take priority.

Otherwise the bootc part will not be forwarded, essentially giving users a package mode image.