### PR TITLE
floorist: remove sensitive aap_registration data (HMS-10828)

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -219,8 +219,7 @@ objects:
                else c.request->'customizations'->'kernel' end as kernel,
           case when c.request->'customizations'->'firewall'='{}' then 'null'
                else c.request->'customizations'->'firewall' end as firewall,
-          jsonb_array_length(c.request->'customizations'->'users') as num_users,
-          c.request->'customizations'->'aap_registration' as aap_registration
+          jsonb_array_length(c.request->'customizations'->'users') as num_users
         from
           composes c
           left outer join blueprint_versions v on c.blueprint_version_id = v.id


### PR DESCRIPTION
The feature has been deployed in prod for quite some time and we are not tracking its use yet. Let's fix that.

---

The first commit drops storing of the whole AAP registration JSON, I think we should not collect that. The new solution only tracks for presence of the customization instead. Note: AAP is stored under a different column now that it is a different data type to make it easier during analysis.

Edit: Update I was made aware we are tracking Satellite registration but not AAP registration. I wonder how and why we have the opposite in the SQL. I can probably turn this PR into fixing this (maybe we can just drop AAP from there)?

@jlsherrill @ochosi 