### PR TITLE
v1: fix parsing of compose error statuses (HMS-10693)

### DIFF
--- a/internal/v1/export_test.go
+++ b/internal/v1/export_test.go
@@ -5,8 +5,9 @@ import (
 )
 
 var (
-	BuildOSTreeOptions     = buildOSTreeOptions
-	ValidateComposeRequest = validateComposeRequest
+	BuildOSTreeOptions      = buildOSTreeOptions
+	ValidateComposeRequest  = validateComposeRequest
+	ParseComposeStatusError = parseComposeStatusError
 )
 
 func (s *Server) GetDB() db.DB {

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -500,15 +500,21 @@ func parseComposeStatusError(ctx echo.Context, composeErr *composer.ComposeStatu
 		fallthrough
 	case 28: // osbuild target errors are added to details
 		if composeErr.Details != nil {
-			intfs := (composeErr.Details).([]any)
-			if len(intfs) == 0 {
+			// details can be both a slice of ComposeStatusError objects, a single
+			// ComposeStatusError object, or a simple string
+			details := composeErr.Details
+			if _, ok := details.(string); ok {
 				return fbErr
 			}
 
+			if intfs, ok := (composeErr.Details).([]any); ok {
+				details = intfs[0]
+			}
+
 			// Try to remarshal the details as another composer.ComposeStatusError
-			jsonDetails, err := json.Marshal(intfs[0])
+			jsonDetails, err := json.Marshal(details)
 			if err != nil {
-				ctx.Logger().Errorf("Error processing compose status error details: %v", err)
+				ctx.Logger().Error("Error processing compose status error details: %v", err)
 				return fbErr
 			}
 			var newErr composer.ComposeStatusError

--- a/internal/v1/handler_get_compose_status_test.go
+++ b/internal/v1/handler_get_compose_status_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -371,6 +372,169 @@ func TestParseComposeStatusError(t *testing.T) {
 			ctx := echo.New().NewContext(nil, nil)
 			result := v1.ParseComposeStatusError(ctx, tt.composerErr)
 			require.Equal(t, tt.expectedErr, result)
+		})
+	}
+}
+
+func TestGetComposeStatusErrorResponse(t *testing.T) {
+	var composerStatus *composer.ComposeStatus
+	var composerStatusCode int
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(composerStatusCode)
+		if composerStatus != nil {
+			err := json.NewEncoder(w).Encode(*composerStatus)
+			require.NoError(t, err)
+		}
+	}))
+	defer apiSrv.Close()
+	srv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, &v1.ServerConfig{
+		DistributionsDir: "../../distributions",
+	})
+	defer srv.Shutdown(t)
+
+	tests := []struct {
+		name               string
+		composerStatus     *composer.ComposeStatus
+		composerStatusCode int
+		expectedCode       int
+		expectedBody       string
+	}{
+		// errors in crc or composer itself
+		{
+			name:               "404 on non-existent compose in crc",
+			composerStatus:     nil,
+			composerStatusCode: 0,
+			expectedCode:       http.StatusNotFound,
+			expectedBody:       "{\"errors\":[{\"detail\":\"Compose entry %s not found compose entry not found\",\"title\":\"404\"}]}\n",
+		},
+		{
+			name:               "404 on non-existent compose in composer",
+			composerStatus:     nil,
+			composerStatusCode: http.StatusNotFound,
+			expectedCode:       http.StatusNotFound,
+			expectedBody:       "{\"errors\":[{\"detail\":\"Compose entry %s not found compose entry not found\",\"title\":\"404\"}]}\n",
+		},
+		// errors in the job itself
+		{
+			name: "failed compose with simple error",
+			composerStatus: &composer.ComposeStatus{
+				Status: composer.ComposeStatusValueFailure,
+				ImageStatus: composer.ImageStatus{
+					Error: &composer.ComposeStatusError{
+						Id:      1,
+						Reason:  "1 pigeon",
+						Details: "many pigeons",
+					},
+				},
+			},
+			composerStatusCode: 200,
+			expectedCode:       200,
+			expectedBody:       "{\"image_status\":{\"error\":{\"details\":\"many pigeons\",\"id\":1,\"reason\":\"1 pigeon\"},\"status\":\"\"},\"request\":{\"distribution\":\"rhel-9\",\"image_requests\":null}}\n",
+		},
+		{
+			name: "failed compose with interpreted error containing string details",
+			composerStatus: &composer.ComposeStatus{
+				Status: composer.ComposeStatusValueFailure,
+				ImageStatus: composer.ImageStatus{
+					Error: &composer.ComposeStatusError{
+						Id:      5,
+						Reason:  "1 pigeon",
+						Details: "many pigeons",
+					},
+				},
+			},
+			composerStatusCode: 200,
+			expectedCode:       200,
+			expectedBody:       "{\"image_status\":{\"error\":{\"details\":\"many pigeons\",\"id\":5,\"reason\":\"1 pigeon\"},\"status\":\"\"},\"request\":{\"distribution\":\"rhel-9\",\"image_requests\":null}}\n",
+		},
+		{
+			name: "failed compose with interpreted error containing compose error details",
+			composerStatus: &composer.ComposeStatus{
+				Status: composer.ComposeStatusValueFailure,
+				ImageStatus: composer.ImageStatus{
+					Error: &composer.ComposeStatusError{
+						Id:     5,
+						Reason: "1 pigeon",
+						Details: &composer.ComposeStatusError{
+							Id:      1,
+							Reason:  "1 pigeon",
+							Details: "many pigeons",
+						},
+					},
+				},
+			},
+			composerStatusCode: 200,
+			expectedCode:       200,
+			expectedBody:       "{\"image_status\":{\"error\":{\"details\":\"many pigeons\",\"id\":1,\"reason\":\"1 pigeon\"},\"status\":\"\"},\"request\":{\"distribution\":\"rhel-9\",\"image_requests\":null}}\n",
+		},
+		{
+			name: "failed compose with interpreted error containing slice of compose error details",
+			composerStatus: &composer.ComposeStatus{
+				Status: composer.ComposeStatusValueFailure,
+				ImageStatus: composer.ImageStatus{
+					Error: &composer.ComposeStatusError{
+						Id:     5,
+						Reason: "1 pigeon",
+						Details: &[]composer.ComposeStatusError{
+							{
+								Id:      1,
+								Reason:  "1 pigeon",
+								Details: "many pigeons",
+							},
+						},
+					},
+				},
+			},
+			composerStatusCode: 200,
+			expectedCode:       200,
+			expectedBody:       "{\"image_status\":{\"error\":{\"details\":\"many pigeons\",\"id\":1,\"reason\":\"1 pigeon\"},\"status\":\"\"},\"request\":{\"distribution\":\"rhel-9\",\"image_requests\":null}}\n",
+		},
+		{
+			name: "failed compose with non-interpreted error containing compose error details",
+			composerStatus: &composer.ComposeStatus{
+				Status: composer.ComposeStatusValueFailure,
+				ImageStatus: composer.ImageStatus{
+					Error: &composer.ComposeStatusError{
+						Id:     1,
+						Reason: "1 pigeon",
+						Details: composer.ComposeStatusError{
+							Id:      1,
+							Reason:  "1 pigeon",
+							Details: "many pigeons",
+						},
+					},
+				},
+			},
+			composerStatusCode: 200,
+			expectedCode:       200,
+			expectedBody:       "{\"image_status\":{\"error\":{\"details\":{\"details\":\"many pigeons\",\"id\":1,\"reason\":\"1 pigeon\"},\"id\":1,\"reason\":\"1 pigeon\"},\"status\":\"\"},\"request\":{\"distribution\":\"rhel-9\",\"image_requests\":null}}\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			composeId := uuid.New()
+			if tt.expectedCode != http.StatusNotFound {
+				err := srv.DB.InsertCompose(t.Context(), composeId, "000000", "user000000@test.test", "000000", nil, []byte("{\"distribution\": \"rhel-9\"}"), nil, nil)
+				require.NoError(t, err)
+			}
+
+			composerStatus = tt.composerStatus
+			composerStatusCode = tt.composerStatusCode
+
+			statusCode, body := tutils.GetResponseBody(t, fmt.Sprintf(srv.URL+"/api/image-builder/v1/composes/%s", composeId), &tutils.AuthString0)
+			require.Equal(t, tt.expectedCode, statusCode)
+
+			expBody := tt.expectedBody
+			if strings.Contains(tt.expectedBody, "%s") {
+				expBody = fmt.Sprintf(expBody, composeId)
+			}
+			require.Equal(t, expBody, body)
 		})
 	}
 }

--- a/internal/v1/handler_get_compose_status_test.go
+++ b/internal/v1/handler_get_compose_status_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/image-builder-crc/internal/clients/composer"
@@ -249,5 +250,127 @@ func TestComposeStatus(t *testing.T) {
 		require.Equal(t, cr.Distribution, result.Request.Distribution)
 		user := (*result.Request.Customizations.Users)[0]
 		require.Nil(t, user.Password)
+	}
+}
+func TestParseComposeStatusError(t *testing.T) {
+	tests := []struct {
+		name        string
+		composerErr *composer.ComposeStatusError
+		expectedErr *v1.ComposeStatusError
+	}{
+		{
+			name: "interpreted error with no details",
+			composerErr: &composer.ComposeStatusError{
+				Id:      5,
+				Reason:  "1 pigeon",
+				Details: nil,
+			},
+			expectedErr: &v1.ComposeStatusError{
+				Id:      5,
+				Reason:  "1 pigeon",
+				Details: nil,
+			},
+		},
+		{
+			name: "interpreted error with string details",
+			composerErr: &composer.ComposeStatusError{
+				Id:      5,
+				Reason:  "1 pigeon",
+				Details: "3 pigeons",
+			},
+			expectedErr: &v1.ComposeStatusError{
+				Id:      5,
+				Reason:  "1 pigeon",
+				Details: "3 pigeons",
+			},
+		},
+		{
+			name: "interpreted error with single object details",
+			composerErr: &composer.ComposeStatusError{
+				Id:     5,
+				Reason: "1 pigeon",
+				Details: &composer.ComposeStatusError{
+					Id:     10,
+					Reason: "many pigeons",
+				},
+			},
+			expectedErr: &v1.ComposeStatusError{
+				Id:     10,
+				Reason: "many pigeons",
+			},
+		},
+		{
+			name: "non-interpreted error with single object details",
+			composerErr: &composer.ComposeStatusError{
+				Id:     1,
+				Reason: "1 pigeon",
+				Details: &composer.ComposeStatusError{
+					Id:     10,
+					Reason: "many pigeons",
+				},
+			},
+			expectedErr: &v1.ComposeStatusError{
+				Id:     1,
+				Reason: "1 pigeon",
+				// this is of type composer.ComposeStatusError because the details
+				// in this case are just forwarded without any casting
+				Details: &composer.ComposeStatusError{
+					Id:     10,
+					Reason: "many pigeons",
+				},
+			},
+		},
+		{
+			name: "interpreted error with details slice",
+			composerErr: &composer.ComposeStatusError{
+				Id:     26,
+				Reason: "1 pigeon",
+				Details: []interface{}{
+					map[string]interface{}{
+						"id":      15,
+						"reason":  "many pigeons",
+						"details": "3 pigeons",
+					},
+				},
+			},
+			expectedErr: &v1.ComposeStatusError{
+				Id:      15,
+				Reason:  "many pigeons",
+				Details: "3 pigeons",
+			},
+		},
+		{
+			name: "interpreted error with double nested details slice",
+			composerErr: &composer.ComposeStatusError{
+				Id:     26,
+				Reason: "1 pigeon",
+				Details: []interface{}{
+					map[string]interface{}{
+						"id":     26,
+						"reason": "1 more pigeon",
+						"details": []interface{}{
+							map[string]interface{}{
+								"id":      15,
+								"reason":  "1 more extra pigeon",
+								"details": "3 pigeons total",
+							},
+						},
+					},
+				},
+			},
+			expectedErr: &v1.ComposeStatusError{
+				Id:      15,
+				Reason:  "1 more extra pigeon",
+				Details: "3 pigeons total",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := echo.New().NewContext(nil, nil)
+			result := v1.ParseComposeStatusError(ctx, tt.composerErr)
+			require.Equal(t, tt.expectedErr, result)
+		})
 	}
 }

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
@@ -123,95 +122,6 @@ func TestGetComposeEntryNotFoundResponse(t *testing.T) {
 		id), &tutils.AuthString0)
 	require.Equal(t, http.StatusNotFound, respStatusCode)
 	require.Contains(t, body, "compose entry not found")
-}
-
-func TestGetComposeStatusErrorResponse(t *testing.T) {
-	testCases := []struct {
-		statusCode       int
-		checkImageStatus bool
-		expectedBody     string
-	}{
-		{http.StatusNotFound,
-			true,
-			"",
-		},
-		{http.StatusInternalServerError,
-			false,
-			"Failed querying compose status",
-		},
-	}
-
-	for _, tc := range testCases {
-		ctx := t.Context()
-		composeId := uuid.New()
-
-		var composerStatus composer.ComposeStatus
-		apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Header.Get("Authorization") == "Bearer" {
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			}
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(tc.statusCode)
-			err := json.NewEncoder(w).Encode(composerStatus)
-			require.NoError(t, err)
-		}))
-		defer apiSrv.Close()
-
-		cr := v1.ComposeRequest{
-			Distribution: common.ToPtr(v1.Distributions("rhel-9")),
-			Customizations: &v1.Customizations{
-				// Since we are not calling handleCommonCompose but inserting directly to DB
-				// there is no point in using plaintext passwords
-				// If there is plaintext password in DB there is problem elsewhere (eg. CreateBlueprint)
-				Users: &[]v1.User{
-					{
-						Name:     "user",
-						SshKey:   common.ToPtr("ssh-rsa AAAAB3NzaC2"),
-						Password: common.ToPtr("$6$password123"),
-					},
-				},
-			}}
-
-		crRaw, err := json.Marshal(cr)
-		require.NoError(t, err)
-		srv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, &v1.ServerConfig{
-			DistributionsDir: "../../distributions",
-		})
-		defer srv.Shutdown(t)
-		err = srv.DB.InsertCompose(ctx, composeId, "000000", "user000000@test.test", "000000", cr.ImageName, crRaw, (*string)(cr.ClientId), nil)
-		require.NoError(t, err)
-
-		payloads := []struct {
-			composerStatus composer.ComposeStatus
-			imageStatus    v1.ImageStatus
-		}{
-			{
-				composerStatus: composer.ComposeStatus{
-					ImageStatus: composer.ImageStatus{},
-				},
-			},
-		}
-		for idx, payload := range payloads {
-			fmt.Printf("TT payload %d\n", idx)
-			composerStatus = payload.composerStatus
-
-			respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf(srv.URL+"/api/image-builder/v1/composes/%s",
-				composeId), &tutils.AuthString0)
-			require.Equal(t, tc.statusCode, respStatusCode)
-			var result v1.ComposeStatus
-			err := json.Unmarshal([]byte(body), &result)
-			require.NoError(t, err)
-			if tc.checkImageStatus {
-				require.Equal(t, payload.imageStatus, result.ImageStatus)
-			}
-			if tc.expectedBody != "" {
-				require.Contains(t, body, tc.expectedBody)
-			}
-		}
-		srv.Shutdown(t)
-		apiSrv.Close()
-	}
 }
 
 func TestGetComposeMetadata(t *testing.T) {


### PR DESCRIPTION

    In select error cases the compose error is presumed to contain error
    details which are formatted as a list of
    `composer.ComposeStatusError`s. However these details could also be a
    string or just a single, top-level `composer.ComposeStatusError`
    object. This fixes a panic in case the error details are formatted
    differently.
