### PR TITLE
distributions: Rename to Fedora Hummingbird (HMS-10603)

### DIFF
--- a/distributions/hummingbird/hummingbird.json
+++ b/distributions/hummingbird/hummingbird.json
@@ -2,7 +2,7 @@
   "module_platform_id": "platform:el10",
   "distribution": {
     "name": "hummingbird",
-    "description": "Hummingbird OS",
+    "description": "Fedora Hummingbird",
     "no_package_list": true
   },
   "x86_64": {

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -1012,7 +1012,7 @@ func TestGetBootcDistributions(t *testing.T) {
 				require.Contains(t, result, v1.BootcDistributionItem{
 					Arch:      "x86_64",
 					Distro:    "hummingbird",
-					Name:      "Hummingbird OS",
+					Name:      "Fedora Hummingbird",
 					Type:      "guest-image",
 					Reference: "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/hummingbird-qcow2:latest",
 				})


### PR DESCRIPTION
This is the correct official name of the distribution.