### PR TITLE
distribution: ensure symlinks are respected for bootc distros

### DIFF
--- a/internal/distribution/distroregistry.go
+++ b/internal/distribution/distroregistry.go
@@ -47,12 +47,7 @@ func LoadDistroRegistry(distsDir string) (*AllDistroRegistry, error) {
 
 func (adr *AllDistroRegistry) CollectBootcFromRegistry() []BootcDistributionEntry {
 	var all []BootcDistributionEntry
-	seenDistros := make(map[string]bool)
-	for _, d := range adr.distros {
-		if seenDistros[d.Distribution.Name] {
-			continue
-		}
-		seenDistros[d.Distribution.Name] = true
+	for k, d := range adr.distros {
 		displayName := d.Distribution.Description
 		if displayName == "" {
 			displayName = d.Distribution.Name
@@ -63,7 +58,7 @@ func (adr *AllDistroRegistry) CollectBootcFromRegistry() []BootcDistributionEntr
 			}
 			for _, b := range arch.Bootc {
 				all = append(all, BootcDistributionEntry{
-					Distro:               d.Distribution.Name,
+					Distro:               k,
 					Name:                 displayName,
 					Type:                 b.Type,
 					Arch:                 archName,

--- a/internal/distribution/distroregistry_test.go
+++ b/internal/distribution/distroregistry_test.go
@@ -17,6 +17,7 @@ func TestDistroRegistry_List(t *testing.T) {
 		"rhel-34",
 		"standard",
 		"with-bootc",
+		"bootc-link",
 	}
 	notEntitledDistros := []string{
 		"no-packages",
@@ -25,6 +26,7 @@ func TestDistroRegistry_List(t *testing.T) {
 		"rhel-34",
 		"standard",
 		"with-bootc",
+		"bootc-link",
 	}
 
 	dr, err := LoadDistroRegistry("./testdata/distributions")
@@ -255,6 +257,21 @@ func TestDistroRegistry_CollectBootcFromRegistry(t *testing.T) {
 					Reference:            "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-installer:latest",
 					IsoPayloadReferences: []string{"quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest"},
 				},
+				{
+					Distro:    "bootc-link",
+					Name:      "Test distro with bootc entries",
+					Type:      "ec2",
+					Arch:      "x86_64",
+					Reference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest",
+				},
+				{
+					Distro:               "bootc-link",
+					Name:                 "Test distro with bootc entries",
+					Type:                 "bootable-container-iso",
+					Arch:                 "x86_64",
+					Reference:            "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-installer:latest",
+					IsoPayloadReferences: []string{"quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest"},
+				},
 			},
 		},
 		{
@@ -271,7 +288,7 @@ func TestDistroRegistry_CollectBootcFromRegistry(t *testing.T) {
 				require.Empty(t, list)
 				return
 			}
-			require.Equal(t, tt.want, list)
+			require.ElementsMatch(t, tt.want, list)
 		})
 	}
 }

--- a/internal/distribution/testdata/distributions/bootc-link
+++ b/internal/distribution/testdata/distributions/bootc-link
@@ -1,0 +1,1 @@
+with-bootc

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -932,11 +932,18 @@ func TestGetBootcDistributions(t *testing.T) {
 		{
 			name:    "returns list from distribution JSON bootc field",
 			query:   "kind=bootc",
-			wantLen: 6,
+			wantLen: 11,
 			check: func(t *testing.T, result []v1.BootcDistributionItem) {
 				require.Contains(t, result, v1.BootcDistributionItem{
 					Arch:      "x86_64",
 					Distro:    "rhel-10.1",
+					Name:      "Red Hat Enterprise Linux (RHEL) 10",
+					Type:      "aws",
+					Reference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest",
+				})
+				require.Contains(t, result, v1.BootcDistributionItem{
+					Arch:      "x86_64",
+					Distro:    "rhel-10",
 					Name:      "Red Hat Enterprise Linux (RHEL) 10",
 					Type:      "aws",
 					Reference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest",
@@ -961,7 +968,7 @@ func TestGetBootcDistributions(t *testing.T) {
 		{
 			name:    "filters by arch",
 			query:   "kind=bootc&arch=x86_64",
-			wantLen: 6,
+			wantLen: 11,
 			check: func(t *testing.T, result []v1.BootcDistributionItem) {
 				for _, item := range result {
 					require.Equal(t, "x86_64", item.Arch)
@@ -976,17 +983,25 @@ func TestGetBootcDistributions(t *testing.T) {
 		{
 			name:    "filters by type",
 			query:   "kind=bootc&type=aws",
-			wantLen: 1,
+			wantLen: 2,
 			check: func(t *testing.T, result []v1.BootcDistributionItem) {
 				require.Equal(t, "aws", result[0].Type)
+				require.Equal(t, "aws", result[1].Type)
 				require.Nil(t, result[0].IsoPayloadReferences)
 			},
 		},
 		{
 			name:    "combines arch and type filters",
 			query:   "kind=bootc&arch=x86_64&type=guest-image",
-			wantLen: 2,
+			wantLen: 3,
 			check: func(t *testing.T, result []v1.BootcDistributionItem) {
+				require.Contains(t, result, v1.BootcDistributionItem{
+					Arch:      "x86_64",
+					Distro:    "rhel-10",
+					Name:      "Red Hat Enterprise Linux (RHEL) 10",
+					Type:      "guest-image",
+					Reference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest",
+				})
 				require.Contains(t, result, v1.BootcDistributionItem{
 					Arch:      "x86_64",
 					Distro:    "rhel-10.1",
@@ -1006,7 +1021,7 @@ func TestGetBootcDistributions(t *testing.T) {
 		{
 			name:    "filters by type bootable-container-iso includes iso_payload_references",
 			query:   "kind=bootc&type=bootable-container-iso",
-			wantLen: 1,
+			wantLen: 2,
 			check: func(t *testing.T, result []v1.BootcDistributionItem) {
 				require.Equal(t, "bootable-container-iso", result[0].Type)
 				require.Equal(t, "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-installer:latest", result[0].Reference)


### PR DESCRIPTION
    `rhel-10` would not show up under the bootc distributions, even though
    it's a valid distribution. The frontend currently relies on being able
    to filter by distro, so both the explicit minor version and the latest
    major version need to be listed.
    
    This is similar to how the `DistroRegistry.Get` function would work, as
    this filters on the key of the distro registry map, which is the
    file (or symlink) name.