### PR TITLE
Add pxe-tar-xz image type to AWS S3 upload options (HMS-10716)

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -1000,6 +1000,8 @@ func (h *Handlers) buildUploadOptions(ctx echo.Context, ur UploadRequest, it Ima
 			composerImageType = composer.ImageTypesWsl
 		case ImageTypesBootableContainerIso:
 			composerImageType = composer.ImageTypesBootableContainerIso
+		case ImageTypesPxeTarXz:
+			composerImageType = composer.ImageTypesPxeTarXz
 		default:
 			return uploadOptions, "", echo.NewHTTPError(http.StatusBadRequest, "Invalid image type for upload target")
 		}


### PR DESCRIPTION
## Summary
The `pxe-tar-xz` image type was missing from the `buildUploadOptions` switch case, causing requests with this image type to fail with "Invalid image type for upload target". This adds it to the AWS S3 upload target where it belongs.

## Changes
- Add `ImageTypesPxeTarXz` case to the `UploadTypesAwsS3` switch in `buildUploadOptions`, mapping it to `composer.ImageTypesPxeTarXz`