### PR TITLE
v1: check if distribution is bootc only in distribution details

### DIFF
--- a/internal/distribution/distribution.go
+++ b/internal/distribution/distribution.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/labstack/echo/v4"
+	"github.com/osbuild/image-builder-crc/internal/common"
 )
 
 var ErrDistributionNotFound = errors.New("distribution not available")
@@ -143,6 +144,13 @@ func (dist DistributionFile) Architecture(arch string) (*Architecture, error) {
 	default:
 		return nil, echo.NewHTTPError(http.StatusBadRequest, "Architecture not supported")
 	}
+}
+
+func (dist DistributionFile) IsBootcOnly() bool {
+	x86, a64 := common.FromPtr(dist.ArchX86), common.FromPtr(dist.Aarch64)
+	hasBootc := len(x86.Bootc) > 0 || len(a64.Bootc) > 0
+	hasITs := len(x86.ImageTypes) > 0 || len(a64.ImageTypes) > 0
+	return hasBootc && !hasITs
 }
 
 func (arch Architecture) FindPackages(search string) []Package {

--- a/internal/distribution/distribution_test.go
+++ b/internal/distribution/distribution_test.go
@@ -316,3 +316,43 @@ func TestArchitecture_ValidateBootcReferences(t *testing.T) {
 		})
 	}
 }
+
+func TestIsBootcOnly(t *testing.T) {
+	adr, err := LoadDistroRegistry("./testdata/distributions")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		distro    string
+		bootcOnly bool
+	}{
+		{
+			name:      "rhel-1.2 is not bootc only",
+			distro:    "rhel-1.2",
+			bootcOnly: false,
+		},
+		{
+			name:      "with-bootc is not bootc only",
+			distro:    "with-bootc",
+			bootcOnly: false,
+		},
+		{
+			name:      "bootc-link is not bootc only",
+			distro:    "bootc-link",
+			bootcOnly: false,
+		},
+		{
+			name:      "bootc-only is bootc only",
+			distro:    "bootc-only",
+			bootcOnly: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := adr.Available(true).Get(tt.distro)
+			require.NoError(t, err)
+			require.Equal(t, tt.bootcOnly, d.IsBootcOnly())
+		})
+	}
+}

--- a/internal/distribution/distroregistry_test.go
+++ b/internal/distribution/distroregistry_test.go
@@ -18,6 +18,7 @@ func TestDistroRegistry_List(t *testing.T) {
 		"standard",
 		"with-bootc",
 		"bootc-link",
+		"bootc-only",
 	}
 	notEntitledDistros := []string{
 		"no-packages",
@@ -27,6 +28,7 @@ func TestDistroRegistry_List(t *testing.T) {
 		"standard",
 		"with-bootc",
 		"bootc-link",
+		"bootc-only",
 	}
 
 	dr, err := LoadDistroRegistry("./testdata/distributions")
@@ -271,6 +273,13 @@ func TestDistroRegistry_CollectBootcFromRegistry(t *testing.T) {
 					Arch:                 "x86_64",
 					Reference:            "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-installer:latest",
 					IsoPayloadReferences: []string{"quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest"},
+				},
+				{
+					Distro:    "bootc-only",
+					Name:      "Test distro with only bootc entries",
+					Type:      "ec2",
+					Arch:      "x86_64",
+					Reference: "reffy.io",
 				},
 			},
 		},

--- a/internal/distribution/testdata/distributions/bootc-only/bootc-only.json
+++ b/internal/distribution/testdata/distributions/bootc-only/bootc-only.json
@@ -1,0 +1,13 @@
+{
+  "module_platform_id": "platform:el10",
+  "distribution": {
+    "name": "bootc-only",
+    "description": "Test distro with only bootc entries",
+    "no_package_list": true
+  },
+  "x86_64": {
+    "bootc": [
+      { "type": "ec2", "reference": "reffy.io" }
+    ]
+  }
+}

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -204,6 +204,18 @@ func (h *Handlers) GetDistribution(ctx echo.Context, distro string, params GetDi
 		architectures = *params.Architecture
 	}
 
+	d, err := h.server.distroRegistry(ctx).Get(distro)
+	if err != nil {
+		if err == distribution.ErrDistributionNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("distribution '%s' not found", distro))
+		}
+		return err
+	}
+
+	if d.IsBootcOnly() {
+		return echo.NewHTTPError(http.StatusBadRequest, "distribution details are only available for package mode distributions")
+	}
+
 	resp, err := h.server.cClient.GetDistribution(ctx.Request().Context(), distro, imageTypes, architectures)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get distribution details").SetInternal(err)


### PR DESCRIPTION
Distribution details are only supported for package mode distributions.