### PR TITLE
internal: fix error handling of 401 from content sources (HMS-10083)

### DIFF
--- a/internal/clients/content_sources/client.go
+++ b/internal/clients/content_sources/client.go
@@ -158,7 +158,7 @@ func (csc *ContentSourcesClient) FindRepoByID(repos []ApiRepositoryResponse, tar
 func (csc *ContentSourcesClient) FetchLabelsFromNonBaseRHRepos(ctx context.Context, repoIDs []string) ([]string, error) {
 	rhRepoMap, err := csc.GetRepositories(ctx, nil, repoIDs, false)
 	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve RH repositories: %v", err)
+		return nil, fmt.Errorf("unable to retrieve RH repositories: %w", err)
 	}
 
 	var labels []string

--- a/internal/clients/content_sources/client.go
+++ b/internal/clients/content_sources/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,6 +15,8 @@ import (
 	"github.com/osbuild/logging/pkg/strc"
 	"github.com/redhatinsights/identity"
 )
+
+var ErrorAuth = errors.New("user is not authorized - please check your 'Repositories viewer' or 'Content Template viewer' permissions")
 
 type RepositoryByID map[string]ApiRepositoryResponse
 
@@ -83,13 +86,14 @@ func (csc *ContentSourcesClient) fetchRepositories(ctx context.Context, repoURLs
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode != http.StatusUnauthorized {
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return nil, fmt.Errorf("unable to fetch repositories from %s, got %v response, body: %s", csReposURL.String(), resp.StatusCode, body)
-			}
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, ErrorAuth
 		}
-		return nil, fmt.Errorf("unable to fetch repositories from %s, got %v response", csReposURL.String(), resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("unable to fetch repositories from %s, got %v response", csReposURL.String(), resp.StatusCode)
+		}
+		return nil, fmt.Errorf("unable to fetch repositories from %s, got %v response, body: %s", csReposURL.String(), resp.StatusCode, body)
 	}
 
 	var repos *ApiRepositoryCollectionResponse
@@ -223,13 +227,14 @@ func (csc *ContentSourcesClient) GetTemplateByID(ctx context.Context, uuid strin
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode != http.StatusUnauthorized {
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return nil, fmt.Errorf("unable to fetch template, got %v response, body: %s", resp.StatusCode, body)
-			}
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, ErrorAuth
 		}
-		return nil, fmt.Errorf("unable to fetch template, got %v response", resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("unable to fetch template, got %v response", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("unable to fetch template, got %v response, body: %s", resp.StatusCode, body)
 	}
 
 	var template *ApiTemplateResponse

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -569,7 +569,7 @@ func (h *Handlers) ExportBlueprint(ctx echo.Context, id openapi_types.UUID) erro
 	defer closeBody(ctx, exportedRepositoriesResp.Body)
 
 	if exportedRepositoriesResp.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf("unable to fetch custom repositories, got %v response", exportedRepositoriesResp.StatusCode)
+		return echo.NewHTTPError(http.StatusForbidden, content_sources.ErrorAuth.Error())
 	}
 
 	if exportedRepositoriesResp.Body == nil {

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -492,13 +492,14 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 	defer closeBody(ctx, snapResp.Body)
 
 	if snapResp.StatusCode != http.StatusOK {
-		if snapResp.StatusCode != http.StatusUnauthorized {
-			body, err := io.ReadAll(snapResp.Body)
-			if err != nil {
-				return nil, nil, nil, err
-			}
-			ctx.Logger().Warnf("Unable to resolve snapshots: %s", body)
+		if snapResp.StatusCode == http.StatusUnauthorized {
+			return nil, nil, nil, content_sources.ErrorAuth
 		}
+		body, err := io.ReadAll(snapResp.Body)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		ctx.Logger().Warnf("Unable to resolve snapshots: %s", body)
 		return nil, nil, nil, fmt.Errorf("unable to fetch snapshots for date, got %v response", snapResp.StatusCode)
 	}
 

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -452,7 +452,7 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 		rhRepoMap, err := h.server.csClient.GetRepositories(ctx.Request().Context(), repoURLs, repoIDs, false)
 		if err != nil {
 			ctx.Logger().Warnf("Unable to get RH repositories for base urls: %v", err)
-			return nil, nil, nil, fmt.Errorf("unable to retrieve RH repositories: %v", err)
+			return nil, nil, nil, fmt.Errorf("unable to retrieve RH repositories: %w", err)
 		} else {
 			for id, repo := range rhRepoMap {
 				repoMap[id] = repo
@@ -462,7 +462,7 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 		nonRHRepoMap, err := h.server.csClient.GetRepositories(ctx.Request().Context(), repoURLs, repoIDs, true)
 		if err != nil {
 			ctx.Logger().Warnf("Unable to get non-RH repositories for base urls: %v", err)
-			return nil, nil, nil, fmt.Errorf("unable to retrieve non-RH repositories: %v", err)
+			return nil, nil, nil, fmt.Errorf("unable to retrieve non-RH repositories: %w", err)
 		} else {
 			for id, repo := range nonRHRepoMap {
 				repoMap[id] = repo
@@ -472,7 +472,7 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 		repoMap, err = h.server.csClient.GetRepositories(ctx.Request().Context(), repoURLs, repoIDs, external)
 		if err != nil {
 			ctx.Logger().Warnf("Unable to get repositories for base urls: %v", err)
-			return nil, nil, nil, fmt.Errorf("unable to retrieve repositories: %v", err)
+			return nil, nil, nil, fmt.Errorf("unable to retrieve repositories: %w", err)
 		}
 	}
 
@@ -696,7 +696,7 @@ func (h *Handlers) checkForRHReposInCustom(ctx echo.Context, customRepos []Custo
 
 	rhRepoMap, err := h.server.csClient.GetRepositories(ctx.Request().Context(), repoURLs, repoIDs, false)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unable to retrieve RH repositories: %v", err)
+		return nil, nil, nil, fmt.Errorf("unable to retrieve RH repositories: %w", err)
 	}
 
 	var rhRepos []content_sources.ApiRepositoryResponse
@@ -726,7 +726,7 @@ func (h *Handlers) checkForRHReposInPayload(ctx echo.Context, payloadRepos []Rep
 	}
 	rhRepoMap, err := h.server.csClient.GetRepositories(ctx.Request().Context(), repoURLs, repoIDs, false)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unable to retrieve RH repositories: %v", err)
+		return nil, nil, nil, fmt.Errorf("unable to retrieve RH repositories: %w", err)
 	}
 
 	var rhRepos []content_sources.ApiRepositoryResponse
@@ -832,7 +832,7 @@ func (h *Handlers) buildTemplateRepositories(ctx echo.Context, templateID string
 
 	template, err := h.server.csClient.GetTemplateByID(ctx.Request().Context(), templateID)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("unable to retrieve template: %v", err)
+		return nil, nil, nil, nil, fmt.Errorf("unable to retrieve template: %w", err)
 	}
 
 	if template == nil || template.RepositoryUuids == nil {
@@ -841,7 +841,7 @@ func (h *Handlers) buildTemplateRepositories(ctx echo.Context, templateID string
 
 	rhRepoMap, err := h.server.csClient.GetRepositories(ctx.Request().Context(), []string{}, *template.RepositoryUuids, false)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("unable to retrieve Red Hat repositories: %v", err)
+		return nil, nil, nil, nil, fmt.Errorf("unable to retrieve Red Hat repositories: %w", err)
 	}
 	for repoID := range rhRepoMap {
 		rhRepoIDs = append(rhRepoIDs, repoID)
@@ -849,7 +849,7 @@ func (h *Handlers) buildTemplateRepositories(ctx echo.Context, templateID string
 
 	customRepoMap, err := h.server.csClient.GetRepositories(ctx.Request().Context(), []string{}, *template.RepositoryUuids, true)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("unable to retrieve custom repositories: %v", err)
+		return nil, nil, nil, nil, fmt.Errorf("unable to retrieve custom repositories: %w", err)
 	}
 	for repoID := range customRepoMap {
 		customRepoIDs = append(customRepoIDs, repoID)

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -103,6 +103,9 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 		customizations, _, err = h.buildCustomizations(ctx, &composeRequest, nil)
 		if err != nil {
 			ctx.Logger().Errorf("Failed building customizations: %v", err)
+			if errors.Is(err, content_sources.ErrorAuth) {
+				return ComposeResponse{}, echo.NewHTTPError(http.StatusForbidden, err)
+			}
 			if _, ok := err.(*echo.HTTPError); ok {
 				return ComposeResponse{}, err
 			}
@@ -133,6 +136,9 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 		customizations, extraRHRepos, err = h.buildCustomizations(ctx, &composeRequest, d)
 		if err != nil {
 			ctx.Logger().Errorf("Failed building customizations: %v", err)
+			if errors.Is(err, content_sources.ErrorAuth) {
+				return ComposeResponse{}, echo.NewHTTPError(http.StatusForbidden, err)
+			}
 			if _, ok := err.(*echo.HTTPError); ok {
 				return ComposeResponse{}, err
 			}
@@ -142,6 +148,9 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 		var detectedOsVersion *string
 		repositories, detectedOsVersion, err = h.buildRepositories(ctx, composeRequest, arch, extraRHRepos)
 		if err != nil {
+			if errors.Is(err, content_sources.ErrorAuth) {
+				return ComposeResponse{}, echo.NewHTTPError(http.StatusForbidden, err)
+			}
 			return ComposeResponse{}, err
 		}
 

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -3956,3 +3956,40 @@ func TestComposeWithSnapshotEmptyDetectedOsVersion(t *testing.T) {
 	// default "rhel-9.8" distribution, not attempt to look up an empty version.
 	require.Equal(t, common.ToPtr("rhel-9.8"), composerRequest.Distribution)
 }
+
+func TestComposeContentSourcesUnauthorized(t *testing.T) {
+	apiSrv := httptest.NewServer(validatingComposerHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})))
+	defer apiSrv.Close()
+
+	csHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	srv := startServer(t, &testServerClientsConf{
+		ComposerURL: apiSrv.URL,
+		CSHandler:   csHandler,
+	}, nil)
+	defer srv.Shutdown(t)
+
+	var uo v1.UploadRequest_Options
+	require.NoError(t, uo.FromAWSS3UploadRequestOptions(v1.AWSS3UploadRequestOptions{}))
+	payload := v1.ComposeRequest{
+		Distribution: common.ToPtr(v1.Distributions("rhel-9.8")),
+		ImageRequests: []v1.ImageRequest{
+			{
+				Architecture: "x86_64",
+				ImageType:    v1.ImageTypesGuestImage,
+				SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
+				UploadRequest: v1.UploadRequest{
+					Type:    v1.UploadTypesAwsS3,
+					Options: uo,
+				},
+			},
+		},
+	}
+
+	respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
+	require.Equal(t, http.StatusForbidden, respStatusCode, "expected 403 when content-sources returns unauthorized, got %d: %s", respStatusCode, body)
+}


### PR DESCRIPTION
### Context
Content Sources require specific roles for operations during blueprint compose and blueprint export, which can result in a `401 Unauthorized` response. 

Previously, errors from `content_sources/client.go/request` were wrapped in plain `fmt.Errorf`, causing them to lose their specific error status and ultimately surface to the user as generic `500 Internal Server Error`.

### Changes
- adds explicit handling for 401 errors so they are preserved and properly communicated to the user instead of being swallowed.
-  adds a dedicated unit test covering the 401 error path.
- corrects inverted logic when handling `body` on read errors (drive-by fix):
  ```go
  body, err := io.ReadAll(resp.Body)
  if err != nil {
     return nil, fmt.Errorf("Some text: %s", body)
  }
