### PR TITLE
clowdapp: fix aap floorist selection

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -220,7 +220,8 @@ objects:
           case when c.request->'customizations'->'firewall'='{}' then 'null'
                else c.request->'customizations'->'firewall' end as firewall,
           jsonb_array_length(c.request->'customizations'->'users') as num_users,
-          c.request->'customizations'->'aap_registration' as aap_registration
+          (c.request->'customizations'->'aap_registration' is not null
+           and c.request->'customizations'->'aap_registration' != '{}') as aap_registration
         from
           composes c
           left outer join blueprint_versions v on c.blueprint_version_id = v.id


### PR DESCRIPTION
parquet seems to interpet {} as 'false', and thus categorizes the entire filed as boolean.  This appears to be counting everything as 'false' even though data is there