### PR TITLE
ci: enable allow-unsafe-pr-checkout

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - uses: octokit/request-action@v2.x
         id: fetch_pulls


### PR DESCRIPTION
Github recently backported a security change to `actions/checkout` requiring a usage of a new flag: allow-unsafe-pr-checkout, in order to opt-in to checking out fork pull request code by default.